### PR TITLE
修复 Issue #33

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/ocelot/TransformativeOcelotEntity.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/ocelot/TransformativeOcelotEntity.java
@@ -28,6 +28,13 @@ public class TransformativeOcelotEntity extends OcelotEntity {
     // 当前冷却时间
     private float cooldown = 0;
 
+    @Override
+    protected void initGoals() {
+        super.initGoals();
+        // 添加攻击目标（玩家）
+        this.targetSelector.add(1, new ActiveTargetGoal<>(this, PlayerEntity.class, true));
+    }
+
     public static boolean canCustomSpawn(EntityType<TransformativeOcelotEntity> type, WorldAccess world, SpawnReason spawnReason, BlockPos pos, Random random) {
         return random.nextInt(3) != 0;
     }


### PR DESCRIPTION
<img width="1573" height="1010" alt="屏幕截图 2025-08-31 155857" src="https://github.com/user-attachments/assets/b3faac19-ca30-49d4-83e6-9a4cf2049877" />
由于误替换的initGoals导致咒文豹猫不会攻击玩家
修复Issue #33 