### PR TITLE
临时解决 Issues #40

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/OverrideSkinFirstPersonMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/OverrideSkinFirstPersonMixin.java
@@ -54,6 +54,14 @@ public abstract class OverrideSkinFirstPersonMixin extends LivingEntityRenderer<
                 RenderSystem.enableCull();
                 ci.cancel(); // 取消默认渲染
             }
+            else {
+                // 临时解决方法
+                RenderSystem.disableCull();
+                arm.render(matrices, vertexConsumers.getBuffer(RenderLayer.getEntitySolid(player.getSkinTexture())), light, OverlayTexture.DEFAULT_UV);
+                sleeve.render(matrices, vertexConsumers.getBuffer(RenderLayer.getEntityTranslucent(player.getSkinTexture())), light, OverlayTexture.DEFAULT_UV);
+                RenderSystem.enableCull();
+                ci.cancel();
+            }
         }
     }
 }


### PR DESCRIPTION
我模仿未启用keepOriginalSkin的渲染方法添加了启用keepOriginalSkin的渲染

未启用keepOriginalSkin的渲染方法似乎也有些问题, 它似乎需要在生存背包界面刷新才可以生效, 并且打开背包时手会乱动.
我尝试挨个注释原版渲染手的函数, 完整解决可能需要修改 PlayerEntityRenderer.setModelPose 函数