### PR TITLE
修复 命令set_form瞬间变形导致 ExtraItemFeatureRenderer 未及时同步玩家变形状态导致 First Person Mod 配置异常

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/transform/TransformManager.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/transform/TransformManager.java
@@ -537,6 +537,18 @@ public class TransformManager {
             fpm.getConfig().xOffset = 0;
             fpm.getConfig().sitXOffset = 0;
             fpm.getConfig().sneakXOffset = 0;
+
+            // 1s 后再次重置 防止 ExtraItemFeatureRenderer 未同步玩家变形状态
+            new Thread(() -> {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                fpm.getConfig().xOffset = 0;
+                fpm.getConfig().sitXOffset = 0;
+                fpm.getConfig().sneakXOffset = 0;
+            }).start();
         }
     }
 


### PR DESCRIPTION
修复 命令set_form瞬间变形导致 ExtraItemFeatureRenderer 未及时同步玩家变形状态导致 First PersonMod 配置异常(非Feral形态FPM配置为-25)
transform_to_form 由于有动画延迟没有问题

添加一个1s后重置FPM配置的线程