### PR TITLE
修复手臂渲染 减少瞬间变身未同步导致FPM设置异常的感知

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/transform/TransformManager.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/transform/TransformManager.java
@@ -538,16 +538,16 @@ public class TransformManager {
             fpm.getConfig().sitXOffset = 0;
             fpm.getConfig().sneakXOffset = 0;
 
-            // 1s 后再次重置 防止 ExtraItemFeatureRenderer 未同步玩家变形状态
+            // 0.05s 0.1s 0.2s 1s 后重置 防止 ExtraItemFeatureRenderer 未同步玩家变形状态 减少玩家感知未同步
             new Thread(() -> {
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-                fpm.getConfig().xOffset = 0;
-                fpm.getConfig().sitXOffset = 0;
-                fpm.getConfig().sneakXOffset = 0;
+                try { Thread.sleep(50); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }  // 0.05s
+                fpm.getConfig().xOffset = 0; fpm.getConfig().sitXOffset = 0; fpm.getConfig().sneakXOffset = 0;
+                try { Thread.sleep(50); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }  // 0.1s
+                fpm.getConfig().xOffset = 0; fpm.getConfig().sitXOffset = 0; fpm.getConfig().sneakXOffset = 0;
+                try { Thread.sleep(100); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }  // 0.2s
+                fpm.getConfig().xOffset = 0; fpm.getConfig().sitXOffset = 0; fpm.getConfig().sneakXOffset = 0;
+                try { Thread.sleep(800); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }  // 1s  最终修复 大部分均在1s内恢复同步
+                fpm.getConfig().xOffset = 0; fpm.getConfig().sitXOffset = 0; fpm.getConfig().sneakXOffset = 0;
             }).start();
         }
     }


### PR DESCRIPTION
修复手臂渲染 #44 
- 修改为 原版+FERAL不渲染 的手臂渲染方式 修复上个修复中发现需要刷新的问题
--(我不知道MinecraftClient.getInstance().getTextureManager().bindTexture的作用, 尝试删除后一切正常如果没用, 可以把Skin赋值修改为三元运算符)
--(似乎可以通过 Mixin Invoke player.getSkinTexture() 来减少对渲染的修改 但可能需要测试兼容)

减少瞬间变身未同步导致FPM设置异常的感知 #46
- 从1s修改到 0.05s+0.1s+0.2s+1s四次重置 减少玩家感知
--(我的设备在测试中高概率出现此问题 经修改后明显减少视角瞬移的感知)