### PR TITLE
再次修改手臂渲染逻辑

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalPowers.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalPowers.java
@@ -27,6 +27,7 @@ public class AdditionalPowers {
         register(SnowballBlockTransformPower.createFactory());
         register(BatBlockAttachPower.createFactory());
         register(ActionOnJumpPower.createFactory());
+        register(NoRenderArmPower.createFactory());
     }
 
     public static PowerFactory<?> register(PowerFactory<?> powerFactory) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/NoRenderArmPower.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/NoRenderArmPower.java
@@ -1,0 +1,22 @@
+package net.onixary.shapeShifterCurseFabric.additional_power;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.power.Power;
+import io.github.apace100.apoli.power.PowerType;
+import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.calio.data.SerializableData;
+import net.minecraft.entity.LivingEntity;
+
+public class NoRenderArmPower extends Power {
+    public NoRenderArmPower(PowerType<?> type, LivingEntity entity) {
+        super(type, entity);
+    }
+
+    public static PowerFactory<?> createFactory() {
+        return new PowerFactory<>(
+                Apoli.identifier("no_render_arm"),
+                new SerializableData(),
+                data -> (type, entity) -> new NoRenderArmPower(type, entity)
+        ).allowCondition();
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/OverrideSkinFirstPersonMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/OverrideSkinFirstPersonMixin.java
@@ -2,6 +2,7 @@ package net.onixary.shapeShifterCurseFabric.mixin;
 
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import io.github.apace100.apoli.component.PowerHolderComponent;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.model.ModelPart;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
@@ -14,6 +15,7 @@ import net.minecraft.client.render.entity.model.PlayerEntityModel;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+import net.onixary.shapeShifterCurseFabric.additional_power.NoRenderArmPower;
 import net.onixary.shapeShifterCurseFabric.data.ConfigSSC;
 import net.onixary.shapeShifterCurseFabric.data.PlayerDataStorage;
 import net.onixary.shapeShifterCurseFabric.player_form.PlayerFormBodyType;
@@ -47,7 +49,7 @@ public abstract class OverrideSkinFirstPersonMixin extends LivingEntityRenderer<
         PlayerForms CurrentForm = RegPlayerFormComponent.PLAYER_FORM.get(player).getCurrentForm();
         if (CurrentForm != PlayerForms.ORIGINAL_BEFORE_ENABLE)  // 仅当玩家激活Mod后才进行修改
         {
-            if (RegFormConfig.getConfig(CurrentForm).getBodyType() == PlayerFormBodyType.FERAL) {  // 不渲染手臂情况
+            if (PowerHolderComponent.hasPower(player, NoRenderArmPower.class)) {  // 不渲染手臂情况
                 ci.cancel();
                 return;
             }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/OverrideSkinFirstPersonMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/OverrideSkinFirstPersonMixin.java
@@ -27,6 +27,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 // issue: OverrideSkinFirstPersonMixin会与某些其他mod不兼容，需要寻找原因所在
 @Mixin(PlayerEntityRenderer.class)
@@ -36,8 +37,8 @@ public abstract class OverrideSkinFirstPersonMixin extends LivingEntityRenderer<
         super(ctx, model, shadowSize);
     }
 
-    @Shadow
-    private void setModelPose(AbstractClientPlayerEntity player) {}
+    // 自定义皮肤路径
+    private static final Identifier CUSTOM_SKIN = new Identifier(ShapeShifterCurseFabric.MOD_ID, "textures/entity/base_player/ssc_base_skin.png");
 
     @Inject(
             method =  "renderArm",
@@ -46,33 +47,19 @@ public abstract class OverrideSkinFirstPersonMixin extends LivingEntityRenderer<
     )
 
     private void shape_shifter_curse$onRenderArm(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, AbstractClientPlayerEntity player, ModelPart arm, ModelPart sleeve, CallbackInfo ci) {
-        PlayerForms CurrentForm = RegPlayerFormComponent.PLAYER_FORM.get(player).getCurrentForm();
-        if (CurrentForm != PlayerForms.ORIGINAL_BEFORE_ENABLE)  // 仅当玩家激活Mod后才进行修改
-        {
-            if (PowerHolderComponent.hasPower(player, NoRenderArmPower.class)) {  // 不渲染手臂情况
-                ci.cancel();
-                return;
-            }
-            Identifier Skin = null;
-            if (!RegPlayerSkinComponent.SKIN_SETTINGS.get(player).shouldKeepOriginalSkin()) {
-                Skin = new Identifier(ShapeShifterCurseFabric.MOD_ID, "textures/entity/base_player/ssc_base_skin.png");
-                MinecraftClient.getInstance().getTextureManager().bindTexture(Skin);
-            }
-            else {
-                Skin = player.getSkinTexture();
-            }
-            // 原版渲染 仅修改注释位置
-            PlayerEntityModel playerEntityModel = (PlayerEntityModel)this.getModel();
-            this.setModelPose(player);
-            playerEntityModel.handSwingProgress = 0.0f;
-            playerEntityModel.sneaking = false;
-            playerEntityModel.leaningPitch = 0.0f;
-            playerEntityModel.setAngles(player, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
-            arm.pitch = 0.0f;
-            arm.render(matrices, vertexConsumers.getBuffer(RenderLayer.getEntitySolid(Skin)), light, OverlayTexture.DEFAULT_UV);  // 修改SKIN位置
-            sleeve.pitch = 0.0f;
-            sleeve.render(matrices, vertexConsumers.getBuffer(RenderLayer.getEntityTranslucent(Skin)), light, OverlayTexture.DEFAULT_UV);  // 修改SKIN位置
-            ci.cancel();  // 取消默认渲染 或许可以用Invoke Mixin getSkinTexture 来增加兼容性
+        if (PowerHolderComponent.hasPower(player, NoRenderArmPower.class)) {  // 不渲染手臂情况
+            ci.cancel();
         }
+    }
+
+    @Redirect(method="renderArm", at= @At(value="INVOKE", target = "Lnet/minecraft/client/network/AbstractClientPlayerEntity;getSkinTexture()Lnet/minecraft/util/Identifier;"))
+    private Identifier shape_shifter_curse$getSkinTexture(AbstractClientPlayerEntity player) {
+        if (RegPlayerFormComponent.PLAYER_FORM.get(player).getCurrentForm() != PlayerForms.ORIGINAL_BEFORE_ENABLE)  // 仅当玩家激活Mod后才进行修改
+        {
+            if (!RegPlayerSkinComponent.SKIN_SETTINGS.get(player).shouldKeepOriginalSkin()) {
+                return CUSTOM_SKIN;
+            }
+        }
+        return player.getSkinTexture();
     }
 }

--- a/src/main/resources/data/origins/origins/form_axolotl_2.json
+++ b/src/main/resources/data/origins/origins/form_axolotl_2.json
@@ -1,5 +1,6 @@
 {
 	"powers": [
+		"origins:no_render_arm_when_sneaking",
 		"origins:form_axolotl_2_scale",
 
 		"origins:water_breathing_slow",

--- a/src/main/resources/data/origins/origins/form_bat_3.json
+++ b/src/main/resources/data/origins/origins/form_bat_3.json
@@ -1,5 +1,6 @@
 {
 	"powers":[
+		"origins:no_render_arm",
 		"origins:form_bat_2_scale",
 		"origins:elytra_no_render",
 		"origins:bat_vision",

--- a/src/main/resources/data/origins/origins/form_familiar_fox_2.json
+++ b/src/main/resources/data/origins/origins/form_familiar_fox_2.json
@@ -1,5 +1,6 @@
 {
 	"powers": [
+		"origins:no_render_arm_when_sneaking",
 		"origins:form_familiar_fox_2_scale",
 		"origins:form_sprint_speed_up",
 		"origins:form_familiar_fox_1_looting",

--- a/src/main/resources/data/origins/origins/form_familiar_fox_3.json
+++ b/src/main/resources/data/origins/origins/form_familiar_fox_3.json
@@ -1,5 +1,6 @@
 {
 	"powers": [
+		"origins:no_render_arm",
 		"origins:form_familiar_fox_3_scale",
 		"origins:form_familiar_fox_3_particle",
 		"origins:form_familiar_fox_3_craft_healing_potion",

--- a/src/main/resources/data/origins/origins/form_feral_cat_sp.json
+++ b/src/main/resources/data/origins/origins/form_feral_cat_sp.json
@@ -1,5 +1,6 @@
 {
 	"powers": [
+		"origins:no_render_arm",
 		"origins:form_feral_cat_sp_scale",
 		"origins:form_disable_leg_armor",
 		"origins:form_disable_feet_armor",

--- a/src/main/resources/data/origins/origins/form_ocelot_2.json
+++ b/src/main/resources/data/origins/origins/form_ocelot_2.json
@@ -1,5 +1,6 @@
 {
 	"powers": [
+		"origins:no_render_arm_when_sneaking",
 		"origins:form_ocelot_2_scale",
 		"origins:scare_creepers",
 		"origins:fall_immunity",

--- a/src/main/resources/data/origins/origins/form_ocelot_3.json
+++ b/src/main/resources/data/origins/origins/form_ocelot_3.json
@@ -1,5 +1,6 @@
 {
 	"powers": [
+		"origins:no_render_arm",
 		"origins:form_ocelot_3_scale",
 		"origins:scare_creepers",
 		"origins:fall_immunity",

--- a/src/main/resources/data/origins/origins/form_phi_sp.json
+++ b/src/main/resources/data/origins/origins/form_phi_sp.json
@@ -1,5 +1,6 @@
 {
 	"powers": [
+		"origins:no_render_arm",
 		"origins:form_feral_cat_sp_scale"
 	],
 	"icon": {

--- a/src/main/resources/data/origins/origins/form_snow_fox_2.json
+++ b/src/main/resources/data/origins/origins/form_snow_fox_2.json
@@ -1,5 +1,6 @@
 {
 	"powers": [
+		"origins:no_render_arm_when_sneaking",
 		"origins:form_familiar_fox_2_scale",
 		"origins:form_sprint_speed_up",
 		"origins:form_disable_leg_armor",

--- a/src/main/resources/data/origins/origins/form_snow_fox_3.json
+++ b/src/main/resources/data/origins/origins/form_snow_fox_3.json
@@ -1,5 +1,6 @@
 {
 	"powers": [
+		"origins:no_render_arm",
 		"origins:form_familiar_fox_3_scale",
 		"origins:form_sprint_speed_up",
 		"origins:form_familiar_fox_3_water_speed_down",

--- a/src/main/resources/data/origins/powers/no_render_arm.json
+++ b/src/main/resources/data/origins/powers/no_render_arm.json
@@ -1,0 +1,3 @@
+{
+  "type": "origins:no_render_arm"
+}

--- a/src/main/resources/data/origins/powers/no_render_arm_when_sneaking.json
+++ b/src/main/resources/data/origins/powers/no_render_arm_when_sneaking.json
@@ -1,0 +1,11 @@
+{
+  "type": "origins:no_render_arm",
+  "condition": {
+    "type": "origins:and",
+    "conditions": [
+      {
+        "type": "origins:sneaking"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
将PR #47 提到的问题修改
- 使用数据包Power系统修改手臂渲染黑名单
-- 支持Power启用条件
-- 现在实现: 四足形态隐藏, 蹲下动作为坐下的形态在蹲下时隐藏, 美西螈最终形态蹲下时隐藏
- 将注入onRenderArm 的Mixin拆分为两部分 渲染逻辑使用原版方案 仅修改获取皮肤和添加渲染黑名单逻辑