### PR TITLE
添加AccessWidener访问加宽支持

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ loom {
             runDir "run/server"
         }
     }
+    accessWidenerPath = file("src/main/resources/shape-shifter-curse.accesswidener")
 }
 
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -47,6 +47,8 @@
     "originalfur.fabric.mixins.json"
   ],
 
+  "accessWidener": "shape-shifter-curse.accesswidener",
+
   "custom": {
     "cardinal-components": [
       "origins:origin",

--- a/src/main/resources/shape-shifter-curse.accesswidener
+++ b/src/main/resources/shape-shifter-curse.accesswidener
@@ -1,0 +1,1 @@
+accessWidener   v1  named


### PR DESCRIPTION
支持AccessWidener访问加宽 (比Mixin访问加宽编写方便 仅需一行 且在IDEA上MinecraftDeveloper插件支持快速生成条目)