### PR TITLE
修复悦灵不显示手臂Geo模型

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/ShapeShifterCurseFabric.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/ShapeShifterCurseFabric.java
@@ -38,6 +38,7 @@ import net.onixary.shapeShifterCurseFabric.command.CustomFormArgumentType;
 import net.onixary.shapeShifterCurseFabric.command.FormArgumentType;
 import net.onixary.shapeShifterCurseFabric.command.ShapeShifterCurseCommand;
 import net.onixary.shapeShifterCurseFabric.config.ClientConfig;
+import net.onixary.shapeShifterCurseFabric.config.CommonConfig;
 import net.onixary.shapeShifterCurseFabric.data.ConfigSSC;
 import net.onixary.shapeShifterCurseFabric.data.CursedMoonData;
 import net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.RegTransformativeEntitySpawnEgg;
@@ -168,6 +169,7 @@ public class ShapeShifterCurseFabric implements ModInitializer {
 
         // 注册配置文件
         AutoConfig.register(ClientConfig.class, Toml4jConfigSerializer::new);  // 客户端配置
+        AutoConfig.register(CommonConfig.class, Toml4jConfigSerializer::new);  // 双端配置
 
         // network package
         ModPacketsC2S.register();

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/config/CommonConfig.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/config/CommonConfig.java
@@ -5,15 +5,14 @@ import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.autoconfig.annotation.ConfigEntry;
 import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Comment;
 
-// 客户端配置 (仅客户端加载)
-@Config(name = "shape-shifter-curse-client")
-public class ClientConfig implements ConfigData {
-    public ClientConfig() {}
+// 双端配置
+@Config(name = "shape-shifter-curse-common")
+public class CommonConfig implements ConfigData {
+    public CommonConfig() {}
 
-    // Comment 不知道如何本地化
     @ConfigEntry.Category("General")
-    @Comment("Enable form model on vanilla first person render Default: true")
-    public boolean enableFormModelOnVanillaFirstPersonRender = true;  // 原版第一人称下启用形态模型渲染
+    @Comment("PLACEHOLDER Default: false")
+    public boolean generalConfigPlaceHolder = false;  // 占位符 添加新项目时请删除
 
     // 开发用
     @ConfigEntry.Category("InDevelopment")

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/config/ConfigIntegration.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/config/ConfigIntegration.java
@@ -1,15 +1,14 @@
 package net.onixary.shapeShifterCurseFabric.config;
 
+
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 import me.shedaniel.autoconfig.AutoConfig;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 
-@Environment(EnvType.CLIENT)
-public class ClientConfigIntegration implements ModMenuApi {
+public class ConfigIntegration implements ModMenuApi {
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
-        return parent -> AutoConfig.getConfigScreen(ClientConfig.class, parent).get();
+        return ConfigMenuScreen::new;
     }
 }
+

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/config/ConfigMenuScreen.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/config/ConfigMenuScreen.java
@@ -1,0 +1,58 @@
+package net.onixary.shapeShifterCurseFabric.config;
+
+import io.github.apace100.apoli.util.ApoliConfigClient;
+import me.shedaniel.autoconfig.AutoConfig;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.text.Text;
+
+import java.util.function.Supplier;
+
+// 配置菜单Mod 只支持一个配置菜单 添加一个选择菜单
+public class ConfigMenuScreen extends Screen {
+    private Screen parent;
+    public ConfigMenuScreen(Screen parent) {
+        super(Text.translatable("text.shape-shifter-curse.config.title"));
+    }
+
+    public void init() {
+        int Config_BTN_Size_X = 240;  // 按钮长 英文过长时请修改
+        int Config_BTN_Size_Y = 20;  // 按钮宽
+        int Config_BTN_Interval = 10;  // 按钮Y方向间隔 留空部分
+        int Config_Count = 3;  // 配置数量  **** 添加配置时修改 ****
+        int Additional_Button_Count = 1;  // 额外按钮数量 [关闭配置界面按钮]
+        int Config_BTN_X_Pos = (width - Config_BTN_Size_X) / 2;  // 按钮X坐标
+        int Config_BTN_Y_Start_Pos = (height - Config_BTN_Size_Y * (Config_Count + Additional_Button_Count) - Config_BTN_Interval * (Config_Count + Additional_Button_Count - 1)) / 2;  // 按钮Y坐标起始位置
+        int Config_BTN_Y_Pos = Config_BTN_Y_Start_Pos;  // 按钮Y坐标
+
+        // 添加按钮
+        // 客户端配置
+        AddButton(Config_BTN_X_Pos, Config_BTN_Y_Pos, Config_BTN_Size_X, Config_BTN_Size_Y, Text.translatable("text.autoconfig.shape-shifter-curse-client.title"), AutoConfig.getConfigScreen(ClientConfig.class, this));
+        Config_BTN_Y_Pos += Config_BTN_Size_Y + Config_BTN_Interval;
+        // 双端配置
+        AddButton(Config_BTN_X_Pos, Config_BTN_Y_Pos, Config_BTN_Size_X, Config_BTN_Size_Y, Text.translatable("text.autoconfig.shape-shifter-curse-common.title"), AutoConfig.getConfigScreen(CommonConfig.class, this));
+        Config_BTN_Y_Pos += Config_BTN_Size_Y + Config_BTN_Interval;
+
+        // 被吞进去的Apoli配置 **** 提取起源模组时记得删除这项 ****
+        AddButton(Config_BTN_X_Pos, Config_BTN_Y_Pos, Config_BTN_Size_X, Config_BTN_Size_Y, Text.translatable("text.autoconfig.power_config.title"), AutoConfig.getConfigScreen(ApoliConfigClient.class, this));
+        Config_BTN_Y_Pos += Config_BTN_Size_Y + Config_BTN_Interval;
+
+        // **** 在这里添加配置 ****
+
+        // 关闭配置界面按钮
+        AddButton(Config_BTN_X_Pos, Config_BTN_Y_Pos, Config_BTN_Size_X, Config_BTN_Size_Y, Text.translatable("text.shape-shifter-curse.config.close"), () -> parent);
+    }
+
+    public void AddButton(int PosX, int PosY, int SizeX, int SizeY, Text text, Supplier<Screen> ConfigScreenSupplier) {
+        addDrawableChild(ButtonWidget.builder(text, button -> {
+            MinecraftClient.getInstance().setScreen(ConfigScreenSupplier.get());
+        }).size(SizeX, SizeY).position(PosX, PosY).build());
+    }
+
+    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+        this.renderBackground(context);
+        super.render(context, mouseX, mouseY, delta);
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/OverrideSkinFirstPersonMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/OverrideSkinFirstPersonMixin.java
@@ -125,7 +125,7 @@ public abstract class OverrideSkinFirstPersonMixin extends LivingEntityRenderer<
             // fur.renderBone(GeoBoneName, matrices, vertexConsumers, renderLayerFullBright, null, Integer.MAX_VALUE - 1);
             matrices.pop();
             // Render Overlay 藏得够深的 要不是发现悦灵手臂无法显示我都不会发现
-            // 从 PlayerEntityRenderer.renderOverlayTexture 提取的代码并进行修改
+            // 从 PlayerEntityRendererMixin.renderOverlayTexture 提取的代码并进行修改
             Identifier OverlayTextureID = OFModel.getOverlayTexture(acc.originalFur$isSlim());
             if (OverlayTextureID != null) {
                 // 玩家看自己绝对是非隐身

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/OverrideSkinFirstPersonMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/OverrideSkinFirstPersonMixin.java
@@ -26,7 +26,6 @@ import net.onixary.shapeShifterCurseFabric.player_form.skin.RegPlayerSkinCompone
 import net.onixary.shapeShifterCurseFabric.player_form_render.*;
 import org.joml.Quaternionf;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -38,8 +37,6 @@ import java.util.Optional;
 // issue: OverrideSkinFirstPersonMixin会与某些其他mod不兼容，需要寻找原因所在
 @Mixin(PlayerEntityRenderer.class)
 public abstract class OverrideSkinFirstPersonMixin extends LivingEntityRenderer<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> {
-
-    @Shadow protected abstract void setModelPose(AbstractClientPlayerEntity player);
 
     protected OverrideSkinFirstPersonMixin(EntityRendererFactory.Context ctx, PlayerEntityModel<AbstractClientPlayerEntity> model, float shadowSize) {
         super(ctx, model, shadowSize);

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerEntityAnimOverrideMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerEntityAnimOverrideMixin.java
@@ -179,7 +179,9 @@ public abstract class PlayerEntityAnimOverrideMixin extends PlayerEntity {
 
             }
 
-            if (world.getBlockState(getBlockPos()).getBlock() instanceof LadderBlock && !isOnGround() && !jumping)
+            // if ((world.getBlockState(getBlockPos()).getBlock() instanceof LadderBlock && !isOnGround() && !jumping))
+            // 直接使用isClimbing()判断是否在攀爬
+            if (this.isClimbing())
             {
                 currentState = PlayerAnimState.ANIM_CLIMB_IDLE;
                 if (getVelocity().y > 0)

--- a/src/main/resources/assets/shape-shifter-curse/lang/en_us.json
+++ b/src/main/resources/assets/shape-shifter-curse/lang/en_us.json
@@ -638,6 +638,16 @@
   "codex.form.phi_sp.cons": [" "],
   "codex.form.phi_sp.instincts": ["\n\n\nCompared to other forms, you notice this one seems \"special\": it barely affects your mind and feels less stable. If desired, you could likely revert it relatively easily"],
 
+  "text.shape-shifter-curse.config.title": "Shape Shifter Curse Config Menu",
+  "text.shape-shifter-curse.config.close": "Cancel",
   "text.autoconfig.shape-shifter-curse-client.title": "Shape Shifter Curse - Client Config",
-  "text.autoconfig.shape-shifter-curse-client.option.enableFormModelOnVanillaFirstPersonRender": "Enable Render form model on vanilla first person render"
+  "text.autoconfig.shape-shifter-curse-client.category.General": "General",
+  "text.autoconfig.shape-shifter-curse-client.option.enableFormModelOnVanillaFirstPersonRender": "Enable Render form model on vanilla first person render",
+  "text.autoconfig.shape-shifter-curse-client.category.InDevelopment": "In Development",
+  "text.autoconfig.shape-shifter-curse-client.option.inDevelopmentConfigPlaceHolder": "In Development Config Placeholder",
+  "text.autoconfig.shape-shifter-curse-common.title": "Shape Shifter Curse - Common Config",
+  "text.autoconfig.shape-shifter-curse-common.category.General": "General",
+  "text.autoconfig.shape-shifter-curse-common.option.generalConfigPlaceHolder": "Placeholder",
+  "text.autoconfig.shape-shifter-curse-common.category.InDevelopment": "In Development",
+  "text.autoconfig.shape-shifter-curse-common.option.inDevelopmentConfigPlaceHolder": "In Development Config Placeholder"
 }

--- a/src/main/resources/assets/shape-shifter-curse/lang/zh_cn.json
+++ b/src/main/resources/assets/shape-shifter-curse/lang/zh_cn.json
@@ -599,6 +599,16 @@
   "codex.form.phi_sp.cons": [" "],
   "codex.form.phi_sp.instincts": ["\n\n\n与其它形态相比，你觉察到你当前的形态似乎有些“特别之处”：它并没有对你的内心造成太多影响，似乎也没有那么稳定。如果你希望的话，应该可以较为容易地将其逆转"],
 
+  "text.shape-shifter-curse.config.title": "幻形者诅咒 配置界面",
+  "text.shape-shifter-curse.config.close": "取消",
   "text.autoconfig.shape-shifter-curse-client.title": "幻形者诅咒 - 客户端配置",
-  "text.autoconfig.shape-shifter-curse-client.option.enableFormModelOnVanillaFirstPersonRender": "原版第一人称下启用形态模型渲染"
+  "text.autoconfig.shape-shifter-curse-client.category.General": "常规配置",
+  "text.autoconfig.shape-shifter-curse-client.option.enableFormModelOnVanillaFirstPersonRender": "原版第一人称下启用形态模型渲染",
+  "text.autoconfig.shape-shifter-curse-client.category.InDevelopment": "开发中配置",
+  "text.autoconfig.shape-shifter-curse-client.option.inDevelopmentConfigPlaceHolder": "开发中配置占位符",
+  "text.autoconfig.shape-shifter-curse-common.title": "幻形者诅咒 - 通用配置",
+  "text.autoconfig.shape-shifter-curse-common.category.General": "常规配置",
+  "text.autoconfig.shape-shifter-curse-common.option.generalConfigPlaceHolder": "配置占位符",
+  "text.autoconfig.shape-shifter-curse-common.category.InDevelopment": "开发中配置",
+  "text.autoconfig.shape-shifter-curse-common.option.inDevelopmentConfigPlaceHolder": "开发中配置占位符"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,8 +28,7 @@
       "net.onixary.shapeShifterCurseFabric.player_form_render.OriginalFurClient"
     ],
     "modmenu": [
-      "net.onixary.shapeShifterCurseFabric.integration.origins.integration.ModMenuIntegration",
-      "net.onixary.shapeShifterCurseFabric.config.ClientConfigIntegration"
+      "net.onixary.shapeShifterCurseFabric.config.ConfigIntegration"
     ],
     "cardinal-components-entity": [
       "net.onixary.shapeShifterCurseFabric.integration.origins.registry.ModComponents",


### PR DESCRIPTION
悦灵还使用Overlay图层渲染 添加手臂渲染对含有Overlay图层的模型的支持
- 藏得够深的 要不是昨天测试能力发现悦灵手臂无法显示我都不会发现 渲染不在 FurRenderFeature 中 由 PlayerEntityRendererMixin.renderOverlayTexture 渲染