### PR TITLE
提供修改咒文生物生成成功率的配置项 重构幻形者之书

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/ShapeShifterCurseFabric.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/ShapeShifterCurseFabric.java
@@ -2,13 +2,14 @@ package net.onixary.shapeShifterCurseFabric;
 
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.Toml4jConfigSerializer;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.ArgumentTypeRegistry;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.entity.event.v1.EntitySleepEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
-import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
 import net.minecraft.advancement.criterion.Criteria;
@@ -78,6 +79,10 @@ public class ShapeShifterCurseFabric implements ModInitializer {
     public static final String MOD_ID = "shape-shifter-curse";
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
     public static final ConfigSSC CONFIG = ConfigSSC.createAndLoad();
+
+    public static ClientConfig clientConfig;
+    public static CommonConfig commonConfig;
+
     // 用于在游戏内测试调参用的临时变量
     public static Vec3d feralItemCenter = new Vec3d(0.0F, 0.0F, 0.0F);
     public static Vec3d feralItemPosOffset = new Vec3d(0.0F, 0.0F, 0.0F);
@@ -169,7 +174,9 @@ public class ShapeShifterCurseFabric implements ModInitializer {
 
         // 注册配置文件
         AutoConfig.register(ClientConfig.class, Toml4jConfigSerializer::new);  // 客户端配置
+        clientConfig = AutoConfig.getConfigHolder(ClientConfig.class).getConfig();
         AutoConfig.register(CommonConfig.class, Toml4jConfigSerializer::new);  // 双端配置
+        commonConfig = AutoConfig.getConfigHolder(CommonConfig.class).getConfig();
 
         // network package
         ModPacketsC2S.register();

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/client/ShapeShifterCurseFabricClient.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/client/ShapeShifterCurseFabricClient.java
@@ -2,38 +2,30 @@ package net.onixary.shapeShifterCurseFabric.client;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.CoreShaderRegistrationCallback;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
-import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
-import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.ShaderProgram;
 import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.client.render.VertexFormat;
 import net.minecraft.client.render.VertexFormats;
 import net.minecraft.client.render.entity.model.EntityModelLayer;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.resource.ResourceManager;
-import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
 import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
 import net.onixary.shapeShifterCurseFabric.custom_ui.BookOfShapeShifterScreen;
+import net.onixary.shapeShifterCurseFabric.custom_ui.StartBookScreenV2;
 import net.onixary.shapeShifterCurseFabric.custom_ui.StartBookScreen;
 import net.onixary.shapeShifterCurseFabric.data.StaticParams;
 import net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.axolotl.TAxolotlEntityRenderer;
 import net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.bat.BatEntityModel;
 import net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.bat.BatEntityRenderer;
 import net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.ocelot.TOcelotEntityRenderer;
-import net.onixary.shapeShifterCurseFabric.networking.ModPackets;
 import net.onixary.shapeShifterCurseFabric.networking.ModPacketsS2C;
 import net.onixary.shapeShifterCurseFabric.player_animation.RegPlayerAnimation;
 import net.onixary.shapeShifterCurseFabric.render.render_layer.FurGradientRenderLayer;
 import net.onixary.shapeShifterCurseFabric.util.ClientTicker;
 import net.onixary.shapeShifterCurseFabric.util.TickManager;
-
-import java.io.IOException;
 
 import static net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric.*;
 
@@ -55,10 +47,19 @@ public class ShapeShifterCurseFabricClient implements ClientModInitializer {
 		}
 	}
 	public static void openStartBookScreen(PlayerEntity user) {
-		if (!(MinecraftClient.getInstance().currentScreen instanceof StartBookScreen)) {
-			StartBookScreen startScreen = new StartBookScreen();
-			startScreen.currentPlayer = user;
-			MinecraftClient.getInstance().setScreen(startScreen);
+		if (commonConfig.enableNewStartBook) {
+			if (!(MinecraftClient.getInstance().currentScreen instanceof StartBookScreenV2)) {
+				StartBookScreenV2 startScreen = new StartBookScreenV2();
+				startScreen.currentPlayer = user;
+				MinecraftClient.getInstance().setScreen(startScreen);
+			}
+		}
+		else {
+			if (!(MinecraftClient.getInstance().currentScreen instanceof StartBookScreen)) {
+				StartBookScreen startScreen = new StartBookScreen();
+				startScreen.currentPlayer = user;
+				MinecraftClient.getInstance().setScreen(startScreen);
+			}
 		}
 	}
 

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/client/ShapeShifterCurseFabricClient.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/client/ShapeShifterCurseFabricClient.java
@@ -14,6 +14,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Identifier;
 import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
 import net.onixary.shapeShifterCurseFabric.custom_ui.BookOfShapeShifterScreen;
+import net.onixary.shapeShifterCurseFabric.custom_ui.BookOfShapeShifterScreenV2_P1;
 import net.onixary.shapeShifterCurseFabric.custom_ui.StartBookScreenV2;
 import net.onixary.shapeShifterCurseFabric.custom_ui.StartBookScreen;
 import net.onixary.shapeShifterCurseFabric.data.StaticParams;
@@ -40,10 +41,19 @@ public class ShapeShifterCurseFabricClient implements ClientModInitializer {
 	private static ShaderProgram furGradientShader;
 
 	public static void openBookScreen(PlayerEntity user) {
-		if (!(MinecraftClient.getInstance().currentScreen instanceof BookOfShapeShifterScreen)) {
-			BookOfShapeShifterScreen bookScreen = new BookOfShapeShifterScreen();
-			bookScreen.currentPlayer = user;
-			MinecraftClient.getInstance().setScreen(bookScreen);
+		if (commonConfig.enableNewStartBook) {
+			if (!(MinecraftClient.getInstance().currentScreen instanceof BookOfShapeShifterScreenV2_P1)) {
+				BookOfShapeShifterScreenV2_P1 bookScreen = new BookOfShapeShifterScreenV2_P1();
+				bookScreen.currentPlayer = user;
+				MinecraftClient.getInstance().setScreen(bookScreen);
+			}
+		}
+		else {
+			if (!(MinecraftClient.getInstance().currentScreen instanceof BookOfShapeShifterScreen)) {
+				BookOfShapeShifterScreen bookScreen = new BookOfShapeShifterScreen();
+				bookScreen.currentPlayer = user;
+				MinecraftClient.getInstance().setScreen(bookScreen);
+			}
 		}
 	}
 	public static void openStartBookScreen(PlayerEntity user) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/config/CommonConfig.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/config/CommonConfig.java
@@ -10,9 +10,18 @@ import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Comment;
 public class CommonConfig implements ConfigData {
     public CommonConfig() {}
 
+    // Cloth Config 没有浮点的边界检查 只有整数的
     @ConfigEntry.Category("General")
-    @Comment("PLACEHOLDER Default: false")
-    public boolean generalConfigPlaceHolder = false;  // 占位符 添加新项目时请删除
+    @Comment("Transformative Ocelot Spawn Chance, 0 For Disable Spawn. Default: 0.5f [0.0f ~ 1.0f]")
+    public float transformativeBatSpawnChance = 0.5f;
+
+    @ConfigEntry.Category("General")
+    @Comment("Transformative Ocelot Spawn Chance, 0 For Disable Spawn. Default: 1.0f [0.0f ~ 1.0f]")
+    public float transformativeAxolotlSpawnChance = 1.0f;
+
+    @ConfigEntry.Category("General")
+    @Comment("Transformative Ocelot Spawn Chance, 0 For Disable Spawn. Default: 0.67f [0.0f ~ 1.0f]")
+    public float transformativeOcelotSpawnChance = 0.67f;
 
     // 开发用
     @ConfigEntry.Category("InDevelopment")

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/config/CommonConfig.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/config/CommonConfig.java
@@ -25,6 +25,6 @@ public class CommonConfig implements ConfigData {
 
     // 开发用
     @ConfigEntry.Category("InDevelopment")
-    @Comment("PLACEHOLDER Default: false")
-    public boolean inDevelopmentConfigPlaceHolder = false;  // 占位符 添加新项目时请删除
+    @Comment("Only Developer Use Default: false")
+    public boolean enableNewStartBook = false;  // 新版启动书
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P1.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P1.java
@@ -1,0 +1,87 @@
+package net.onixary.shapeShifterCurseFabric.custom_ui;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.InventoryScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import org.joml.Quaternionf;
+
+import static net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric.MOD_ID;
+
+public class BookOfShapeShifterScreenV2_P1 extends Screen {
+    private static final Identifier page_texID = new Identifier(MOD_ID,"textures/gui/codex_page_1.png");
+    public PlayerEntity currentPlayer;
+    public static final int BookSizeX = 350;
+    public static final int BookSizeY = 320;
+
+    public BookOfShapeShifterScreenV2_P1() {
+        super(Text.of("ShapeShifterCurse_Book_Screen_V2"));
+    }
+
+    @Override
+    public void init() {
+        int BookPosX = width / 2 - BookSizeX / 2;
+        int BookPosY = height / 2 - BookSizeY / 2;
+        // 文本数据
+        // 下一页按钮
+        int NextPage_ButtonSizeX = 15;
+        int NextPage_ButtonSizeY = 30;
+        int NextPage_ButtonPosX = width / 2 + BookSizeX / 2 - 18;
+        int NextPage_ButtonPosY = height / 2 - NextPage_ButtonSizeY / 2;
+        this.addDrawableChild(
+                ButtonWidget.builder(Text.of(">"), button -> NextPage()).size(NextPage_ButtonSizeX, NextPage_ButtonSizeY).position(NextPage_ButtonPosX, NextPage_ButtonPosY).build()
+        );
+    }
+
+    private void RenderEntity(DrawContext context, int x, int y, int size, int mouseX, int mouseY, LivingEntity entity) {
+        float f = (float)Math.atan((double)(mouseX / 40.0F));
+        float g = (float)Math.atan((double)(mouseY / 40.0F));
+        Quaternionf quaternionf = (new Quaternionf()).rotateZ(3.1415927F);
+        Quaternionf quaternionf2 = (new Quaternionf()).rotateX(g * 20.0F * 0.017453292F);
+        quaternionf.mul(quaternionf2);
+        float h = entity.bodyYaw;
+        float i = entity.getYaw();
+        float j = entity.getPitch();
+        float k = entity.prevHeadYaw;
+        float l = entity.headYaw;
+        entity.bodyYaw = 180.0F + f * 20.0F;
+        entity.setYaw(180.0F + f * 40.0F);
+        entity.setPitch(-g * 20.0F);
+        entity.headYaw = entity.getYaw();
+        entity.prevHeadYaw = entity.getYaw();
+        InventoryScreen.drawEntity(context, x, y, size, quaternionf, quaternionf2, entity);
+        entity.bodyYaw = h;
+        entity.setYaw(i);
+        entity.setPitch(j);
+        entity.prevHeadYaw = k;
+        entity.headYaw = l;
+    }
+
+    private void RenderBook(DrawContext context) {
+        int BookPosX = width / 2 - BookSizeX / 2;
+        int BookPosY = height / 2 - BookSizeY / 2;
+        context.drawTexture(page_texID, BookPosX, BookPosY, 0, 0, BookSizeX, BookSizeY, BookSizeX, BookSizeY);
+    }
+
+    private void NextPage() {
+        BookOfShapeShifterScreenV2_P2 NextPage = new BookOfShapeShifterScreenV2_P2();
+        NextPage.currentPlayer = currentPlayer;
+        MinecraftClient.getInstance().setScreen(NextPage);
+    }
+
+    @Override
+    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+        int BookPosX = width / 2 - BookSizeX / 2;
+        int BookPosY = height / 2 - BookSizeY / 2;
+        int PlayerX = BookPosX + 70;
+        int PlayerY = BookPosY + 100;
+        this.RenderBook(context);
+        this.RenderEntity(context, PlayerX, PlayerY, 30, PlayerX - mouseX, PlayerY - 37 - mouseY, currentPlayer);
+        super.render(context, mouseX, mouseY, delta);
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P1.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P1.java
@@ -5,11 +5,17 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.MultilineTextWidget;
+import net.minecraft.client.gui.widget.TextWidget;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+import net.onixary.shapeShifterCurseFabric.data.CodexData;
 import org.joml.Quaternionf;
+
+import java.util.OptionalInt;
 
 import static net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric.MOD_ID;
 
@@ -19,15 +25,36 @@ public class BookOfShapeShifterScreenV2_P1 extends Screen {
     public static final int BookSizeX = 350;
     public static final int BookSizeY = 320;
 
+    private int GetFixedY(int y) {
+        // 原点为书本左上角
+        // 书的材质大小为 (350, 220) 需要校准Y坐标
+        int BookPosY = height / 2 - BookSizeY / 2;
+        return BookPosY + (int)((float)y * 1.455f);
+    }
+
     public BookOfShapeShifterScreenV2_P1() {
         super(Text.of("ShapeShifterCurse_Book_Screen_V2"));
     }
 
     @Override
     public void init() {
+        // 这字够大了, 不用添加展开按钮了
         int BookPosX = width / 2 - BookSizeX / 2;
-        int BookPosY = height / 2 - BookSizeY / 2;
-        // 文本数据
+        int DefaultTextColor = 0xFFFFFF;  // 这里的颜色属于乘法模式 (float)(R1*R2,G1*G2,B1*B2) 需要在lang中修改
+        // Title
+        // Size -> (108, 48) Pos -> (17, 92)
+        MultilineTextWidget TitleLabel = new MultilineTextWidget(BookPosX + 17, GetFixedY(92), CodexData.getContentText(CodexData.ContentType.TITLE, currentPlayer), textRenderer).setMaxWidth(108).setTextColor(DefaultTextColor);
+        this.addDrawableChild(TitleLabel);
+        // Status
+        // Size -> (107, 56) Pos -> (17, 153)
+        this.addDrawableChild(new TextWidget(17, GetFixedY(153 - 6), 107, 5, CodexData.headerStatus, textRenderer).setTextColor(DefaultTextColor));
+        MultilineTextWidget StatusLabel = new MultilineTextWidget(BookPosX + 17, GetFixedY(153), CodexData.getPlayerStatusText(currentPlayer), textRenderer).setMaxWidth(107).setTextColor(DefaultTextColor);
+        this.addDrawableChild(StatusLabel);
+        // Appearance
+        // Size -> (176, 184) Pos -> (142, 23)
+        this.addDrawableChild(new TextWidget(142, GetFixedY(23 - 6), 176, 5, CodexData.headerStatus, textRenderer).setTextColor(DefaultTextColor));
+        MultilineTextWidget AppearanceLabel = new MultilineTextWidget(BookPosX + 142, GetFixedY(23), CodexData.getContentText(CodexData.ContentType.APPEARANCE, currentPlayer), textRenderer).setMaxWidth(176).setTextColor(DefaultTextColor);
+        this.addDrawableChild(AppearanceLabel);
         // 下一页按钮
         int NextPage_ButtonSizeX = 15;
         int NextPage_ButtonSizeY = 30;
@@ -77,10 +104,11 @@ public class BookOfShapeShifterScreenV2_P1 extends Screen {
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {
         int BookPosX = width / 2 - BookSizeX / 2;
-        int BookPosY = height / 2 - BookSizeY / 2;
-        int PlayerX = BookPosX + 70;
-        int PlayerY = BookPosY + 100;
         this.RenderBook(context);
+        // 实体渲染原点为实体中心脚下
+        // Size -> (70, 66) Pos -> (35, 15)
+        int PlayerX = BookPosX + 70;
+        int PlayerY = GetFixedY(70);
         this.RenderEntity(context, PlayerX, PlayerY, 30, PlayerX - mouseX, PlayerY - 37 - mouseY, currentPlayer);
         super.render(context, mouseX, mouseY, delta);
     }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P2.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P2.java
@@ -1,0 +1,55 @@
+package net.onixary.shapeShifterCurseFabric.custom_ui;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import static net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric.MOD_ID;
+
+public class BookOfShapeShifterScreenV2_P2 extends Screen {
+    private static final Identifier page_texID = new Identifier(MOD_ID,"textures/gui/codex_page_2.png");
+    public PlayerEntity currentPlayer;
+    public static final int BookSizeX = 350;
+    public static final int BookSizeY = 320;
+
+    public BookOfShapeShifterScreenV2_P2() {
+        super(Text.of("ShapeShifterCurse_Book_Screen_V2"));
+    }
+
+    @Override
+    public void init() {
+        int BookPosX = width / 2 - BookSizeX / 2;
+        int BookPosY = height / 2 - BookSizeY / 2;
+        // 文本数据
+        // 下一页按钮
+        int NextPage_ButtonSizeX = 15;
+        int NextPage_ButtonSizeY = 30;
+        int NextPage_ButtonPosX = width / 2 + BookSizeX / 2 - 18;
+        int NextPage_ButtonPosY = height / 2 - NextPage_ButtonSizeY / 2;
+        this.addDrawableChild(
+                ButtonWidget.builder(Text.of(">"), button -> NextPage()).size(NextPage_ButtonSizeX, NextPage_ButtonSizeY).position(NextPage_ButtonPosX, NextPage_ButtonPosY).build()
+        );
+    }
+
+    private void RenderBook(DrawContext context) {
+        int BookPosX = width / 2 - BookSizeX / 2;
+        int BookPosY = height / 2 - BookSizeY / 2;
+        context.drawTexture(page_texID, BookPosX, BookPosY, 0, 0, BookSizeX, BookSizeY, BookSizeX, BookSizeY);
+    }
+
+    private void NextPage() {
+        BookOfShapeShifterScreenV2_P1 NextPage = new BookOfShapeShifterScreenV2_P1();
+        NextPage.currentPlayer = currentPlayer;
+        MinecraftClient.getInstance().setScreen(NextPage);
+    }
+
+    @Override
+    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+        this.RenderBook(context);
+        super.render(context, mouseX, mouseY, delta);
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P2.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P2.java
@@ -4,9 +4,12 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.MultilineTextWidget;
+import net.minecraft.client.gui.widget.TextWidget;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
+import net.onixary.shapeShifterCurseFabric.data.CodexData;
 
 import static net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric.MOD_ID;
 
@@ -20,11 +23,33 @@ public class BookOfShapeShifterScreenV2_P2 extends Screen {
         super(Text.of("ShapeShifterCurse_Book_Screen_V2"));
     }
 
+    private int GetFixedY(int y) {
+        // 原点为书本左上角
+        // 书的材质大小为 (350, 220) 需要校准Y坐标
+        int BookPosY = height / 2 - BookSizeY / 2;
+        return BookPosY + (int)((float)y * 1.455f);
+    }
+
     @Override
     public void init() {
+        // 这字够大了, 不用添加展开按钮了
         int BookPosX = width / 2 - BookSizeX / 2;
-        int BookPosY = height / 2 - BookSizeY / 2;
-        // 文本数据
+        int DefaultTextColor = 0xFFFFFF;  // 这里的颜色属于乘法模式 (float)(R1*R2,G1*G2,B1*B2) 需要在lang中修改
+        // Pros
+        // Size -> (83, 181) Pos -> (13, 26)
+        this.addDrawableChild(new TextWidget(BookPosX + 26, GetFixedY(10), 53, 11, CodexData.headerPros, textRenderer).setTextColor(DefaultTextColor));
+        MultilineTextWidget Pros = new MultilineTextWidget(BookPosX + 13, GetFixedY(26), CodexData.getContentText(CodexData.ContentType.PROS, currentPlayer), textRenderer).setMaxWidth(83).setTextColor(DefaultTextColor);
+        this.addDrawableChild(Pros);
+        // Cons
+        // Size -> (82, 182) Pos -> (110, 26)
+        this.addDrawableChild(new TextWidget(BookPosX + 120, GetFixedY(10), 63, 11, CodexData.headerCons, textRenderer).setTextColor(DefaultTextColor));
+        MultilineTextWidget Cons = new MultilineTextWidget(BookPosX + 110, GetFixedY(26), CodexData.getContentText(CodexData.ContentType.CONS, currentPlayer), textRenderer).setMaxWidth(82).setTextColor(DefaultTextColor);
+        this.addDrawableChild(Cons);
+        // Instincts
+        // Size -> (106, 136) Pos -> (220, 24)
+        this.addDrawableChild(new TextWidget(BookPosX + 242, GetFixedY(10), 63, 12, CodexData.headerCons, textRenderer).setTextColor(DefaultTextColor));
+        MultilineTextWidget Instincts = new MultilineTextWidget(BookPosX + 220, GetFixedY(24), CodexData.getContentText(CodexData.ContentType.INSTINCTS, currentPlayer), textRenderer).setMaxWidth(106).setTextColor(DefaultTextColor);
+        this.addDrawableChild(Instincts);
         // 下一页按钮
         int NextPage_ButtonSizeX = 15;
         int NextPage_ButtonSizeY = 30;

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/StartBookScreenV2.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/StartBookScreenV2.java
@@ -37,8 +37,8 @@ public class StartBookScreenV2 extends Screen {
         // 渲染文字
         int TextPosX = width / 2 - TextSizeX / 2;
         int TextPosY = height / 2 - TextSizeY / 2;
-        MultilineTextWidget StartBookLabel = new MultilineTextWidget(TextPosX, TextPosY, Text.translatable("screen.shape-shifter-curse.book_of_shape_shifter.start_content_text"), client.textRenderer);
-        StartBookLabel.maxWidth = OptionalInt.of(TextSizeX);
+        MultilineTextWidget StartBookLabel = new MultilineTextWidget(TextPosX, TextPosY, Text.translatable("screen.shape-shifter-curse.book_of_shape_shifter.start_content_text"), textRenderer);
+        StartBookLabel.setMaxWidth(TextSizeX);
         this.addDrawableChild(StartBookLabel);
         // 渲染按钮
         int BookBottomY = height / 2 + BookSizeY / 2;

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/StartBookScreenV2.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/StartBookScreenV2.java
@@ -54,6 +54,7 @@ public class StartBookScreenV2 extends Screen {
                     if(MinecraftClient.getInstance().currentScreen instanceof StartBookScreen){
                         MinecraftClient.getInstance().setScreen(null);
                     }
+                    this.close(); // 关闭当前界面
                 }
         ).size(ButtonSizeX, ButtonSizeY).position(ButtonPosX, ButtonPosY).build());
     }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/StartBookScreenV2.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/StartBookScreenV2.java
@@ -1,0 +1,72 @@
+package net.onixary.shapeShifterCurseFabric.custom_ui;
+
+import io.netty.buffer.Unpooled;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.MultilineTextWidget;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.onixary.shapeShifterCurseFabric.networking.ModPackets;
+
+import java.util.OptionalInt;
+
+import static net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric.MOD_ID;
+
+public class StartBookScreenV2 extends Screen {
+    private static final Identifier StartBook_TexID = new Identifier(MOD_ID,"textures/gui/start_book.png");
+    public PlayerEntity currentPlayer;
+
+    public static final int BookSizeX = 360;
+    public static final int BookSizeY = 330;
+    public static final int TextSizeX = 270;
+    public static final int TextSizeY = 300;
+    public static final int ButtonSizeX = 200;
+    public static final int ButtonSizeY = 30;
+
+    public StartBookScreenV2() {
+        super(Text.of("ShapeShifterCurse_StartBook_Screen_V2"));
+    }
+
+    @Override
+    public void init() {
+        // 渲染文字
+        int TextPosX = width / 2 - TextSizeX / 2;
+        int TextPosY = height / 2 - TextSizeY / 2;
+        MultilineTextWidget StartBookLabel = new MultilineTextWidget(TextPosX, TextPosY, Text.translatable("screen.shape-shifter-curse.book_of_shape_shifter.start_content_text"), client.textRenderer);
+        StartBookLabel.maxWidth = OptionalInt.of(TextSizeX);
+        this.addDrawableChild(StartBookLabel);
+        // 渲染按钮
+        int BookBottomY = height / 2 + BookSizeY / 2;
+        int ButtonPosX = width / 2 - ButtonSizeX / 2;
+        int ButtonPosY = BookBottomY - 50;
+        this.addDrawableChild(ButtonWidget.builder(
+                Text.translatable("screen.shape-shifter-curse.book_of_shape_shifter.start_button_text"),
+                button -> {
+                    PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
+                    buf.writeUuid(currentPlayer.getUuid());
+                    // 发送到服务端
+                    ClientPlayNetworking.send(ModPackets.VALIDATE_START_BOOK_BUTTON, buf);
+                    if(MinecraftClient.getInstance().currentScreen instanceof StartBookScreen){
+                        MinecraftClient.getInstance().setScreen(null);
+                    }
+                }
+        ).size(ButtonSizeX, ButtonSizeY).position(ButtonPosX, ButtonPosY).build());
+    }
+
+    private void RenderBook(DrawContext context) {
+        int BookPosX = width / 2 - BookSizeX / 2;
+        int BookPosY = height / 2 - BookSizeY / 2;
+        context.drawTexture(StartBook_TexID, BookPosX, BookPosY, 0, 0, BookSizeX, BookSizeY, BookSizeX, BookSizeY);
+    }
+
+    @Override
+    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+        this.RenderBook(context);
+        super.render(context, mouseX, mouseY, delta);
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/TransformativeEntitySpawning.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/TransformativeEntitySpawning.java
@@ -2,13 +2,8 @@ package net.onixary.shapeShifterCurseFabric.form_giving_custom_entity;
 
 import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
-import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnGroup;
 import net.minecraft.entity.SpawnRestriction;
-import net.minecraft.entity.passive.AnimalEntity;
-import net.minecraft.entity.passive.AxolotlEntity;
-import net.minecraft.entity.passive.BatEntity;
-import net.minecraft.entity.passive.OcelotEntity;
 import net.minecraft.registry.tag.BiomeTags;
 import net.minecraft.world.Heightmap;
 import net.minecraft.world.biome.BiomeKeys;
@@ -42,7 +37,7 @@ public class TransformativeEntitySpawning {
                 ShapeShifterCurseFabric.T_AXOLOTL,
                 SpawnRestriction.Location.IN_WATER,
                 Heightmap.Type.MOTION_BLOCKING_NO_LEAVES,
-                TransformativeAxolotlEntity::canSpawn
+                TransformativeAxolotlEntity::canCustomSpawn
         );
         BiomeModifications.addSpawn(
                 BiomeSelectors.includeByKey(BiomeKeys.LUSH_CAVES),

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/axolotl/TransformativeAxolotlEntity.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/axolotl/TransformativeAxolotlEntity.java
@@ -1,19 +1,19 @@
 package net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.axolotl;
 
-import net.minecraft.entity.Bucketable;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
-import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.*;
 import net.minecraft.entity.ai.goal.ActiveTargetGoal;
 import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.passive.AxolotlEntity;
-import net.minecraft.entity.passive.BatEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.ServerWorldAccess;
 import net.minecraft.world.World;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
 import net.onixary.shapeShifterCurseFabric.data.StaticParams;
 import net.onixary.shapeShifterCurseFabric.player_form.PlayerForms;
 import net.onixary.shapeShifterCurseFabric.player_form.ability.RegPlayerFormComponent;
@@ -26,6 +26,15 @@ public class TransformativeAxolotlEntity extends AxolotlEntity {
 
     public static DefaultAttributeContainer.Builder createTAxolotlAttributes() {
         return MobEntity.createMobAttributes().add(EntityAttributes.GENERIC_MAX_HEALTH, 6.0);
+    }
+
+    public static boolean canCustomSpawn(EntityType<TransformativeAxolotlEntity> type, ServerWorldAccess world, SpawnReason spawnReason, BlockPos pos, Random random) {
+        // ~100% 刷新成功率
+        float Chance = ShapeShifterCurseFabric.commonConfig.transformativeAxolotlSpawnChance;
+        if (Chance <= 0.0f) { return false; }
+        if (Chance >= 1.0f) { return true; }
+        if (random.nextFloat() < Chance) { return true; }
+        return canSpawn(type, world, spawnReason, pos, random);
     }
 
     // 20 ticks = 1 second

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/bat/TransformativeBatEntity.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/bat/TransformativeBatEntity.java
@@ -11,15 +11,13 @@ import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.passive.BatEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.particle.ParticleTypes;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
 import net.onixary.shapeShifterCurseFabric.data.StaticParams;
 import net.onixary.shapeShifterCurseFabric.player_form.PlayerForms;
-import net.onixary.shapeShifterCurseFabric.player_form.ability.FormAbilityManager;
-import net.onixary.shapeShifterCurseFabric.player_form.ability.PlayerFormComponent;
 import net.onixary.shapeShifterCurseFabric.player_form.ability.RegPlayerFormComponent;
 import net.onixary.shapeShifterCurseFabric.status_effects.TStatusApplier;
 
@@ -45,9 +43,13 @@ public class TransformativeBatEntity extends BatEntity {
         } else {
             int i = world.getLightLevel(pos);
             int j = 4;
-            if (random.nextBoolean()) {
-                return false;
-            }
+//            if (random.nextBoolean()) {  // ~ 50% 成功率
+//                return false;
+//            }
+            float Chance = ShapeShifterCurseFabric.commonConfig.transformativeBatSpawnChance;
+            if (Chance <= 0) { return false; }
+            if (Chance >= 1) { return true; }
+            if (random.nextFloat() > Chance) { return false; }
 
             return i > random.nextInt(j) ? false : canMobSpawn(type, world, spawnReason, pos, random);
         }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/ocelot/TransformativeOcelotEntity.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/ocelot/TransformativeOcelotEntity.java
@@ -11,6 +11,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
 import net.onixary.shapeShifterCurseFabric.data.StaticParams;
 import net.onixary.shapeShifterCurseFabric.player_form.PlayerForms;
 import net.onixary.shapeShifterCurseFabric.player_form.ability.RegPlayerFormComponent;
@@ -36,7 +37,11 @@ public class TransformativeOcelotEntity extends OcelotEntity {
     }
 
     public static boolean canCustomSpawn(EntityType<TransformativeOcelotEntity> type, WorldAccess world, SpawnReason spawnReason, BlockPos pos, Random random) {
-        return random.nextInt(3) != 0;
+//        return random.nextInt(3) != 0;  // ~67% 刷新成功率
+        float Chance = ShapeShifterCurseFabric.commonConfig.transformativeOcelotSpawnChance;
+        if (Chance <= 0.0f) { return false; }
+        if (Chance >= 1.0f) { return true; }
+        return random.nextFloat() < Chance;
     }
 
     @Override

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/OverrideSkinFirstPersonMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/OverrideSkinFirstPersonMixin.java
@@ -58,7 +58,7 @@ public abstract class OverrideSkinFirstPersonMixin extends LivingEntityRenderer<
     private void shape_shifter_curse$RenderArm_setModelPose_AFTER(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, AbstractClientPlayerEntity player, ModelPart arm, ModelPart sleeve, CallbackInfo ci) {
         // 渲染变身模型-根据模型设置修改手臂组件渲染
         if (RegPlayerFormComponent.PLAYER_FORM.get(player).getCurrentForm() == PlayerForms.ORIGINAL_BEFORE_ENABLE) {return;}  // 仅当玩家激活Mod后才进行修改
-        if (!AutoConfig.getConfigHolder(ClientConfig.class).getConfig().enableFormModelOnVanillaFirstPersonRender) {return;}  // 仅当启用自定义第一人称渲染时才进行修改
+        if (!ShapeShifterCurseFabric.clientConfig.enableFormModelOnVanillaFirstPersonRender) {return;}  // 仅当启用自定义第一人称渲染时才进行修改
         for (OriginalFurClient.OriginFur fur : ((IPlayerEntityMixins) player).originalFur$getCurrentFurs()) {
             OriginFurModel OFModel = (OriginFurModel) fur.getGeoModel();
             boolean IsRenderRight = arm.equals(this.getModel().rightArm);
@@ -78,7 +78,7 @@ public abstract class OverrideSkinFirstPersonMixin extends LivingEntityRenderer<
     private void shape_shifter_curse$RenderArm_RETURN(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, AbstractClientPlayerEntity player, ModelPart arm, ModelPart sleeve, CallbackInfo ci) {
         // 渲染变身模型
         if (RegPlayerFormComponent.PLAYER_FORM.get(player).getCurrentForm() == PlayerForms.ORIGINAL_BEFORE_ENABLE) {return;}  // 仅当玩家激活Mod后才进行修改
-        if (!AutoConfig.getConfigHolder(ClientConfig.class).getConfig().enableFormModelOnVanillaFirstPersonRender) {return;}  // 仅当启用自定义第一人称渲染时才进行修改
+        if (!ShapeShifterCurseFabric.clientConfig.enableFormModelOnVanillaFirstPersonRender) {return;}  // 仅当启用自定义第一人称渲染时才进行修改
         boolean IsRenderRight = arm.equals(this.getModel().rightArm);
         String GeoBoneName = IsRenderRight ? "bipedRightArm" : "bipedLeftArm";
         for (OriginalFurClient.OriginFur fur : ((IPlayerEntityMixins) player).originalFur$getCurrentFurs()) {

--- a/src/main/resources/assets/shape-shifter-curse/lang/en_us.json
+++ b/src/main/resources/assets/shape-shifter-curse/lang/en_us.json
@@ -647,7 +647,9 @@
   "text.autoconfig.shape-shifter-curse-client.option.inDevelopmentConfigPlaceHolder": "In Development Config Placeholder",
   "text.autoconfig.shape-shifter-curse-common.title": "Shape Shifter Curse - Common Config",
   "text.autoconfig.shape-shifter-curse-common.category.General": "General",
-  "text.autoconfig.shape-shifter-curse-common.option.generalConfigPlaceHolder": "Placeholder",
+  "text.autoconfig.shape-shifter-curse-common.option.transformativeBatSpawnChance": "Transformative Bat Spawn Success Rate",
+  "text.autoconfig.shape-shifter-curse-common.option.transformativeAxolotlSpawnChance": "Transformative Axolotl Spawn Success Rate",
+  "text.autoconfig.shape-shifter-curse-common.option.transformativeOcelotSpawnChance": "Transformative Ocelot Spawn Success Rate",
   "text.autoconfig.shape-shifter-curse-common.category.InDevelopment": "In Development",
   "text.autoconfig.shape-shifter-curse-common.option.inDevelopmentConfigPlaceHolder": "In Development Config Placeholder"
 }

--- a/src/main/resources/assets/shape-shifter-curse/lang/zh_cn.json
+++ b/src/main/resources/assets/shape-shifter-curse/lang/zh_cn.json
@@ -608,7 +608,9 @@
   "text.autoconfig.shape-shifter-curse-client.option.inDevelopmentConfigPlaceHolder": "开发中配置占位符",
   "text.autoconfig.shape-shifter-curse-common.title": "幻形者诅咒 - 通用配置",
   "text.autoconfig.shape-shifter-curse-common.category.General": "常规配置",
-  "text.autoconfig.shape-shifter-curse-common.option.generalConfigPlaceHolder": "配置占位符",
+  "text.autoconfig.shape-shifter-curse-common.option.transformativeBatSpawnChance": "咒文蝙蝠刷新成功率",
+  "text.autoconfig.shape-shifter-curse-common.option.transformativeAxolotlSpawnChance": "咒文美西螈刷新成功率",
+  "text.autoconfig.shape-shifter-curse-common.option.transformativeOcelotSpawnChance": "咒文豹猫刷新成功率",
   "text.autoconfig.shape-shifter-curse-common.category.InDevelopment": "开发中配置",
   "text.autoconfig.shape-shifter-curse-common.option.inDevelopmentConfigPlaceHolder": "开发中配置占位符"
 }

--- a/src/main/resources/shape-shifter-curse.accesswidener
+++ b/src/main/resources/shape-shifter-curse.accesswidener
@@ -1,1 +1,2 @@
 accessWidener   v1  named
+accessible field net/minecraft/client/gui/widget/MultilineTextWidget maxWidth Ljava/util/OptionalInt;

--- a/src/main/resources/shape-shifter-curse.accesswidener
+++ b/src/main/resources/shape-shifter-curse.accesswidener
@@ -1,2 +1,1 @@
 accessWidener   v1  named
-accessible field net/minecraft/client/gui/widget/MultilineTextWidget maxWidth Ljava/util/OptionalInt;


### PR DESCRIPTION
正在尝试移除owo-lib的依赖时发现以前的配置文件
迁移到新的配置文件系统 除了ConfigSSC.keepOriginalSkin 其余迁移到双端配置上
应该可以移除使用owo-lib Config的配置系统
`ShapeShifterCurseFabric.CONFIG`
`net.onixary.shapeShifterCurseFabric.data.ConfigModelSSC`
