### PR TITLE
修改配置的分类 修复书UI中有些字和书材质重叠 修改openBookScreen的逻辑

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/client/ShapeShifterCurseFabricClient.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/client/ShapeShifterCurseFabricClient.java
@@ -42,7 +42,12 @@ public class ShapeShifterCurseFabricClient implements ClientModInitializer {
 	private static ShaderProgram furGradientShader;
 
 	public static void openBookScreen(PlayerEntity user) {
-		if (commonConfig.enableNewStartBook) {
+		// 仅当owo_lib加载时才能调用旧版页面，否则回退回新版
+		if (commonConfig.enableNewStartBook | !FabricLoader.getInstance().isModLoaded("owo")) {
+			if (!commonConfig.enableNewStartBook) {
+				// 以未安装owo_lib为理由进入新版页面时打印日志
+				LOGGER.error("Owo lib is not installed! Old book screen is unavailable, opening new book screen instead.");
+			}
 			if (!(MinecraftClient.getInstance().currentScreen instanceof BookOfShapeShifterScreenV2_P1)) {
 				BookOfShapeShifterScreenV2_P1 bookScreen = new BookOfShapeShifterScreenV2_P1();
 				bookScreen.currentPlayer = user;
@@ -50,26 +55,20 @@ public class ShapeShifterCurseFabricClient implements ClientModInitializer {
 			}
 		}
 		else {
-			// 仅当owo_lib加载时才能调用旧版页面，否则回退回新版
-			if(FabricLoader.getInstance().isModLoaded("owo")){
-				if (!(MinecraftClient.getInstance().currentScreen instanceof BookOfShapeShifterScreen)) {
-					BookOfShapeShifterScreen bookScreen = new BookOfShapeShifterScreen();
-					bookScreen.currentPlayer = user;
-					MinecraftClient.getInstance().setScreen(bookScreen);
-				}
-			}
-			else {
-				LOGGER.error("Owo lib is not installed! Old book screen is unavailable, opening new book screen instead.");
-				if (!(MinecraftClient.getInstance().currentScreen instanceof BookOfShapeShifterScreenV2_P1)) {
-					BookOfShapeShifterScreenV2_P1 bookScreen = new BookOfShapeShifterScreenV2_P1();
-					bookScreen.currentPlayer = user;
-					MinecraftClient.getInstance().setScreen(bookScreen);
-				}
+			if (!(MinecraftClient.getInstance().currentScreen instanceof BookOfShapeShifterScreen)) {
+				BookOfShapeShifterScreen bookScreen = new BookOfShapeShifterScreen();
+				bookScreen.currentPlayer = user;
+				MinecraftClient.getInstance().setScreen(bookScreen);
 			}
 		}
 	}
 	public static void openStartBookScreen(PlayerEntity user) {
-		if (commonConfig.enableNewStartBook) {
+		// 仅当owo_lib加载时才能调用旧版页面，否则回退回新版
+		if (commonConfig.enableNewStartBook | !FabricLoader.getInstance().isModLoaded("owo")) {
+			if (!commonConfig.enableNewStartBook) {
+				// 以未安装owo_lib为理由进入新版页面时打印日志
+				LOGGER.error("Owo lib is not installed! Old book screen is unavailable, opening new book screen instead.");
+			}
 			if (!(MinecraftClient.getInstance().currentScreen instanceof StartBookScreenV2)) {
 				StartBookScreenV2 startScreen = new StartBookScreenV2();
 				startScreen.currentPlayer = user;

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/config/ClientConfig.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/config/ClientConfig.java
@@ -12,11 +12,13 @@ public class ClientConfig implements ConfigData {
 
     // Comment 不知道如何本地化
     @ConfigEntry.Category("General")
-    @Comment("Enable form model on vanilla first person render Default: true")
+    @Comment("Enable form model on vanilla first person render. Default: true")
     public boolean enableFormModelOnVanillaFirstPersonRender = true;  // 原版第一人称下启用形态模型渲染
 
-    // 开发用
-    @ConfigEntry.Category("InDevelopment")
-    @Comment("In Development Default: false")
+    @ConfigEntry.Category("General")
+    @Comment("Use Bigger(2x) Start Book Interface. Default: false")
     public boolean newStartBookForBiggerScreen = false;  // 菜单缩放至少为4
+
+    // 开发用
+    // @ConfigEntry.Category("InDevelopment")
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/config/CommonConfig.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/config/CommonConfig.java
@@ -23,8 +23,10 @@ public class CommonConfig implements ConfigData {
     @Comment("Transformative Ocelot Spawn Chance, 0 For Disable Spawn. Default: 0.67f [0.0f ~ 1.0f]")
     public float transformativeOcelotSpawnChance = 0.67f;
 
-    // 开发用
-    @ConfigEntry.Category("InDevelopment")
-    @Comment("In Development Default: false")
+    @ConfigEntry.Category("General")
+    @Comment("Use The New Start Book Interface. Default: true")
     public boolean enableNewStartBook = true;  // 新版启动书
+
+    // 开发用
+    // @ConfigEntry.Category("InDevelopment")
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P1.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P1.java
@@ -45,7 +45,7 @@ public class BookOfShapeShifterScreenV2_P1 extends Screen {
         scaleTextRenderer.Scale = Scale;
         // Title
         // Size -> (108, 48) Pos -> (17, 92)
-        MultilineTextWidget TitleLabel = new ScaleMultilineTextWidget(BookPosX + 17 * BookScale, BookPosY + 92 * BookScale, CodexData.getContentText(CodexData.ContentType.TITLE, currentPlayer), scaleTextRenderer, Scale).shadow(false).setMaxWidth(108 * BookScale).setTextColor(DefaultTextColor);
+        MultilineTextWidget TitleLabel = new ScaleMultilineTextWidget(BookPosX + 17 * BookScale, BookPosY + 105 * BookScale, CodexData.getContentText(CodexData.ContentType.TITLE, currentPlayer), scaleTextRenderer, Scale).shadow(false).setMaxWidth(108 * BookScale).setTextColor(DefaultTextColor);
         this.addDrawableChild(TitleLabel);
         // Status
         // Size -> (107, 56) Pos -> (17, 153)
@@ -55,7 +55,7 @@ public class BookOfShapeShifterScreenV2_P1 extends Screen {
         // Appearance
         // Size -> (176, 184) Pos -> (142, 23)
         this.addDrawableChild(new TextWidget(BookPosX + 142 * BookScale, BookPosY + 11 * BookScale, 176 * BookScale, 8 * BookScale, CodexData.headerAppearance, textRenderer).setTextColor(HeaderTextColor));
-        MultilineTextWidget AppearanceLabel = new ScaleMultilineTextWidget(BookPosX + 142 * BookScale, BookPosY + 23 * BookScale, CodexData.getContentText(CodexData.ContentType.APPEARANCE, currentPlayer), scaleTextRenderer, Scale).shadow(false).setMaxWidth(176 * BookScale).setTextColor(DefaultTextColor);
+        MultilineTextWidget AppearanceLabel = new ScaleMultilineTextWidget(BookPosX + 142 * BookScale, BookPosY + 26 * BookScale, CodexData.getContentText(CodexData.ContentType.APPEARANCE, currentPlayer), scaleTextRenderer, Scale).shadow(false).setMaxWidth(176 * BookScale).setTextColor(DefaultTextColor);
         this.addDrawableChild(AppearanceLabel);
         // 下一页按钮
         int NextPage_ButtonSizeX = 15 * BookScale;


### PR DESCRIPTION
修改配置的分类 (InDevelopment 用于开发中函数的配置项)
- newStartBookForBiggerScreen -> General
- enableNewStartBook -> General

修复书UI中有些字和书材质重叠 [Title, Appearance] (Title 中非单行显示会向下位移 等我研究一下 暂时先整体向下移动一下)

修改openBookScreen的逻辑
- 打开新版界面代码重复 修改判断语句可以删掉重复
- openStartBookScreen 补上判断owo_lib

颜色代码不推荐在DefaultTextColor中修改 那个是渲染器颜色 会导致Lang中通过json标记的颜色发生变化 推荐在lang中修改 
(明天我看看能否修改字的默认颜色 或者写一个脚本自动修改lang)