### PR TITLE
添加旧版的DetailScreen 让新界面不会暂停游戏(增强玩家实体渲染)

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P1.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P1.java
@@ -44,16 +44,22 @@ public class BookOfShapeShifterScreenV2_P1 extends Screen {
         ScaleTextRenderer scaleTextRenderer = new ScaleTextRenderer(textRenderer);
         scaleTextRenderer.Scale = Scale;
         // Title
+        // D -> (8, 8), (20, 96)
         // Size -> (108, 48) Pos -> (17, 92)
+        this.addDrawableChild(BuildDetailScreenButton(20, 96, 8, 8, CodexData.getContentText(CodexData.ContentType.TITLE, currentPlayer)));
         MultilineTextWidget TitleLabel = new ScaleMultilineTextWidget(BookPosX + 17 * BookScale, BookPosY + 105 * BookScale, CodexData.getContentText(CodexData.ContentType.TITLE, currentPlayer), scaleTextRenderer, Scale).shadow(false).setMaxWidth(108 * BookScale).setTextColor(DefaultTextColor);
         this.addDrawableChild(TitleLabel);
         // Status
+        // D -> (8, 8), (117, 144)
         // Size -> (107, 56) Pos -> (17, 153)
+        this.addDrawableChild(BuildDetailScreenButton(117, 144, 8, 8, CodexData.getPlayerStatusText(currentPlayer)));
         this.addDrawableChild(new TextWidget(BookPosX + 17 * BookScale, BookPosY + 143 * BookScale, 107 * BookScale, 8 * BookScale, CodexData.headerStatus, textRenderer).setTextColor(HeaderTextColor));
         MultilineTextWidget StatusLabel = new ScaleMultilineTextWidget(BookPosX + 17 * BookScale, BookPosY + 153 * BookScale, CodexData.getPlayerStatusText(currentPlayer), scaleTextRenderer, Scale).shadow(false).setMaxWidth(107 * BookScale).setTextColor(DefaultTextColor);
         this.addDrawableChild(StatusLabel);
         // Appearance
+        // D -> (8, 8), (312, 14)
         // Size -> (176, 184) Pos -> (142, 23)
+        this.addDrawableChild(BuildDetailScreenButton(312, 14, 8, 8, CodexData.getContentText(CodexData.ContentType.APPEARANCE, currentPlayer)));
         this.addDrawableChild(new TextWidget(BookPosX + 142 * BookScale, BookPosY + 11 * BookScale, 176 * BookScale, 8 * BookScale, CodexData.headerAppearance, textRenderer).setTextColor(HeaderTextColor));
         MultilineTextWidget AppearanceLabel = new ScaleMultilineTextWidget(BookPosX + 142 * BookScale, BookPosY + 26 * BookScale, CodexData.getContentText(CodexData.ContentType.APPEARANCE, currentPlayer), scaleTextRenderer, Scale).shadow(false).setMaxWidth(176 * BookScale).setTextColor(DefaultTextColor);
         this.addDrawableChild(AppearanceLabel);
@@ -109,6 +115,22 @@ public class BookOfShapeShifterScreenV2_P1 extends Screen {
         MinecraftClient.getInstance().setScreen(NextPage);
     }
 
+    private ButtonWidget BuildDetailScreenButton(int InBookPosX, int InBookPosY, int SizeX, int SizeY, Text DetailText) {
+        int BookScale = 1;
+        if (ShapeShifterCurseFabric.clientConfig.newStartBookForBiggerScreen) {
+            BookScale = 2;
+        }
+        int BookPosX = width / 2 - (BookSizeX * BookScale) / 2;
+        int BookPosY = height / 2 - (BookSizeY * BookScale) / 2;
+        int FixedPosX = BookPosX + InBookPosX * BookScale;
+        int FixedPosY = BookPosY + InBookPosY * BookScale;
+        int FixedSizeX = SizeX * BookScale;
+        int FixedSizeY = SizeY * BookScale;
+        return ButtonWidget.builder(Text.of("+"), button -> {
+            MinecraftClient.getInstance().setScreen(new DetailScreen(this, DetailText));
+        }).size(FixedSizeX, FixedSizeY).position(FixedPosX, FixedPosY).build();
+    }
+
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {
         int BookScale = 1;
@@ -128,5 +150,10 @@ public class BookOfShapeShifterScreenV2_P1 extends Screen {
         int PlayerY = BookPosY + 75 * BookScale;
         this.RenderEntity(context, PlayerX, PlayerY, 30 * BookScale, PlayerX - mouseX, PlayerY - 37 * BookScale - mouseY, currentPlayer);
         super.render(context, mouseX, mouseY, delta);
+    }
+
+    @Override
+    public boolean shouldPause() {
+        return false;
     }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P2.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P2.java
@@ -39,17 +39,23 @@ public class BookOfShapeShifterScreenV2_P2 extends Screen {
         ScaleTextRenderer scaleTextRenderer = new ScaleTextRenderer(textRenderer);
         scaleTextRenderer.Scale = Scale;
         // Pros
+        // D -> (8, 8), (81, 13)
         // Size -> (83, 181) Pos -> (13, 26)
+        this.addDrawableChild(BuildDetailScreenButton(81, 13, 8, 8, CodexData.getContentText(CodexData.ContentType.PROS, currentPlayer)));
         this.addDrawableChild(new TextWidget(BookPosX + 26 * BookScale, BookPosY + 10 * BookScale, 53 * BookScale, 11 * BookScale, CodexData.headerPros, textRenderer).setTextColor(HeaderTextColor));
         MultilineTextWidget Pros = new ScaleMultilineTextWidget(BookPosX + 13 * BookScale, BookPosY + 26 * BookScale, CodexData.getContentText(CodexData.ContentType.PROS, currentPlayer), scaleTextRenderer, Scale).shadow(false).setMaxWidth(83 * BookScale).setTextColor(DefaultTextColor);
         this.addDrawableChild(Pros);
         // Cons
+        // D -> (8, 8), (186, 13)
         // Size -> (82, 182) Pos -> (110, 26)
+        this.addDrawableChild(BuildDetailScreenButton(186, 13, 8, 8, CodexData.getContentText(CodexData.ContentType.CONS, currentPlayer)));
         this.addDrawableChild(new TextWidget(BookPosX + 120 * BookScale, BookPosY + 10 * BookScale, 63 * BookScale, 11 * BookScale, CodexData.headerCons, textRenderer).setTextColor(HeaderTextColor));
         MultilineTextWidget Cons = new ScaleMultilineTextWidget(BookPosX + 110 * BookScale, BookPosY + 26 * BookScale, CodexData.getContentText(CodexData.ContentType.CONS, currentPlayer), scaleTextRenderer, Scale).shadow(false).setMaxWidth(82 * BookScale).setTextColor(DefaultTextColor);
         this.addDrawableChild(Cons);
         // Instincts
+        // D -> (8, 8), (309, 14)
         // Size -> (106, 136) Pos -> (220, 24)
+        this.addDrawableChild(BuildDetailScreenButton(309, 14, 8, 8, CodexData.getContentText(CodexData.ContentType.INSTINCTS, currentPlayer)));
         this.addDrawableChild(new TextWidget(BookPosX + 242 * BookScale, BookPosY + 10 * BookScale, 63 * BookScale, 12 * BookScale, CodexData.headerInstincts, textRenderer).setTextColor(HeaderTextColor));
         MultilineTextWidget Instincts = new ScaleMultilineTextWidget(BookPosX + 220 * BookScale, BookPosY + 24 * BookScale, CodexData.getContentText(CodexData.ContentType.INSTINCTS, currentPlayer), scaleTextRenderer, Scale).shadow(false).setMaxWidth(106 * BookScale).setTextColor(DefaultTextColor);
         this.addDrawableChild(Instincts);
@@ -81,9 +87,30 @@ public class BookOfShapeShifterScreenV2_P2 extends Screen {
         MinecraftClient.getInstance().setScreen(NextPage);
     }
 
+    private ButtonWidget BuildDetailScreenButton(int InBookPosX, int InBookPosY, int SizeX, int SizeY, Text DetailText) {
+        int BookScale = 1;
+        if (ShapeShifterCurseFabric.clientConfig.newStartBookForBiggerScreen) {
+            BookScale = 2;
+        }
+        int BookPosX = width / 2 - (BookSizeX * BookScale) / 2;
+        int BookPosY = height / 2 - (BookSizeY * BookScale) / 2;
+        int FixedPosX = BookPosX + InBookPosX * BookScale;
+        int FixedPosY = BookPosY + InBookPosY * BookScale;
+        int FixedSizeX = SizeX * BookScale;
+        int FixedSizeY = SizeY * BookScale;
+        return ButtonWidget.builder(Text.of("+"), button -> {
+            MinecraftClient.getInstance().setScreen(new DetailScreen(this, DetailText));
+        }).size(FixedSizeX, FixedSizeY).position(FixedPosX, FixedPosY).build();
+    }
+
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {
         this.RenderBook(context);
         super.render(context, mouseX, mouseY, delta);
+    }
+
+    @Override
+    public boolean shouldPause() {
+        return false;
     }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/DetailScreen.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/DetailScreen.java
@@ -1,0 +1,50 @@
+package net.onixary.shapeShifterCurseFabric.custom_ui;
+
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.MultilineTextWidget;
+import net.minecraft.text.Text;
+
+public class DetailScreen extends Screen {
+    private final Screen PreviousScreen;
+    private final Text DetailText;
+
+    public DetailScreen(Screen PreviousScreen, Text DetailText) {
+        super(Text.of("Detail Screen"));
+        this.PreviousScreen = PreviousScreen;
+        this.DetailText = DetailText;
+    }
+
+    public void init() {
+        int TextX = 20;
+        int TextY = 40;
+        int TextSizeX = width - TextX * 2;
+        int TextSizeY = height - 60;
+        int TextDefaultColor = 0xFFFFFF;
+        MultilineTextWidget DetailTextWidget = new MultilineTextWidget(TextX, TextY, DetailText, textRenderer).setMaxWidth(TextSizeX).setMaxRows(TextSizeY).setTextColor(TextDefaultColor);
+        this.addDrawableChild(DetailTextWidget);
+        int ButtonX = width - 30;
+        int ButtonY = 10;
+        int ButtonSizeX = 20;
+        int ButtonSizeY = 20;
+        ButtonWidget CloseButton = ButtonWidget.builder(Text.of("X"), (button) -> {this.close();}).position(ButtonX, ButtonY).size(ButtonSizeX, ButtonSizeY).build();
+        this.addDrawableChild(CloseButton);
+    }
+
+    @Override
+    public void close() {
+        this.client.setScreen(this.PreviousScreen);
+    }
+
+    @Override
+    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+        context.fillGradient(0, 0, this.width, this.height, -1072689136, -804253680);
+        super.render(context, mouseX, mouseY, delta);
+    }
+
+    @Override
+    public boolean shouldPause() {
+        return false;
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/StartBookScreenV2.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/StartBookScreenV2.java
@@ -77,4 +77,9 @@ public class StartBookScreenV2 extends Screen {
         this.RenderBook(context);
         super.render(context, mouseX, mouseY, delta);
     }
+
+    @Override
+    public boolean shouldPause() {
+        return false;
+    }
 }


### PR DESCRIPTION
添加旧版的DetailScreen (也许可以添加一下背景)
- 字体大小为原版大小
- 如果觉得按钮位置不好 修改BuildDetailScreenButton函数 使用相对于书的坐标 可以用PS获取 内部实现BookScale计算位置和大小

让新界面不会暂停游戏(增强玩家实体渲染)

过几天后我尝试修改一些Power实现以增强可修改性 (这几天太肝了先休息几天)