### PR TITLE
修复生物生成问题

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/ShapeShifterCurseFabric.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/ShapeShifterCurseFabric.java
@@ -112,7 +112,7 @@ public class ShapeShifterCurseFabric implements ModInitializer {
     public static final EntityType<TransformativeBatEntity> T_BAT = Registry.register(
             Registries.ENTITY_TYPE,
             new Identifier(ShapeShifterCurseFabric.MOD_ID, "t_bat"),
-            FabricEntityTypeBuilder.create(SpawnGroup.CREATURE, TransformativeBatEntity::new)
+            FabricEntityTypeBuilder.create(SpawnGroup.AMBIENT, TransformativeBatEntity::new)
                     .dimensions(EntityDimensions.fixed(0.5f, 0.5f))
                     .build()
     );
@@ -120,7 +120,7 @@ public class ShapeShifterCurseFabric implements ModInitializer {
     public static final EntityType<TransformativeAxolotlEntity> T_AXOLOTL = Registry.register(
             Registries.ENTITY_TYPE,
             new Identifier(ShapeShifterCurseFabric.MOD_ID, "t_axolotl"),
-            FabricEntityTypeBuilder.create(SpawnGroup.CREATURE, TransformativeAxolotlEntity::new)
+            FabricEntityTypeBuilder.create(SpawnGroup.AXOLOTLS, TransformativeAxolotlEntity::new)
                     .dimensions(EntityDimensions.fixed(0.5f, 0.5f))
                     .build()
     );
@@ -128,7 +128,7 @@ public class ShapeShifterCurseFabric implements ModInitializer {
     public static final EntityType<TransformativeOcelotEntity> T_OCELOT = Registry.register(
             Registries.ENTITY_TYPE,
             new Identifier(ShapeShifterCurseFabric.MOD_ID, "t_ocelot"),
-            FabricEntityTypeBuilder.create(SpawnGroup.CREATURE, TransformativeOcelotEntity::new)
+            FabricEntityTypeBuilder.create(SpawnGroup.MONSTER, TransformativeOcelotEntity::new)
                     .dimensions(EntityDimensions.fixed(0.5f, 0.5f))
                     .build()
     );

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -78,5 +78,9 @@
     "origins": ">0.0.0",
     "optifabric": "<=1.11.18",
     "identity": "<1.14.2-beta"
+  },
+  "recommends": {
+    "rich_translatable_text": ">=1.0.1",
+    "firstperson": "*"
   }
 }


### PR DESCRIPTION
修复 Issues #80
由于咒文美西螈在CREATURE组 游戏会一直生成直到 AXOLOTLS 组满(5只原版美西螈) 一次生成4~6只 如果AXOLOTLS的生物刷新掉后还会再次高速刷新
如果循环Kill原版美西螈 咒文美西螈会直接刷到游戏卡死

Commit 2ede9fef0cbcc31ea1da1bcb9d923bc46f92d6aa 忘了写描述 重新发了一个