### PR TITLE
修复删除data/shape-shifter-curse/{uuid}_*.dat不会还原数据的Bug

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/ability/PlayerFormComponent.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/ability/PlayerFormComponent.java
@@ -47,6 +47,11 @@ public class PlayerFormComponent implements AutoSyncedComponent {
         }
     }
 
+    public PlayerFormComponent clear() {
+        this.readFromNbt(new NbtCompound());
+        return this;
+    }
+
     @Override
     public void writeToNbt(NbtCompound nbtCompound) {
         nbtCompound.putString("currentForm", this.currentForm.name());

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/PlayerEventHandler.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/PlayerEventHandler.java
@@ -73,6 +73,8 @@ public class PlayerEventHandler {
                 // 如果没有保存的数据，说明是首次加入
                 ShapeShifterCurseFabric.LOGGER.info("No saved data found, this is first join with mod");
                 PlayerFormComponent formComponent = RegPlayerFormComponent.PLAYER_FORM.get(player);
+                // 还原到默认值 根据Wiki描述 如果删除data/shape-shifter-curse/{uuid}_*.dat则玩家会回到启用Mod之前的状态
+                formComponent.clear();
                 // 确保 firstJoin 为 true
                 formComponent.setFirstJoin(true);
                 // 触发首次加入成就


### PR DESCRIPTION
[Wiki](https://ssc-wiki.readthedocs.io/zh-cn/latest/mod_content/form_types/)上
> Q: 我后悔了！真的没有其它办法了么？
> A: 有的兄弟有的，在管理员权限下，您可以使用指令 /shape-shifter-curse transform_to_form 来设定形态。另外，您也可以删除<world_name>\\data\\shape-shifter-curse 路径下您UUID对应的存档文件来恢复启用mod内容前的形态

变身数据在玩家数据里还存了一份 
估计是在 `PlayerFormComponent formComponent = RegPlayerFormComponent.PLAYER_FORM.get(player);` 里同步了变身数据