### PR TITLE
修复getBakedOverlayTexture 和 getBakedEmissiveTexture 失效的问题

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form_render/OriginFurModel.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form_render/OriginFurModel.java
@@ -219,14 +219,14 @@ public class OriginFurModel extends GeoModel<OriginFurAnimatable> {
         if (!slim || !json.has("overlay_slim")) {
             if (json.has("overlay")) {
                 if (component.isEnableFormColor()) {
-                    FormTextureUtils.getBakedOverlayTexture(this, component.getFormColor(), false);
+                    return FormTextureUtils.getBakedOverlayTexture(this, component.getFormColor(), false);
                 }
                 return Identifier.tryParse(JsonHelper.getString(json, "overlay"));
             }
         } else {
             if (json.has("overlay_slim")) {
                 if (component.isEnableFormColor()) {
-                    FormTextureUtils.getBakedOverlayTexture(this, component.getFormColor(), true);
+                    return FormTextureUtils.getBakedOverlayTexture(this, component.getFormColor(), true);
                 }
                 return Identifier.tryParse(JsonHelper.getString(json, "overlay_slim"));
             }
@@ -238,15 +238,14 @@ public class OriginFurModel extends GeoModel<OriginFurAnimatable> {
         if (!slim || !json.has("emissive_overlay_slim")) {
             if (json.has("emissive_overlay")) {
                 if (component.isEnableFormColor()) {
-                    FormTextureUtils.getBakedEmissiveTexture(this, component.getFormColor(), false);
+                    return FormTextureUtils.getBakedEmissiveTexture(this, component.getFormColor(), false);
                 }
                 return Identifier.tryParse(JsonHelper.getString(json, "emissive_overlay"));
             }
         } else {
-
             if (json.has("emissive_overlay_slim")) {
                 if (component.isEnableFormColor()) {
-                    FormTextureUtils.getBakedEmissiveTexture(this, component.getFormColor(), true);
+                    return FormTextureUtils.getBakedEmissiveTexture(this, component.getFormColor(), true);
                 }
                 return Identifier.tryParse(JsonHelper.getString(json, "emissive_overlay_slim"));
             }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/FormTextureUtils.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/FormTextureUtils.java
@@ -221,7 +221,6 @@ public class FormTextureUtils {
         return CachedTexture;
     }
 
-    // todo: 当前的OverlayTexture换色方法无效，看了下渲染需要传递Identifier，没敢动它
     public static Identifier getBakedOverlayTexture(OriginFurModel model, ColorSetting colorSetting, boolean Slim) {
         if (!Slim) {
             Identifier CachedTexture = model.ColorMask_Baked_OverlayTexture.get(colorSetting);


### PR DESCRIPTION
当时由于没有测试图像 没有测试 忘了写Return
FF0000 00FF00 0000FF
<img width="854" height="480" alt="2025-09-29_09 14 40" src="https://github.com/user-attachments/assets/c2dce021-976e-42b1-bd5a-e8e26e0a3cdd" />
应该没问题