### PR TITLE
#97 修复一部分 + 修复getTextureResource类似的NullPointerException

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form_render/OriginFurModel.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form_render/OriginFurModel.java
@@ -5,7 +5,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import dev.kosmx.playerAnim.core.util.Vec3f;
-import io.github.apace100.apoli.power.PowerTypeRegistry;
 import mod.azure.azurelib.cache.object.GeoBone;
 import mod.azure.azurelib.model.GeoModel;
 import net.minecraft.util.math.MathHelper;
@@ -215,17 +214,22 @@ public class OriginFurModel extends GeoModel<OriginFurAnimatable> {
         return alib.VectorFromJson(json.getAsJsonObject("rendering_offsets").get("right"));
     }
     public final Identifier getOverlayTexture(boolean slim) {
-        PlayerSkinComponent component = RegPlayerSkinComponent.SKIN_SETTINGS.get(entity);
+        PlayerSkinComponent component = null;
+        try {
+            component = RegPlayerSkinComponent.SKIN_SETTINGS.get(entity);
+        }
+        catch (NullPointerException ignored) {
+        }
         if (!slim || !json.has("overlay_slim")) {
             if (json.has("overlay")) {
-                if (component.isEnableFormColor()) {
+                if (component != null && component.isEnableFormColor()) {
                     return FormTextureUtils.getBakedOverlayTexture(this, component.getFormColor(), false);
                 }
                 return Identifier.tryParse(JsonHelper.getString(json, "overlay"));
             }
         } else {
             if (json.has("overlay_slim")) {
-                if (component.isEnableFormColor()) {
+                if (component != null && component.isEnableFormColor()) {
                     return FormTextureUtils.getBakedOverlayTexture(this, component.getFormColor(), true);
                 }
                 return Identifier.tryParse(JsonHelper.getString(json, "overlay_slim"));
@@ -234,17 +238,22 @@ public class OriginFurModel extends GeoModel<OriginFurAnimatable> {
         return null;
     }
     public final Identifier getEmissiveTexture(boolean slim) {
-        PlayerSkinComponent component = RegPlayerSkinComponent.SKIN_SETTINGS.get(entity);
+        PlayerSkinComponent component = null;
+        try {
+            component = RegPlayerSkinComponent.SKIN_SETTINGS.get(entity);
+        }
+        catch (NullPointerException ignored) {
+        }
         if (!slim || !json.has("emissive_overlay_slim")) {
             if (json.has("emissive_overlay")) {
-                if (component.isEnableFormColor()) {
+                if (component != null && component.isEnableFormColor()) {
                     return FormTextureUtils.getBakedEmissiveTexture(this, component.getFormColor(), false);
                 }
                 return Identifier.tryParse(JsonHelper.getString(json, "emissive_overlay"));
             }
         } else {
             if (json.has("emissive_overlay_slim")) {
-                if (component.isEnableFormColor()) {
+                if (component != null && component.isEnableFormColor()) {
                     return FormTextureUtils.getBakedEmissiveTexture(this, component.getFormColor(), true);
                 }
                 return Identifier.tryParse(JsonHelper.getString(json, "emissive_overlay_slim"));
@@ -788,9 +797,13 @@ public class OriginFurModel extends GeoModel<OriginFurAnimatable> {
     }
     @Override
     public Identifier getTextureResource(OriginFurAnimatable geoAnimatable) {
-        PlayerSkinComponent component = RegPlayerSkinComponent.SKIN_SETTINGS.get(entity);
-        if (component.isEnableFormColor()) {
-            return FormTextureUtils.getBakedTexture(this, component.getFormColor());
+        try {
+            PlayerSkinComponent component = RegPlayerSkinComponent.SKIN_SETTINGS.get(entity);
+            if (component.isEnableFormColor()) {
+                return FormTextureUtils.getBakedTexture(this, component.getFormColor());
+            }
+        }
+        catch (NullPointerException ignored) {
         }
         return dTR(json);
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/jump_out_water.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/jump_out_water.json
@@ -3,7 +3,7 @@
     "entity_action": {
         "type": "origins:add_velocity",
         "y": 0.8,
-        "space": "local"
+        "space": "world"
     },
     "cooldown": 5,
     "hud_render": {


### PR DESCRIPTION
修复了 #97 的部分问题
> 顺带一提，美西螈形态的冲出水面的跳跃有比较影响的特性：冲出的而外速度不是在垂直方向叠加 也不是视角正前方叠加，而是视角的垂直上方。。。这导致我想从水中冲出到高处（习惯性的抬头瞄准目的地）会向身后弹。。。。这种操作方式比较反人类。。（等等。。我是人类，还是美西螈？）

修复了getTextureResource类似的NullPointerException
估计是渲染线程在PlayerSkinComponent更新之前调用了