### PR TITLE
添加玩家自定义配置界面 当关闭配置界面+进入服务器5s后同步

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/ShapeShifterCurseFabric.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/ShapeShifterCurseFabric.java
@@ -40,6 +40,7 @@ import net.onixary.shapeShifterCurseFabric.command.FormArgumentType;
 import net.onixary.shapeShifterCurseFabric.command.ShapeShifterCurseCommand;
 import net.onixary.shapeShifterCurseFabric.config.ClientConfig;
 import net.onixary.shapeShifterCurseFabric.config.CommonConfig;
+import net.onixary.shapeShifterCurseFabric.config.PlayerCustomConfig;
 import net.onixary.shapeShifterCurseFabric.data.CursedMoonData;
 import net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.RegTransformativeEntitySpawnEgg;
 import net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.RegTransformativeEntity;
@@ -81,6 +82,7 @@ public class ShapeShifterCurseFabric implements ModInitializer {
     public static final String MOD_ID = "shape-shifter-curse";
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
+    public static PlayerCustomConfig playerCustomConfig;
     public static ClientConfig clientConfig;
     public static CommonConfig commonConfig;
 
@@ -179,6 +181,8 @@ public class ShapeShifterCurseFabric implements ModInitializer {
         AdditionalEntityActions.register();
 
         // 注册配置文件
+        AutoConfig.register(PlayerCustomConfig.class, Toml4jConfigSerializer::new);  // 客户端配置
+        playerCustomConfig = AutoConfig.getConfigHolder(PlayerCustomConfig.class).getConfig();
         AutoConfig.register(ClientConfig.class, Toml4jConfigSerializer::new);  // 客户端配置
         clientConfig = AutoConfig.getConfigHolder(ClientConfig.class).getConfig();
         AutoConfig.register(CommonConfig.class, Toml4jConfigSerializer::new);  // 双端配置

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/client/ShapeShifterCurseFabricClient.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/client/ShapeShifterCurseFabricClient.java
@@ -221,6 +221,8 @@ public class ShapeShifterCurseFabricClient implements ClientModInitializer {
 		FurGradientRenderLayer.onInitializeClient();
 
 		ClientTickEvents.END_CLIENT_TICK.register(ShapeShifterCurseFabricClient::onClientTick);
+
+
 	}
 
 	public static ShaderProgram getFurGradientShader() {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/config/ConfigMenuScreen.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/config/ConfigMenuScreen.java
@@ -7,6 +7,8 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.text.Text;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+import net.onixary.shapeShifterCurseFabric.networking.ModPacketsS2C;
 
 import java.util.function.Supplier;
 
@@ -21,13 +23,16 @@ public class ConfigMenuScreen extends Screen {
         int Config_BTN_Size_X = 240;  // 按钮长 英文过长时请修改
         int Config_BTN_Size_Y = 20;  // 按钮宽
         int Config_BTN_Interval = 10;  // 按钮Y方向间隔 留空部分
-        int Config_Count = 3;  // 配置数量  **** 添加配置时修改 ****
+        int Config_Count = 4;  // 配置数量  **** 添加配置时修改 ****
         int Additional_Button_Count = 1;  // 额外按钮数量 [关闭配置界面按钮]
         int Config_BTN_X_Pos = (width - Config_BTN_Size_X) / 2;  // 按钮X坐标
         int Config_BTN_Y_Start_Pos = (height - Config_BTN_Size_Y * (Config_Count + Additional_Button_Count) - Config_BTN_Interval * (Config_Count + Additional_Button_Count - 1)) / 2;  // 按钮Y坐标起始位置
         int Config_BTN_Y_Pos = Config_BTN_Y_Start_Pos;  // 按钮Y坐标
 
         // 添加按钮
+        // 玩家自定义配置
+        AddButton(Config_BTN_X_Pos, Config_BTN_Y_Pos, Config_BTN_Size_X, Config_BTN_Size_Y, Text.translatable("text.autoconfig.shape-shifter-curse-custom.title"), AutoConfig.getConfigScreen(PlayerCustomConfig.class, this));
+        Config_BTN_Y_Pos += Config_BTN_Size_Y + Config_BTN_Interval;
         // 客户端配置
         AddButton(Config_BTN_X_Pos, Config_BTN_Y_Pos, Config_BTN_Size_X, Config_BTN_Size_Y, Text.translatable("text.autoconfig.shape-shifter-curse-client.title"), AutoConfig.getConfigScreen(ClientConfig.class, this));
         Config_BTN_Y_Pos += Config_BTN_Size_Y + Config_BTN_Interval;
@@ -42,13 +47,27 @@ public class ConfigMenuScreen extends Screen {
         // **** 在这里添加配置 ****
 
         // 关闭配置界面按钮
-        AddButton(Config_BTN_X_Pos, Config_BTN_Y_Pos, Config_BTN_Size_X, Config_BTN_Size_Y, Text.translatable("text.shape-shifter-curse.config.close"), () -> parent);
+        AddCloseButton(Config_BTN_X_Pos, Config_BTN_Y_Pos, Config_BTN_Size_X, Config_BTN_Size_Y, Text.translatable("text.shape-shifter-curse.config.close"));
     }
 
     public void AddButton(int PosX, int PosY, int SizeX, int SizeY, Text text, Supplier<Screen> ConfigScreenSupplier) {
         addDrawableChild(ButtonWidget.builder(text, button -> {
             MinecraftClient.getInstance().setScreen(ConfigScreenSupplier.get());
         }).size(SizeX, SizeY).position(PosX, PosY).build());
+    }
+
+    public void AddCloseButton(int PosX, int PosY, int SizeX, int SizeY, Text text) {
+        addDrawableChild(ButtonWidget.builder(text, button -> close()).size(SizeX, SizeY).position(PosX, PosY).build());
+    }
+
+    @Override
+    public void close() {
+        ShapeShifterCurseFabric.LOGGER.info("Sending custom settings to server");
+        try {
+            ModPacketsS2C.sendUpdateCustomSetting();  // 尝试发送自定义配置到服务器
+        }
+        catch (Exception ignored) {}  // 如果不在服务器上则忽略
+        MinecraftClient.getInstance().setScreen(parent);
     }
 
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/config/PlayerCustomConfig.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/config/PlayerCustomConfig.java
@@ -1,0 +1,37 @@
+package net.onixary.shapeShifterCurseFabric.config;
+
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
+import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Comment;
+
+@Config(name = "shape-shifter-curse-custom")
+public class PlayerCustomConfig implements ConfigData {
+    @Comment("Keep original skin. Default: false")
+    public boolean keep_original_skin = false;
+
+    @Comment("Enable form color. Default: false")
+    public boolean enable_form_color = false;
+    @ConfigEntry.ColorPicker
+    @Comment("Primary color (RGB). Default: white")
+    public int primaryColor = 0xFFFFFF;
+    @ConfigEntry.ColorPicker
+    @Comment("Accent color 1 (RGB). Default: white")
+    public int accentColor1Color = 0xFFFFFF;
+    @ConfigEntry.ColorPicker
+    @Comment("Accent color 2 (RGB). Default: white")
+    public int accentColor2Color = 0xFFFFFF;
+    @ConfigEntry.ColorPicker
+    @Comment("Eye color (RGB). Default: black")
+    public int eyeColor = 0x000000;
+
+    @Comment("Primary color override grey strength (0~255). Default: 0")
+    @ConfigEntry.BoundedDiscrete(min = 0, max = 255)
+    public int primaryOverrideStrength = 0;
+    @Comment("Accent color 1 override grey strength (0~255). Default: 0")
+    @ConfigEntry.BoundedDiscrete(min = 0, max = 255)
+    public int accent1OverrideStrength = 0;
+    @Comment("Accent color 2 override grey strength (0~255). Default: 0")
+    @ConfigEntry.BoundedDiscrete(min = 0, max = 255)
+    public int accent2OverrideStrength = 0;
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/LoginMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/LoginMixin.java
@@ -1,0 +1,18 @@
+package net.onixary.shapeShifterCurseFabric.mixin;
+
+import net.minecraft.network.ClientConnection;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.onixary.shapeShifterCurseFabric.networking.ModPacketsS2CServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PlayerManager.class)
+public class LoginMixin {
+    @Inject(at = @At("TAIL"), method = "onPlayerConnect(Lnet/minecraft/network/ClientConnection;Lnet/minecraft/server/network/ServerPlayerEntity;)V")
+    private void onPlayerConnectMixin(ClientConnection connection, ServerPlayerEntity player, CallbackInfo info) {
+        ModPacketsS2CServer.sendPlayerLogin(player);
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPackets.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPackets.java
@@ -44,4 +44,7 @@ public class ModPackets {
 
     public static final Identifier UPDATE_DYNAMIC_FORM = new Identifier(ShapeShifterCurseFabric.MOD_ID, "update_dynamic_form");
     public static final Identifier REMOVE_DYNAMIC_FORM_EXCEPT = new Identifier(ShapeShifterCurseFabric.MOD_ID, "remove_dynamic_form_except");
+
+    public static final Identifier LOGIN_PACKET = new Identifier(ShapeShifterCurseFabric.MOD_ID, "login_packet");  // 我暂时没找到玩家进入服务去时的Hook，所以暂时由服务器询问来代替
+    public static final Identifier UPDATE_CUSTOM_SETTING = new Identifier(ShapeShifterCurseFabric.MOD_ID, "update_custom_setting");
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2CServer.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2CServer.java
@@ -160,4 +160,10 @@ public class ModPacketsS2CServer {
             sendUpdateDynamicForm(player, jsonForms);
         }
     }
+
+    // 我暂时没找到玩家进入服务去时的Hook，所以暂时由服务器询问来代替
+    public static void sendPlayerLogin(ServerPlayerEntity player) {
+        PacketByteBuf buf = PacketByteBufs.create();
+        ServerPlayNetworking.send(player, ModPackets.LOGIN_PACKET, buf);
+    }
 }

--- a/src/main/resources/assets/shape-shifter-curse/lang/en_us.json
+++ b/src/main/resources/assets/shape-shifter-curse/lang/en_us.json
@@ -414,6 +414,16 @@
     "text.autoconfig.shape-shifter-curse-common.option.transformativeOcelotSpawnChance": "Transformative Ocelot Spawn Success Rate",
     "text.autoconfig.shape-shifter-curse-common.option.enableNewStartBook": "Enable The New Version of Start Book Interface",
     "text.autoconfig.shape-shifter-curse-common.option.curseMoonPhase": "Curse Moon Phase",
-    "text.autoconfig.shape-shifter-curse-common.category.InDevelopment": "In Development"
+    "text.autoconfig.shape-shifter-curse-common.category.InDevelopment": "In Development",
+    "text.autoconfig.shape-shifter-curse-custom.title": "Shape Shifter Curse - Player Custom Config",
+    "text.autoconfig.shape-shifter-curse-custom.option.keep_original_skin": "Keep Original Skin",
+    "text.autoconfig.shape-shifter-curse-custom.option.enable_form_color": "Enable Form Custom Color System",
+    "text.autoconfig.shape-shifter-curse-custom.option.primaryColor": "Primary Color",
+    "text.autoconfig.shape-shifter-curse-custom.option.accentColor1Color": "Accent Color 1",
+    "text.autoconfig.shape-shifter-curse-custom.option.accentColor2Color": "Accent Color 2",
+    "text.autoconfig.shape-shifter-curse-custom.option.eyeColor": "Eye Color",
+    "text.autoconfig.shape-shifter-curse-custom.option.primaryOverrideStrength": "Primary Grayscale Enhancement",
+    "text.autoconfig.shape-shifter-curse-custom.option.accent1OverrideStrength": "Accent 1 Grayscale Enhancement",
+    "text.autoconfig.shape-shifter-curse-custom.option.accent2OverrideStrength": "Accent 2 Grayscale Enhancement"
 
 }

--- a/src/main/resources/assets/shape-shifter-curse/lang/zh_cn.json
+++ b/src/main/resources/assets/shape-shifter-curse/lang/zh_cn.json
@@ -414,5 +414,15 @@
     "text.autoconfig.shape-shifter-curse-common.option.transformativeOcelotSpawnChance": "咒文豹猫刷新成功率",
     "text.autoconfig.shape-shifter-curse-common.option.enableNewStartBook": "启用新版幻形者之书界面",
     "text.autoconfig.shape-shifter-curse-common.option.curseMoonPhase": "诅咒之月月相",
-    "text.autoconfig.shape-shifter-curse-common.category.InDevelopment": "开发中配置"
+    "text.autoconfig.shape-shifter-curse-common.category.InDevelopment": "开发中配置",
+    "text.autoconfig.shape-shifter-curse-custom.title": "幻形者诅咒 - 玩家自定义配置",
+    "text.autoconfig.shape-shifter-curse-custom.option.keep_original_skin": "保留原版皮肤",
+    "text.autoconfig.shape-shifter-curse-custom.option.enable_form_color": "启用Form自定义颜色系统",
+    "text.autoconfig.shape-shifter-curse-custom.option.primaryColor": "主要色",
+    "text.autoconfig.shape-shifter-curse-custom.option.accentColor1Color": "重点色1",
+    "text.autoconfig.shape-shifter-curse-custom.option.accentColor2Color": "重点色2",
+    "text.autoconfig.shape-shifter-curse-custom.option.eyeColor": "眼睛颜色",
+    "text.autoconfig.shape-shifter-curse-custom.option.primaryOverrideStrength": "主要色灰度增强",
+    "text.autoconfig.shape-shifter-curse-custom.option.accent1OverrideStrength": "重点色1灰度增强",
+    "text.autoconfig.shape-shifter-curse-custom.option.accent2OverrideStrength": "重点色2灰度增强"
 }

--- a/src/main/resources/assets/shape-shifter-curse/rich_lang/en_us.json
+++ b/src/main/resources/assets/shape-shifter-curse/rich_lang/en_us.json
@@ -662,5 +662,15 @@
   "text.autoconfig.shape-shifter-curse-common.option.transformativeOcelotSpawnChance": "Transformative Ocelot Spawn Success Rate",
   "text.autoconfig.shape-shifter-curse-common.option.enableNewStartBook": "Enable The New Version of Start Book Interface",
   "text.autoconfig.shape-shifter-curse-common.option.curseMoonPhase": "Curse Moon Phase",
-  "text.autoconfig.shape-shifter-curse-common.category.InDevelopment": "In Development"
+  "text.autoconfig.shape-shifter-curse-common.category.InDevelopment": "In Development",
+  "text.autoconfig.shape-shifter-curse-custom.title": "Shape Shifter Curse - Player Custom Config",
+  "text.autoconfig.shape-shifter-curse-custom.option.keep_original_skin": "Keep Original Skin",
+  "text.autoconfig.shape-shifter-curse-custom.option.enable_form_color": "Enable Form Custom Color System",
+  "text.autoconfig.shape-shifter-curse-custom.option.primaryColor": "Primary Color",
+  "text.autoconfig.shape-shifter-curse-custom.option.accentColor1Color": "Accent Color 1",
+  "text.autoconfig.shape-shifter-curse-custom.option.accentColor2Color": "Accent Color 2",
+  "text.autoconfig.shape-shifter-curse-custom.option.eyeColor": "Eye Color",
+  "text.autoconfig.shape-shifter-curse-custom.option.primaryOverrideStrength": "Primary Grayscale Enhancement",
+  "text.autoconfig.shape-shifter-curse-custom.option.accent1OverrideStrength": "Accent 1 Grayscale Enhancement",
+  "text.autoconfig.shape-shifter-curse-custom.option.accent2OverrideStrength": "Accent 2 Grayscale Enhancement"
 }

--- a/src/main/resources/assets/shape-shifter-curse/rich_lang/zh_cn.json
+++ b/src/main/resources/assets/shape-shifter-curse/rich_lang/zh_cn.json
@@ -623,5 +623,15 @@
   "text.autoconfig.shape-shifter-curse-common.option.transformativeOcelotSpawnChance": "咒文豹猫刷新成功率",
   "text.autoconfig.shape-shifter-curse-common.option.enableNewStartBook": "启用新版幻形者之书界面",
   "text.autoconfig.shape-shifter-curse-common.option.curseMoonPhase": "诅咒之月月相",
-  "text.autoconfig.shape-shifter-curse-common.category.InDevelopment": "开发中配置"
+  "text.autoconfig.shape-shifter-curse-common.category.InDevelopment": "开发中配置",
+  "text.autoconfig.shape-shifter-curse-custom.title": "幻形者诅咒 - 玩家自定义配置",
+  "text.autoconfig.shape-shifter-curse-custom.option.keep_original_skin": "保留原版皮肤",
+  "text.autoconfig.shape-shifter-curse-custom.option.enable_form_color": "启用Form自定义颜色系统",
+  "text.autoconfig.shape-shifter-curse-custom.option.primaryColor": "主要色",
+  "text.autoconfig.shape-shifter-curse-custom.option.accentColor1Color": "重点色1",
+  "text.autoconfig.shape-shifter-curse-custom.option.accentColor2Color": "重点色2",
+  "text.autoconfig.shape-shifter-curse-custom.option.eyeColor": "眼睛颜色",
+  "text.autoconfig.shape-shifter-curse-custom.option.primaryOverrideStrength": "主要色灰度增强",
+  "text.autoconfig.shape-shifter-curse-custom.option.accent1OverrideStrength": "重点色1灰度增强",
+  "text.autoconfig.shape-shifter-curse-custom.option.accent2OverrideStrength": "重点色2灰度增强"
 }

--- a/src/main/resources/shape-shifter-curse.mixins.json
+++ b/src/main/resources/shape-shifter-curse.mixins.json
@@ -33,7 +33,8 @@
     "EntitySlipperinessMixin",
     "ServerPlayerEntityForceInputMixin",
     "PlayerEntitySprintSwimmingMixin",
-    "projectile.PotionEntityMixin"
+    "projectile.PotionEntityMixin",
+    "LoginMixin"
   ],
   "client": [
     "IEntityRenderDispatcherAccessor",


### PR DESCRIPTION
添加玩家自定义配置界面
现在KeepOriginalSkin 和 Form颜色系统可以使用配置文件(shape-shifter-curse-custom.toml)定义 (仅客户端->服务器 修改需要在配置文件中修改 命令修改仅为临时更改)
当关闭配置界面+进入服务器5s后同步(防止组件未同步炸NullPointerException)

国庆我得帮家里干点活 那几天可能没多少时间写新功能