### PR TITLE
全新玩家形态颜色处理

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/command/ShapeShifterCurseCommand.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/command/ShapeShifterCurseCommand.java
@@ -18,6 +18,7 @@ import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
 import net.onixary.shapeShifterCurseFabric.cursed_moon.CursedMoon;
 import net.onixary.shapeShifterCurseFabric.player_form.PlayerFormBase;
 import net.onixary.shapeShifterCurseFabric.player_form.skin.RegPlayerSkinComponent;
+import net.onixary.shapeShifterCurseFabric.util.FormTextureUtils;
 
 import static net.minecraft.server.command.CommandManager.argument;
 import static net.minecraft.server.command.CommandManager.literal;
@@ -74,15 +75,16 @@ public class ShapeShifterCurseCommand {
                                 )
                         )
                         .then(literal("set_form_color").requires(cs -> cs.hasPermissionLevel(0))
+                                .executes(ShapeShifterCurseCommand::logFormColorSetting)
                                 .then(argument("enable", BoolArgumentType.bool())
                                         .executes(ShapeShifterCurseCommand::setFormColorEnable)
                                         .then(argument("primaryColorRGBA", StringArgumentType.string())
                                                 .then(argument("accentColor1RGBA", StringArgumentType.string())
                                                         .then(argument("accentColor2RGBA", StringArgumentType.string())
                                                                 .then(argument("eyeColor", StringArgumentType.string())
-                                                                        .then(argument("primaryOverrideStrength", FloatArgumentType.floatArg())
-                                                                                .then(argument("accent1OverrideStrength", FloatArgumentType.floatArg())
-                                                                                        .then(argument("accent2OverrideStrength", FloatArgumentType.floatArg())
+                                                                        .then(argument("primaryGreyReverse", BoolArgumentType.bool())
+                                                                                .then(argument("accent1GreyReverse", BoolArgumentType.bool())
+                                                                                        .then(argument("accent2GreyReverse", BoolArgumentType.bool())
                                                                                                 .executes(ShapeShifterCurseCommand::setFormColor)
                                                                                         )
                                                                                 )
@@ -208,6 +210,33 @@ public class ShapeShifterCurseCommand {
         }
     }
 
+    private static int logFormColorSetting(CommandContext<ServerCommandSource> commandContext) {
+        try {
+            ServerPlayerEntity player = commandContext.getSource().getPlayer();
+            if (player == null) {
+                commandContext.getSource().sendError(Text.literal("Must be a player!"));
+                return 0;
+            }
+            String message = "Form color setting: \n";
+            message += "Enable: " + RegPlayerSkinComponent.SKIN_SETTINGS.get(player).isEnableFormColor() + "\n";
+            message += "Primary Color RGBA: " + Integer.toHexString((FormTextureUtils.ABGR2RGBA(RegPlayerSkinComponent.SKIN_SETTINGS.get(player).getFormColor().getPrimaryColor()))) + "\n";
+            message += "Accent Color 1 RGBA: " + Integer.toHexString((FormTextureUtils.ABGR2RGBA(RegPlayerSkinComponent.SKIN_SETTINGS.get(player).getFormColor().getAccentColor1()))) + "\n";
+            message += "Accent Color 2 RGBA: " + Integer.toHexString((FormTextureUtils.ABGR2RGBA(RegPlayerSkinComponent.SKIN_SETTINGS.get(player).getFormColor().getAccentColor2()))) + "\n";
+            message += "Eye Color: " + RegPlayerSkinComponent.SKIN_SETTINGS.get(player).getFormColor().getEyeColor() + "\n";
+            message += "Primary Grey Reverse: " + RegPlayerSkinComponent.SKIN_SETTINGS.get(player).getFormColor().getPrimaryGreyReverse() + "\n";
+            message += "Accent 1 Grey Reverse: " + RegPlayerSkinComponent.SKIN_SETTINGS.get(player).getFormColor().getAccent1GreyReverse() + "\n";
+            message += "Accent 2 Grey Reverse: " + RegPlayerSkinComponent.SKIN_SETTINGS.get(player).getFormColor().getAccent2GreyReverse() + "\n";
+            player.sendMessage(Text.literal(message), false);
+            return 1;
+        }
+        catch (Exception e) {
+            // 处理其他可能的错误
+            commandContext.getSource().sendError(Text.literal("Error when log player form color: " + e.getMessage()));
+            ShapeShifterCurseFabric.LOGGER.error("Error when log player form color: ", e);
+            return 0;
+        }
+    }
+
     private static int setFormColorEnable(CommandContext<ServerCommandSource> commandContext) {
         try {
             ServerPlayerEntity player = commandContext.getSource().getPlayer();
@@ -239,14 +268,7 @@ public class ShapeShifterCurseCommand {
             String accentColor1RGBA = StringArgumentType.getString(commandContext, "accentColor1RGBA");
             String accentColor2RGBA = StringArgumentType.getString(commandContext, "accentColor2RGBA");
             String eyeColor = StringArgumentType.getString(commandContext, "eyeColor");
-            float primaryOverrideStrength = FloatArgumentType.getFloat(commandContext, "primaryOverrideStrength");
-            float accent1OverrideStrength = FloatArgumentType.getFloat(commandContext, "accent1OverrideStrength");
-            float accent2OverrideStrength = FloatArgumentType.getFloat(commandContext, "accent2OverrideStrength");
-            primaryOverrideStrength = Math.max(0.0f, Math.min(1.0f, primaryOverrideStrength));
-            accent1OverrideStrength = Math.max(0.0f, Math.min(1.0f, accent1OverrideStrength));
-            accent2OverrideStrength = Math.max(0.0f, Math.min(1.0f, accent2OverrideStrength));
-            if (!RegPlayerSkinComponent.SKIN_SETTINGS.get(player).setFormColor(primaryColorRGBA, accentColor1RGBA, accentColor2RGBA, eyeColor
-                    , primaryOverrideStrength, accent1OverrideStrength, accent2OverrideStrength)) {
+            if (!RegPlayerSkinComponent.SKIN_SETTINGS.get(player).setFormColor(primaryColorRGBA, accentColor1RGBA, accentColor2RGBA, eyeColor, BoolArgumentType.getBool(commandContext, "primaryGreyReverse"), BoolArgumentType.getBool(commandContext, "accent1GreyReverse"), BoolArgumentType.getBool(commandContext, "accent2GreyReverse"))) {
                 commandContext.getSource().sendError(Text.literal("Invalid color format!"));
                 return 0;
             }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/config/PlayerCustomConfig.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/config/PlayerCustomConfig.java
@@ -25,13 +25,19 @@ public class PlayerCustomConfig implements ConfigData {
     @Comment("Eye color (RGB). Default: black")
     public int eyeColor = 0x000000;
 
-    @Comment("Primary color override grey strength (0~255). Default: 0")
-    @ConfigEntry.BoundedDiscrete(min = 0, max = 255)
-    public int primaryOverrideStrength = 0;
-    @Comment("Accent color 1 override grey strength (0~255). Default: 0")
-    @ConfigEntry.BoundedDiscrete(min = 0, max = 255)
-    public int accent1OverrideStrength = 0;
-    @Comment("Accent color 2 override grey strength (0~255). Default: 0")
-    @ConfigEntry.BoundedDiscrete(min = 0, max = 255)
-    public int accent2OverrideStrength = 0;
+    // @Comment("Primary color override grey strength (0~255). Default: 0")
+    // @ConfigEntry.BoundedDiscrete(min = 0, max = 255)
+    // public int primaryOverrideStrength = 0;
+    // @Comment("Accent color 1 override grey strength (0~255). Default: 0")
+    // @ConfigEntry.BoundedDiscrete(min = 0, max = 255)
+    // public int accent1OverrideStrength = 0;
+    // @Comment("Accent color 2 override grey strength (0~255). Default: 0")
+    // @ConfigEntry.BoundedDiscrete(min = 0, max = 255)
+    // public int accent2OverrideStrength = 0;
+    @Comment("Primary color reverse grey scale mul. Default: false")
+    public boolean primaryGreyReverse = false;
+    @Comment("Accent color 1 reverse grey scale mul. Default: false")
+    public boolean accent1GreyReverse = false;
+    @Comment("Accent color 2 reverse grey scale mul. Default: false")
+    public boolean accent2GreyReverse = false;
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsC2S.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsC2S.java
@@ -121,15 +121,15 @@ public class ModPacketsC2S {
         int accentColor1Color = packetByteBuf.readInt();
         int accentColor2Color = packetByteBuf.readInt();
         int eyeColor = packetByteBuf.readInt();
-        float primaryOverrideStrength = (float) packetByteBuf.readInt() / 255;
-        float accent1OverrideStrength = (float) packetByteBuf.readInt() / 255;
-        float accent2OverrideStrength = (float) packetByteBuf.readInt() / 255;
+        boolean primaryGreyReverse = packetByteBuf.readBoolean();
+        boolean accent1GreyReverse = packetByteBuf.readBoolean();
+        boolean accent2GreyReverse = packetByteBuf.readBoolean();
         minecraftServer.execute(() -> {
             try {
                 PlayerSkinComponent component = RegPlayerSkinComponent.SKIN_SETTINGS.get(playerEntity);
                 component.setKeepOriginalSkin(keepOriginalSkin);
                 component.setEnableFormColor(enableFormColor);
-                component.setFormColor(new FormTextureUtils.ColorSetting(primaryColor, accentColor1Color, accentColor2Color, eyeColor, primaryOverrideStrength, accent1OverrideStrength, accent2OverrideStrength));
+                component.setFormColor(new FormTextureUtils.ColorSetting(primaryColor, accentColor1Color, accentColor2Color, eyeColor, primaryGreyReverse, accent1GreyReverse, accent2GreyReverse));
                 RegPlayerSkinComponent.SKIN_SETTINGS.sync(playerEntity);
             }
             catch (Exception e){

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2C.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2C.java
@@ -281,9 +281,9 @@ public class ModPacketsS2C {
         buf.writeInt(AGBRInt);
         AGBRInt = FormTextureUtils.RGB2ABGR(ShapeShifterCurseFabric.playerCustomConfig.eyeColor);
         buf.writeInt(AGBRInt);
-        buf.writeInt(ShapeShifterCurseFabric.playerCustomConfig.primaryOverrideStrength);
-        buf.writeInt(ShapeShifterCurseFabric.playerCustomConfig.accent1OverrideStrength);
-        buf.writeInt(ShapeShifterCurseFabric.playerCustomConfig.accent2OverrideStrength);
+        buf.writeBoolean(ShapeShifterCurseFabric.playerCustomConfig.primaryGreyReverse);
+        buf.writeBoolean(ShapeShifterCurseFabric.playerCustomConfig.accent1GreyReverse);
+        buf.writeBoolean(ShapeShifterCurseFabric.playerCustomConfig.accent2GreyReverse);
         ClientPlayNetworking.send(UPDATE_CUSTOM_SETTING, buf);
     }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/skin/PlayerSkinComponent.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/skin/PlayerSkinComponent.java
@@ -10,7 +10,7 @@ import java.util.OptionalInt;
 public class PlayerSkinComponent implements Component, AutoSyncedComponent {
     private boolean keepOriginalSkin = false;
     private boolean enableFormColor = false;
-    private FormTextureUtils.ColorSetting formColor = new FormTextureUtils.ColorSetting(0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x3F98FF, 0.0f, 0.0f, 0.0f);
+    private FormTextureUtils.ColorSetting formColor = new FormTextureUtils.ColorSetting(0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFF000000, false, false, false);
 
     public boolean shouldKeepOriginalSkin() {
         return keepOriginalSkin;
@@ -36,8 +36,8 @@ public class PlayerSkinComponent implements Component, AutoSyncedComponent {
         this.formColor = formColor;
     }
 
-    public void setFormColor(int primaryColorRGBA, int accentColor1RGBA, int accentColor2RGBA, int eyeColor, float primaryOverrideStrength, float accent1OverrideStrength, float accent2OverrideStrength) {
-        this.formColor = new FormTextureUtils.ColorSetting(FormTextureUtils.RGBA2ABGR(primaryColorRGBA), FormTextureUtils.RGBA2ABGR(accentColor1RGBA), FormTextureUtils.RGBA2ABGR(accentColor2RGBA), FormTextureUtils.RGBA2ABGR(eyeColor), primaryOverrideStrength, accent1OverrideStrength, accent2OverrideStrength);
+    public void setFormColor(int primaryColorRGBA, int accentColor1RGBA, int accentColor2RGBA, int eyeColor, boolean primaryGreyReverse, boolean accent1GreyReverse, boolean accent2GreyReverse) {
+        this.formColor = new FormTextureUtils.ColorSetting(FormTextureUtils.RGBA2ABGR(primaryColorRGBA), FormTextureUtils.RGBA2ABGR(accentColor1RGBA), FormTextureUtils.RGBA2ABGR(accentColor2RGBA), FormTextureUtils.RGBA2ABGR(eyeColor), primaryGreyReverse, accent1GreyReverse, accent2GreyReverse);
     }
 
     public OptionalInt RGBA_Str2RGBA(String rgbaStr) {
@@ -54,15 +54,14 @@ public class PlayerSkinComponent implements Component, AutoSyncedComponent {
         }
     }
 
-    public boolean setFormColor(String primaryColorRGBAHex, String accentColor1RGBAHex, String accentColor2RGBAHex, String eyeColorHex
-    , float primaryOverrideStrength, float accent1OverrideStrength, float accent2OverrideStrength) {
+    public boolean setFormColor(String primaryColorRGBAHex, String accentColor1RGBAHex, String accentColor2RGBAHex, String eyeColorHex, boolean primaryGreyReverse, boolean accent1GreyReverse, boolean accent2GreyReverse) {
         // FFE189 FBD972 F0AD32
         OptionalInt primaryColorRGBA = RGBA_Str2RGBA(primaryColorRGBAHex);
         OptionalInt accentColor1RGBA = RGBA_Str2RGBA(accentColor1RGBAHex);
         OptionalInt accentColor2RGBA = RGBA_Str2RGBA(accentColor2RGBAHex);
         OptionalInt eyeColor = RGBA_Str2RGBA(eyeColorHex);
         if (primaryColorRGBA.isPresent() && accentColor1RGBA.isPresent() && accentColor2RGBA.isPresent() && eyeColor.isPresent()) {
-            setFormColor(primaryColorRGBA.getAsInt(), accentColor1RGBA.getAsInt(), accentColor2RGBA.getAsInt(), eyeColor.getAsInt(), primaryOverrideStrength, accent1OverrideStrength, accent2OverrideStrength);
+            setFormColor(primaryColorRGBA.getAsInt(), accentColor1RGBA.getAsInt(), accentColor2RGBA.getAsInt(), eyeColor.getAsInt(), primaryGreyReverse, accent1GreyReverse, accent2GreyReverse);
             return true;
         }
         else {
@@ -76,13 +75,13 @@ public class PlayerSkinComponent implements Component, AutoSyncedComponent {
             this.keepOriginalSkin = tag.getBoolean("KeepOriginalSkin");
             this.enableFormColor = tag.getBoolean("EnableFormColor");
             this.formColor = new FormTextureUtils.ColorSetting(FormTextureUtils.RGBA2ABGR(tag.getInt("PrimaryColor")), FormTextureUtils.RGBA2ABGR(tag.getInt("AccentColor1")), FormTextureUtils.RGBA2ABGR(tag.getInt("AccentColor2")), FormTextureUtils.RGBA2ABGR(tag.getInt("EyeColor")),
-                    tag.getFloat("PrimaryOverrideStrength"), tag.getFloat("Accent1OverrideStrength"), tag.getFloat("Accent2OverrideStrength"));
+                    tag.getBoolean("PrimaryGreyReverse"), tag.getBoolean("Accent1GreyReverse"), tag.getBoolean("Accent2GreyReverse"));
         }
         catch(IllegalArgumentException e)
         {
             this.keepOriginalSkin = false; // Default to false
             this.enableFormColor = false; // Default to false
-            this.formColor = new FormTextureUtils.ColorSetting(0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0.0f, 0.0f, 0.0f); // Default to default color
+            this.formColor = new FormTextureUtils.ColorSetting(0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, false, false, false); // Default to default color
         }
     }
 
@@ -94,8 +93,8 @@ public class PlayerSkinComponent implements Component, AutoSyncedComponent {
         tag.putInt("AccentColor1", FormTextureUtils.ABGR2RGBA(this.formColor.getAccentColor1()));
         tag.putInt("AccentColor2", FormTextureUtils.ABGR2RGBA(this.formColor.getAccentColor2()));
         tag.putInt("EyeColor", FormTextureUtils.ABGR2RGBA(this.formColor.getEyeColor()));
-        tag.putFloat("PrimaryOverrideStrength", this.formColor.getPrimaryOverrideStrength());
-        tag.putFloat("Accent1OverrideStrength", this.formColor.getAccent1OverrideStrength());
-        tag.putFloat("Accent2OverrideStrength", this.formColor.getAccent2OverrideStrength());
+        tag.putBoolean("PrimaryGreyReverse", this.formColor.getPrimaryGreyReverse());
+        tag.putBoolean("Accent1GreyReverse", this.formColor.getAccent1GreyReverse());
+        tag.putBoolean("Accent2GreyReverse", this.formColor.getAccent2GreyReverse());
     }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/FormTextureUtils.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/FormTextureUtils.java
@@ -10,6 +10,8 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
 import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
 import net.onixary.shapeShifterCurseFabric.player_form_render.OriginFurModel;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Triple;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,7 +24,7 @@ public class FormTextureUtils {
     // 一些形态原版的贴图过黑，转换为灰度后无法看出自定义颜色，
     // 应用后的灰度 = max(原灰度 + overrideStrength*255, 255)
     public record ColorSetting(int primaryColor, int accentColor1, int accentColor2, int eyeColor
-            , float primaryOverrideStrength, float accent1OverrideStrength, float accent2OverrideStrength) {
+            , boolean primaryGreyReverse, boolean accent1GreyReverse, boolean accent2GreyReverse) {
         public int getPrimaryColor() {
             return this.primaryColor;
         }
@@ -35,14 +37,14 @@ public class FormTextureUtils {
         public int getEyeColor() {
             return this.eyeColor;
         }
-        public float getPrimaryOverrideStrength() {
-            return this.primaryOverrideStrength;
+        public boolean getPrimaryGreyReverse() {
+            return this.primaryGreyReverse;
         }
-        public float getAccent1OverrideStrength() {
-            return this.accent1OverrideStrength;
+        public boolean getAccent1GreyReverse() {
+            return this.accent1GreyReverse;
         }
-        public float getAccent2OverrideStrength() {
-            return this.accent2OverrideStrength;
+        public boolean getAccent2GreyReverse() {
+            return this.accent2GreyReverse;
         }
     }
 
@@ -151,12 +153,21 @@ public class FormTextureUtils {
                (((ColorA & 0xFF) * Bytes) / 255); // Blue
     }
 
+    public static int GreyScaleMul(int Color, float GreyScale) {
+        // ABGR顺序
+        int R = Math.min(255, Math.max((int)(GreyScale * (Color & 0xFF)), 0));
+        int G = Math.min(255, Math.max((int)(GreyScale * ((Color >> 8) & 0xFF)), 0));
+        int B = Math.min(255, Math.max((int)(GreyScale * ((Color >> 16) & 0xFF)), 0));
+        // Math.clamp 是Java 21的方法
+        return 0xFF000000 | (B << 16) | (G << 8) | R;
+    }
+
     // public static int ColorOverlay(int ColorA, int ColorOverlay) {
     //     int OverlayA = (ColorOverlay >> 24) & 0xFF;
     //     return ColorMix(ColorA, ColorOverlay, OverlayA);
     // }
 
-    public static int getLight(int color) {
+    public static int getGreyScale(int color) {
         // 提取RGB通道（忽略Alpha通道）
         int R = (color >> 16) & 0xFF;
         int G = (color >> 8) & 0xFF;
@@ -169,7 +180,39 @@ public class FormTextureUtils {
         return Math.min(a + (int)(t * b), 255);
     }
 
-    public static int ProcessPixel(int Color, int Mask, ColorSetting colorSetting) {
+    public static Triple<Integer, Integer, Integer> getAverageGreyScale(NativeImage image, NativeImage maskImage) {
+        // ABGR顺序
+        int textureWidth = image.getWidth();
+        int textureHeight = image.getHeight();
+        long R = 0, G = 0, B = 0;
+        int RC = 0, GC = 0, BC = 0;
+        for (int x = 0; x < textureWidth; x++) {
+            for (int y = 0; y < textureHeight; y++) {
+                int Mask = maskImage.getColor(x, y);
+                if ((Mask & 0x00FF0000) > 0) {
+                    B += getGreyScale(image.getColor(x, y));
+                    BC ++;
+                }
+                else if ((Mask & 0x0000FF00) > 0) {
+                    G += getGreyScale(image.getColor(x, y));
+                    GC ++;
+                }
+                else if ((Mask & 0x000000FF) > 0) {
+                    R += getGreyScale(image.getColor(x, y));
+                    RC ++;
+                }
+            }
+        }
+        return new ImmutableTriple<>((int)R/RC, (int)G/GC, (int)B/BC);
+    }
+
+    public static int ProcessMaskChannel(int Color, int Mask, int ColorSetting, int AverageGreyScale, boolean ReverseGreyScale) {
+        int GreyScaleAdd = ReverseGreyScale ? AverageGreyScale - getGreyScale(Color) : getGreyScale(Color) - AverageGreyScale;
+        Color = GreyScaleMul(ColorSetting, 1.0f + (float)GreyScaleAdd / 255.0f);
+        return ColorMulBytes(Color, Mask);
+    }
+
+    public static int ProcessPixel(int Color, int Mask, ColorSetting colorSetting, Triple<Integer, Integer, Integer> MaskLayerAverageGreyScale) {
         // ABGR顺序
         // int A = (Mask >> 24);
 
@@ -177,35 +220,26 @@ public class FormTextureUtils {
         int maskAlpha = Mask & 0xFF000000;
         if (maskAlpha >= 0 && maskAlpha < 16) {
             // 使用eyeColor替换颜色，但保留原始颜色的Alpha通道
-            int originalAlpha = Color & 0xFF000000;
-            return (colorSetting.getEyeColor() & 0x00FFFFFF) | originalAlpha;
+            return (colorSetting.eyeColor & 0x00FFFFFF) | (Color & 0xFF000000);
         }
 
         if (Mask == 0) return Color;
         
         // 提取原始颜色的 alpha 值
-        int originalAlpha = Color & 0xFF000000;
-        int L = getLight(Color);
         int B = (Mask >> 16) & 0xFF;
         if (B > 0) {
-            int adjustedL = overrideGreyScale(L, 255, colorSetting.getAccent2OverrideStrength());
-            B = (adjustedL * B) / 255;
-            int result = ColorMulBytes(colorSetting.accentColor2, B);
-            return (result & 0x00FFFFFF) | originalAlpha;
+            int result = ProcessMaskChannel(Color, B, colorSetting.accentColor2, MaskLayerAverageGreyScale.getRight(), colorSetting.accent2GreyReverse);
+            return (result & 0x00FFFFFF) | (Color & 0xFF000000);
         }
         int G = (Mask >> 8) & 0xFF;
         if (G > 0) {
-            int adjustedL1 = overrideGreyScale(L, 255, colorSetting.getAccent1OverrideStrength());
-            G = (adjustedL1 * G) / 255;
-            int result = ColorMulBytes(colorSetting.accentColor1, G);
-            return (result & 0x00FFFFFF) | originalAlpha;
+            int result = ProcessMaskChannel(Color, G, colorSetting.accentColor1, MaskLayerAverageGreyScale.getMiddle(), colorSetting.accent1GreyReverse);
+            return (result & 0x00FFFFFF) | (Color & 0xFF000000);
         }
         int R = Mask & 0xFF;
         if (R > 0) {
-            int adjustedL2 = overrideGreyScale(L, 255, colorSetting.getPrimaryOverrideStrength());
-            R = (adjustedL2 * R) / 255;
-            int result = ColorMulBytes(colorSetting.primaryColor, R);
-            return (result & 0x00FFFFFF) | originalAlpha;
+            int result = ProcessMaskChannel(Color, R, colorSetting.primaryColor, MaskLayerAverageGreyScale.getLeft(), colorSetting.primaryGreyReverse);
+            return (result & 0x00FFFFFF) | (Color & 0xFF000000);
         }
         return Color;
     }
@@ -216,9 +250,10 @@ public class FormTextureUtils {
         NativeImage maskImage = toNativeImage(mask);
         int textureWidth = textureImage.getWidth();
         int textureHeight = textureImage.getHeight();
+        Triple<Integer, Integer, Integer> MaskLayerAverageGreyScale = getAverageGreyScale(textureImage, maskImage);
         for (int x = 0; x < textureWidth; x++) {
             for (int y = 0; y < textureHeight; y++) {
-                textureImage.setColor(x, y, ProcessPixel(textureImage.getColor(x, y), maskImage.getColor(x, y), colorSetting));
+                textureImage.setColor(x, y, ProcessPixel(textureImage.getColor(x, y), maskImage.getColor(x, y), colorSetting, MaskLayerAverageGreyScale));
             }
         }
         TextureManager TM = MinecraftClient.getInstance().getTextureManager();

--- a/src/main/resources/assets/shape-shifter-curse/lang/en_us.json
+++ b/src/main/resources/assets/shape-shifter-curse/lang/en_us.json
@@ -422,8 +422,10 @@
     "text.autoconfig.shape-shifter-curse-custom.option.accentColor1Color": "Accent Color 1",
     "text.autoconfig.shape-shifter-curse-custom.option.accentColor2Color": "Accent Color 2",
     "text.autoconfig.shape-shifter-curse-custom.option.eyeColor": "Eye Color",
-    "text.autoconfig.shape-shifter-curse-custom.option.primaryOverrideStrength": "Primary Grayscale Enhancement",
-    "text.autoconfig.shape-shifter-curse-custom.option.accent1OverrideStrength": "Accent 1 Grayscale Enhancement",
-    "text.autoconfig.shape-shifter-curse-custom.option.accent2OverrideStrength": "Accent 2 Grayscale Enhancement"
+    "text.autoconfig.shape-shifter-curse-custom.option.primaryGreyReverse": "Primary Grayscale Reverse",
+    "text.autoconfig.shape-shifter-curse-custom.option.accent1GreyReverse": "Accent 1 Grayscale Reverse",
+    "text.autoconfig.shape-shifter-curse-custom.option.accent2GreyReverse": "Accent 2 Grayscale Reverse"
+
+
 
 }

--- a/src/main/resources/assets/shape-shifter-curse/lang/zh_cn.json
+++ b/src/main/resources/assets/shape-shifter-curse/lang/zh_cn.json
@@ -422,7 +422,7 @@
     "text.autoconfig.shape-shifter-curse-custom.option.accentColor1Color": "重点色1",
     "text.autoconfig.shape-shifter-curse-custom.option.accentColor2Color": "重点色2",
     "text.autoconfig.shape-shifter-curse-custom.option.eyeColor": "眼睛颜色",
-    "text.autoconfig.shape-shifter-curse-custom.option.primaryOverrideStrength": "主要色灰度增强",
-    "text.autoconfig.shape-shifter-curse-custom.option.accent1OverrideStrength": "重点色1灰度增强",
-    "text.autoconfig.shape-shifter-curse-custom.option.accent2OverrideStrength": "重点色2灰度增强"
+    "text.autoconfig.shape-shifter-curse-custom.option.primaryGreyReverse": "主要色灰度反转",
+    "text.autoconfig.shape-shifter-curse-custom.option.accent1GreyReverse": "重点色1灰度反转",
+    "text.autoconfig.shape-shifter-curse-custom.option.accent2GreyReverse": "重点色2灰度反转"
 }

--- a/src/main/resources/assets/shape-shifter-curse/rich_lang/en_us.json
+++ b/src/main/resources/assets/shape-shifter-curse/rich_lang/en_us.json
@@ -670,7 +670,7 @@
   "text.autoconfig.shape-shifter-curse-custom.option.accentColor1Color": "Accent Color 1",
   "text.autoconfig.shape-shifter-curse-custom.option.accentColor2Color": "Accent Color 2",
   "text.autoconfig.shape-shifter-curse-custom.option.eyeColor": "Eye Color",
-  "text.autoconfig.shape-shifter-curse-custom.option.primaryOverrideStrength": "Primary Grayscale Enhancement",
-  "text.autoconfig.shape-shifter-curse-custom.option.accent1OverrideStrength": "Accent 1 Grayscale Enhancement",
-  "text.autoconfig.shape-shifter-curse-custom.option.accent2OverrideStrength": "Accent 2 Grayscale Enhancement"
+  "text.autoconfig.shape-shifter-curse-custom.option.primaryGreyReverse": "Primary Grayscale Reverse",
+  "text.autoconfig.shape-shifter-curse-custom.option.accent1GreyReverse": "Accent 1 Grayscale Reverse",
+  "text.autoconfig.shape-shifter-curse-custom.option.accent2GreyReverse": "Accent 2 Grayscale Reverse"
 }

--- a/src/main/resources/assets/shape-shifter-curse/rich_lang/zh_cn.json
+++ b/src/main/resources/assets/shape-shifter-curse/rich_lang/zh_cn.json
@@ -631,7 +631,7 @@
   "text.autoconfig.shape-shifter-curse-custom.option.accentColor1Color": "重点色1",
   "text.autoconfig.shape-shifter-curse-custom.option.accentColor2Color": "重点色2",
   "text.autoconfig.shape-shifter-curse-custom.option.eyeColor": "眼睛颜色",
-  "text.autoconfig.shape-shifter-curse-custom.option.primaryOverrideStrength": "主要色灰度增强",
-  "text.autoconfig.shape-shifter-curse-custom.option.accent1OverrideStrength": "重点色1灰度增强",
-  "text.autoconfig.shape-shifter-curse-custom.option.accent2OverrideStrength": "重点色2灰度增强"
+  "text.autoconfig.shape-shifter-curse-custom.option.primaryGreyReverse": "主要色灰度反转",
+  "text.autoconfig.shape-shifter-curse-custom.option.accent1GreyReverse": "重点色1灰度反转",
+  "text.autoconfig.shape-shifter-curse-custom.option.accent2GreyReverse": "重点色2灰度反转"
 }


### PR DESCRIPTION
今天突发奇想想到一种新的颜色处理方案 (不需要玩家手动调整亮度了)
效果 同样的设置 (豹猫+黑猫):
<img width="854" height="480" alt="2025-10-01_21 06 40" src="https://github.com/user-attachments/assets/e44f05ed-1142-4650-b1b7-979a21109761" />
<img width="854" height="480" alt="2025-10-01_21 08 39" src="https://github.com/user-attachments/assets/7a9d7355-acc5-41fd-bfd2-40c4a32a6468" />
上面的EyeColor显示问题刚修完 (写PR时发现 就不重新截图了)

**现在的处理逻辑**
Mask在Texture中需要修改的像素的灰度平均值 greyavg
获取当前像素灰度与greyavg的差值 之后修正colorsetting的灰度值(可以通过修改配置反向修正) 最后乘以Mask对应通道值

现在 `shape_shifter_curse set_form_color` 无参数时可以打印颜色信息

网络动态形态目前我按照第3方案在写 等国庆后几天应该就能完成 可以在我的Fork的[branch](https://github.com/xu233333/shape-shifter-curse-fabric/tree/%E7%BD%91%E7%BB%9C%E5%8A%A8%E6%80%81Form)中查看