### PR TITLE
移除踏浪攻击中的y动量防止其他Mod中的damage触发导致起飞Bug

### DIFF
--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_attack.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_attack.json
@@ -5,8 +5,7 @@
         "actions": [
             {
                 "type": "origins:add_velocity",
-                "z": 4.0,
-                "y": 8.0
+                "z": 4.0
             },
             {
                 "type": "origins:target_action",


### PR DESCRIPTION
> 荆棘踏浪起飞的原因找到了 由于在玩家攻击时 `origins:add_velocity` 中y参数不会生效(可能是异步问题?) 而荆棘会正常生效add_velocity 攻击时 add_velocity 会在生效时瞬间y动量掉到1.0以下(就算是用IDEA调试修改动量也会瞬间变小) 而荆棘为每tick降低0.2的y动量

在上个PR里说的 防止特殊攻击让add_velocity中的y正常生效导致起飞