### PR TITLE
修改限制物品逻辑 现在拥有MorphScaleItem的NBT和在morph_scale_item里的物品不会被形态限制

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/ShapeShifterCurseFabric.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/ShapeShifterCurseFabric.java
@@ -30,10 +30,7 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
-import net.onixary.shapeShifterCurseFabric.additional_power.AdditionalEntityActions;
-import net.onixary.shapeShifterCurseFabric.additional_power.AdditionalEntityConditions;
-import net.onixary.shapeShifterCurseFabric.additional_power.AdditionalPowers;
-import net.onixary.shapeShifterCurseFabric.additional_power.BatAttachEventHandler;
+import net.onixary.shapeShifterCurseFabric.additional_power.*;
 import net.onixary.shapeShifterCurseFabric.advancement.*;
 import net.onixary.shapeShifterCurseFabric.command.CustomFormArgumentType;
 import net.onixary.shapeShifterCurseFabric.command.FormArgumentType;
@@ -177,6 +174,7 @@ public class ShapeShifterCurseFabric implements ModInitializer {
         registerAnimations();
 
         AdditionalEntityConditions.register();
+        AdditionalItemCondition.register();
         AdditionalPowers.register();
         AdditionalEntityActions.register();
 

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalItemCondition.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalItemCondition.java
@@ -1,0 +1,17 @@
+package net.onixary.shapeShifterCurseFabric.additional_power;
+
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.apoli.registry.ApoliRegistries;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registry;
+
+public class AdditionalItemCondition {
+    public static void register() {
+        register(IsMorphScaleItemCondition.getFactory());
+    }
+
+    private static void register(ConditionFactory<ItemStack> conditionFactory) {
+        Registry.register(ApoliRegistries.ITEM_CONDITION, conditionFactory.getSerializerId(), conditionFactory);
+
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/IsMorphScaleItemCondition.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/IsMorphScaleItemCondition.java
@@ -1,0 +1,33 @@
+package net.onixary.shapeShifterCurseFabric.additional_power;
+
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+import net.onixary.shapeShifterCurseFabric.util.ModTags;
+
+public class IsMorphScaleItemCondition {
+    public static final String IsMorphScaleArmorTagName = "MorphScaleItem";
+
+    public static boolean condition(SerializableData.Instance data, ItemStack itemStack) {
+        if (itemStack.isIn(ModTags.MorphScaleItem_Tag)) {
+            return true;
+        }
+        NbtCompound itemNBT = itemStack.getNbt();
+        if (itemNBT != null) {
+            if (itemNBT.getBoolean(IsMorphScaleArmorTagName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static ConditionFactory<ItemStack> getFactory() {
+        return new ConditionFactory<ItemStack>(
+                ShapeShifterCurseFabric.identifier("is_morph_scale_item"),
+                new SerializableData(),
+                IsMorphScaleItemCondition::condition
+        );
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/ModTags.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/ModTags.java
@@ -1,6 +1,7 @@
 package net.onixary.shapeShifterCurseFabric.util;
 
 import net.minecraft.entity.EntityType;
+import net.minecraft.item.Item;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.util.Identifier;
@@ -9,5 +10,5 @@ import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
 public class ModTags {
     public static final TagKey<EntityType<?>> Illager_Tag = TagKey.of(RegistryKeys.ENTITY_TYPE, new Identifier(ShapeShifterCurseFabric.MOD_ID, "illager"));
     public static final TagKey<EntityType<?>> Witch_Tag = TagKey.of(RegistryKeys.ENTITY_TYPE, new Identifier(ShapeShifterCurseFabric.MOD_ID, "witch"));
-
+    public static final TagKey<Item> MorphScaleItem_Tag = TagKey.of(RegistryKeys.ITEM, new Identifier(ShapeShifterCurseFabric.MOD_ID, "morph_scale_item"));
 }

--- a/src/main/resources/assets/shape-shifter-curse/lang/en_us.json
+++ b/src/main/resources/assets/shape-shifter-curse/lang/en_us.json
@@ -200,6 +200,8 @@
   "power.origins.vegetarian.name": "vegetarian",
   "power.shape-shifter-curse.form_familiar_fox_3_no_food.name": "Familiar Constitution",
   "power.shape-shifter-curse.prevent_ranged_weapon_use.name": "Prevent Ranged Weapon",
+  "power.shape-shifter-curse.no_shield.name": "Unwieldy",
+  "power.shape-shifter-curse.no_shield.description": "The way your hands are formed provide no way of holding a shield upright.",
   "power.shape-shifter-curse.form_vegetarian.name": "vegetarian",
   "commands.shape-shifter-curse.form_not_found": "Specified form not found!",
   "codex.header.status": "Status",

--- a/src/main/resources/assets/shape-shifter-curse/lang/zh_cn.json
+++ b/src/main/resources/assets/shape-shifter-curse/lang/zh_cn.json
@@ -200,6 +200,8 @@
   "power.shape-shifter-curse.form_ocelot_2_raw_meat_only.name": "生肉食性",
   "power.shape-shifter-curse.form_familiar_fox_3_no_food.name": "使魔体质",
   "power.shape-shifter-curse.prevent_ranged_weapon_use.name": "禁用弓弩",
+  "power.shape-shifter-curse.no_shield.name":"持盾不能",
+  "power.shape-shifter-curse.no_shield.description":"你双手的造型让你无法正常地手持盾牌。",
   "power.shape-shifter-curse.form_vegetarian.name": "素食者",
   "power.origins.vegetarian.name": "素食者",
   "codex.header.status": "状态",

--- a/src/main/resources/assets/shape-shifter-curse/rich_lang/en_us.json
+++ b/src/main/resources/assets/shape-shifter-curse/rich_lang/en_us.json
@@ -289,6 +289,8 @@
   "power.origins.vegetarian.name": ["vegetarian"],
   "power.shape-shifter-curse.form_familiar_fox_3_no_food.name": ["Familiar Constitution"],
   "power.shape-shifter-curse.prevent_ranged_weapon_use.name": ["Prevent Ranged Weapon"],
+  "power.shape-shifter-curse.no_shield.name": ["Unwieldy"],
+  "power.shape-shifter-curse.no_shield.description": ["The way your hands are formed provide no way of holding a shield upright."],
   "power.shape-shifter-curse.form_vegetarian.name": ["vegetarian"],
 
   "commands.shape-shifter-curse.form_not_found": ["Specified form not found!"],

--- a/src/main/resources/assets/shape-shifter-curse/rich_lang/zh_cn.json
+++ b/src/main/resources/assets/shape-shifter-curse/rich_lang/zh_cn.json
@@ -277,6 +277,8 @@
   "power.shape-shifter-curse.form_familiar_fox_3_no_food.name": ["使魔体质"],
   "power.shape-shifter-curse.prevent_ranged_weapon_use.name": ["禁用弓弩"],
   "power.shape-shifter-curse.form_vegetarian.name": ["素食者"],
+  "power.shape-shifter-curse.no_shield.name":["持盾不能"],
+  "power.shape-shifter-curse.no_shield.description":["你双手的造型让你无法正常地手持盾牌。"],
   "power.origins.vegetarian.name": ["素食者"],
   "codex.header.status": ["状态"],
   "codex.header.appearance": ["外观"],

--- a/src/main/resources/data/shape-shifter-curse/origins/form_ocelot_2.json
+++ b/src/main/resources/data/shape-shifter-curse/origins/form_ocelot_2.json
@@ -14,7 +14,7 @@
         "shape-shifter-curse:form_ocelot_2_sneaking_jump_high",
         "shape-shifter-curse:form_ocelot_2_sneaking_speed_up",
         "origins:hotblooded",
-        "origins:no_shield",
+        "shape-shifter-curse:no_shield",
         "origins:velvet_paws",
         "origins:more_exhaustion",
         "shape-shifter-curse:prevent_sprinting",

--- a/src/main/resources/data/shape-shifter-curse/origins/form_ocelot_3.json
+++ b/src/main/resources/data/shape-shifter-curse/origins/form_ocelot_3.json
@@ -16,7 +16,7 @@
         "shape-shifter-curse:form_ocelot_3_jump_high",
         "shape-shifter-curse:form_ocelot_3_hunger",
         "origins:hotblooded",
-        "origins:no_shield",
+        "shape-shifter-curse:no_shield",
         "origins:velvet_paws",
         "origins:more_exhaustion",
         "shape-shifter-curse:prevent_sprinting",

--- a/src/main/resources/data/shape-shifter-curse/powers/drop_tool_after_digging.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/drop_tool_after_digging.json
@@ -3,9 +3,18 @@
     "entity_action": {
         "type": "origins:drop_inventory",
         "item_condition": {
-            "type": "origins:harvest_level",
-            "comparison": ">",
-            "compare_to": 1
+            "type": "origins:and",
+            "conditions": [
+                {
+                    "type": "origins:harvest_level",
+                    "comparison": ">",
+                    "compare_to": 1
+                },
+                {
+                    "type": "shape-shifter-curse:is_morph_scale_item",
+                    "inverted": true
+                }
+            ]
         },
         "slots": [
             "weapon.mainhand"

--- a/src/main/resources/data/shape-shifter-curse/powers/drop_weapon_after_hit.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/drop_weapon_after_hit.json
@@ -3,19 +3,28 @@
     "entity_action": {
         "type": "origins:drop_inventory",
         "item_condition": {
-            "type": "origins:or",
+            "type": "origins:and",
             "conditions": [
                 {
-                    "type": "origins:ingredient",
-                    "ingredient": {
-                        "tag": "origins:melee_weapons"
-                    }
+                    "type": "origins:or",
+                    "conditions": [
+                        {
+                            "type": "origins:ingredient",
+                            "ingredient": {
+                                "tag": "origins:melee_weapons"
+                            }
+                        },
+                        {
+                            "type": "origins:ingredient",
+                            "ingredient": {
+                                "tag": "origins:tools"
+                            }
+                        }
+                    ]
                 },
                 {
-                    "type": "origins:ingredient",
-                    "ingredient": {
-                        "tag": "origins:tools"
-                    }
+                    "type": "shape-shifter-curse:is_morph_scale_item",
+                    "inverted": true
                 }
             ]
         },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_disable_chest_armor.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_disable_chest_armor.json
@@ -16,10 +16,7 @@
                 "inverted": true
             },
             {
-              "type": "origins:ingredient",
-              "ingredient": {
-                "item": "shape-shifter-curse:morphscale_vest"
-              },
+              "type": "shape-shifter-curse:is_morph_scale_item",
               "inverted": true
             }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_disable_feet_armor.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_disable_feet_armor.json
@@ -9,10 +9,7 @@
           "compare_to": -1
         },
         {
-          "type": "origins:ingredient",
-          "ingredient": {
-            "item": "shape-shifter-curse:morphscale_anklet"
-          },
+          "type": "shape-shifter-curse:is_morph_scale_item",
           "inverted": true
         }
       ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_disable_head_armor.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_disable_head_armor.json
@@ -9,10 +9,7 @@
           "compare_to": -1
         },
         {
-          "type": "origins:ingredient",
-          "ingredient": {
-            "item": "shape-shifter-curse:morphscale_headring"
-          },
+          "type": "shape-shifter-curse:is_morph_scale_item",
           "inverted": true
         }
       ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_disable_leg_armor.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_disable_leg_armor.json
@@ -9,10 +9,7 @@
           "compare_to": -1
         },
         {
-          "type": "origins:ingredient",
-          "ingredient": {
-            "item": "shape-shifter-curse:morphscale_cuish"
-          },
+          "type": "shape-shifter-curse:is_morph_scale_item",
           "inverted": true
         }
       ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_light_armor.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_light_armor.json
@@ -22,10 +22,7 @@
         }
       },
       {
-        "type": "origins:ingredient",
-        "ingredient": {
-          "item": "shape-shifter-curse:morphscale_vest"
-        }
+        "type": "shape-shifter-curse:is_morph_scale_item"
       }
     ],
     "inverted": true
@@ -46,10 +43,7 @@
         }
       },
       {
-        "type": "origins:ingredient",
-        "ingredient": {
-          "item": "shape-shifter-curse:morphscale_cuish"
-        }
+        "type": "shape-shifter-curse:is_morph_scale_item"
       }
     ],
     "inverted": true
@@ -70,10 +64,7 @@
         }
       },
       {
-        "type": "origins:ingredient",
-        "ingredient": {
-          "item": "shape-shifter-curse:morphscale_anklet"
-        }
+        "type": "shape-shifter-curse:is_morph_scale_item"
       }
     ],
     "inverted": true

--- a/src/main/resources/data/shape-shifter-curse/powers/no_shield.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/no_shield.json
@@ -1,0 +1,18 @@
+{
+  "type": "origins:prevent_item_use",
+  "item_condition": {
+    "type": "origins:and",
+    "conditions": [
+      {
+        "type": "origins:ingredient",
+        "ingredient": {
+          "tag": "origins:shields"
+        }
+      },
+      {
+        "type": "shape-shifter-curse:is_morph_scale_item",
+        "inverted": true
+      }
+    ]
+  }
+}

--- a/src/main/resources/data/shape-shifter-curse/powers/prevent_ranged_weapon_use.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/prevent_ranged_weapon_use.json
@@ -1,9 +1,18 @@
 {
     "type": "origins:prevent_item_use",
     "item_condition": {
-        "type": "origins:ingredient",
-        "ingredient": {
-            "tag": "origins:ranged_weapons"
-        }
+        "type": "origins:and",
+        "conditions": [
+            {
+                "type": "origins:ingredient",
+                "ingredient": {
+                    "tag": "origins:ranged_weapons"
+                }
+            },
+            {
+                "type": "shape-shifter-curse:is_morph_scale_item",
+                "inverted": true
+            }
+        ]
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/tags/items/morph_scale_item.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/items/morph_scale_item.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "shape-shifter-curse:morphscale_headring",
+    "shape-shifter-curse:morphscale_vest",
+    "shape-shifter-curse:morphscale_cuish",
+    "shape-shifter-curse:morphscale_anklet"
+  ],
+  "optional": [
+  ]
+}


### PR DESCRIPTION
样例:
获取一把可以在蝙蝠形态下可以使用的弓 `/give @p bow{MorphScaleItem:1b} 1`
一条可以被所有(除了悦灵)形态穿的护腿 `/give @p diamond_leggings{MorphScaleItem:1b} 1`

拥有`MorphScaleItem:[boolean]`的NBT和在morph_scale_item里的物品不会被形态限制(类似塑形装备但是包括物品)
使用shape-shifter-curse:is_morph_scale_item物品条件来判断

一般用于一些RPG数据包或者添加额外塑形装备的Mod使用 Power系统难以兼容性覆盖(多个数据包修改同一Power)

这两天我有些感冒 等我好了之后再写一些复杂的功能