### PR TITLE
添加修改水中移速的Power

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalPowers.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalPowers.java
@@ -46,6 +46,7 @@ public class AdditionalPowers {
         register(ActionOnSplashPotionTakeEffect.createFactory());
         register(ConditionScalePower.createFactory());
         register(SneakingJumpClashPower.createFactory());
+        register(InWaterSpeedModifierPower.createFactory());
     }
 
     public static PowerFactory<?> register(PowerFactory<?> powerFactory) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/InWaterSpeedModifierPower.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/InWaterSpeedModifierPower.java
@@ -1,0 +1,31 @@
+package net.onixary.shapeShifterCurseFabric.additional_power;
+
+import io.github.apace100.apoli.power.Power;
+import io.github.apace100.apoli.power.PowerType;
+import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.LivingEntity;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+
+public class InWaterSpeedModifierPower extends Power {
+    private final float Modifier;
+
+    public InWaterSpeedModifierPower(PowerType<?> type, LivingEntity entity, float Modifier) {
+        super(type, entity);
+        this.Modifier = Modifier;
+    }
+
+    public float getSpeedModifier() {
+        return Modifier;
+    }
+
+    public static PowerFactory<Power> createFactory() {
+        return new PowerFactory<>(
+                ShapeShifterCurseFabric.identifier("in_water_speed_modifier"),
+                new SerializableData()
+                        .add("modifier", SerializableDataTypes.FLOAT, 1.0f),
+                data -> (type, entity) -> new InWaterSpeedModifierPower(type, entity, data.getFloat("modifier"))
+        ).allowCondition();
+    }
+}

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_0_water_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_0_water_speed_down.json
@@ -1,16 +1,4 @@
 {
-    "type": "origins:conditioned_attribute",
-    "modifier": {
-        "attribute": "minecraft:generic.movement_speed",
-        "operation": "addition",
-        "value": -0.15,
-        "name": "water speed down"
-    },
-    "tick_rate": 5,
-    "condition": {
-        "type": "origins:fluid_height",
-        "fluid": "minecraft:water",
-        "comparison": ">",
-        "compare_to": 0
-    }
+    "type": "shape-shifter-curse:in_water_speed_modifier",
+    "modifier": 0.7
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_1_water_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_1_water_speed_down.json
@@ -1,16 +1,4 @@
 {
-    "type": "origins:conditioned_attribute",
-    "modifier": {
-        "attribute": "minecraft:generic.movement_speed",
-        "operation": "addition",
-        "value": -0.25,
-        "name": "water speed down"
-    },
-    "tick_rate": 5,
-    "condition": {
-        "type": "origins:fluid_height",
-        "fluid": "minecraft:water",
-        "comparison": ">",
-        "compare_to": 0
-    }
+    "type": "shape-shifter-curse:in_water_speed_modifier",
+    "modifier": 0.4
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_water_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_water_speed_down.json
@@ -1,16 +1,4 @@
 {
-    "type": "origins:conditioned_attribute",
-    "modifier": {
-        "attribute": "minecraft:generic.movement_speed",
-        "operation": "multiply_total",
-        "value": -0.8,
-        "name": "water speed down"
-    },
-    "tick_rate": 5,
-    "condition": {
-        "type": "origins:fluid_height",
-        "fluid": "minecraft:water",
-        "comparison": ">",
-        "compare_to": 0
-    }
+    "type": "shape-shifter-curse:in_water_speed_modifier",
+    "modifier": 0.2
 }


### PR DESCRIPTION
使用in_water_speed_modifier来修改水中移动速度(算法为乘积)
至于Mixin上面注释掉的代码是~~我尝试使用线性插值修正速度的尝试 结果当速度=0.02就没法计算了~~ 重新计算g 但是会忽略其他Mod的修改 所有没用
如果这种方法还冲突 还可以在调用updateVelocity之后再调用一个负的速度
如果最后的方法还冲突 那我也就没辙了 可以尝试修改水中减速的设定了