### PR TITLE
动作系统小补丁

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/AnimationController.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/AnimationController.java
@@ -89,9 +89,6 @@ public class AnimationController {
         // 先判断后处理变量
         this.DataHolderTick(player, animDataHolder);
         animDataHolder.prevAnimState = animState;
-        if (animState == null) {
-            return null;
-        }
         // 获取具体动画
         switch (animState) {
             // 特殊动画在这里修改


### PR DESCRIPTION
比较奇怪的是 `!playerEntity.isOnGround() && playerEntity.getVelocity().y < 0.0` 和 `!playerEntity.isOnGround() && playerEntity.getVelocity().y >= 0.0` 在离地到达最高点时竟然会同时不成立 导致跳跃State顺序(默认为Idle时)Jump->Idle->Fall->Walk->Idle 等我之后研究一下
现在默认动作为重复上一Tick的动作 并添加了Idle的动作判断