### PR TITLE
修改animState为null时的处理

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/AnimationController.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/AnimationController.java
@@ -22,7 +22,7 @@ public class AnimationController {
     public static class PlayerAnimDataHolder {
         // 跟随PlayerEntity Object
         PlayerFormBase playerForm = RegPlayerForms.ORIGINAL_BEFORE_ENABLE;
-        PlayerAnimState prevAnimState = null;
+        PlayerAnimState prevAnimState = PlayerAnimState.NONE;
         public Vec3d lastPos = new Vec3d(0, 0, 0);
         int continueSwingAnimCounter = 0;
         boolean lastOnGround = false;
@@ -92,7 +92,7 @@ public class AnimationController {
         // 获取具体动画
         // 由于switch无法处理null的情况 所以这里需要单独处理
         if(animState == null){
-            return animDataHolder.playerForm.Anim_getFormAnimToPlay(animState);
+            return null;
         }
         switch (animState) {
             // 特殊动画在这里修改


### PR DESCRIPTION
我才知道switch判断null会爆空指针异常(我之前以为会到default里) 以前一般都写if else 这回由于下面的特殊动画后期可能会拓展就用了switch
现在是直接返回null 因为在处理动作时有对动作为null的额外判断和处理
原先的null的原因是prevAnimState默认为null 在所有条件都不满足时会返回prevAnimState导致会返回null 现在修改prevAnimState的默认值为`PlayerAnimState.NONE`就不会返回null了