### PR TITLE
改了一下食物饱和度系统 现在增加饱食度也兼容AppleSkin

### DIFF
--- a/src/main/resources/data/shape-shifter-curse/powers/form_meat_food_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_meat_food_up.json
@@ -1,9 +1,14 @@
 {
-    "type": "origins:action_on_item_use",
-    "entity_action": {
-        "type": "origins:feed",
-        "food": 2.5,
-        "saturation": 0.4
+    "type": "origins:modify_food",
+    "food_modifier": {
+        "name": "increase food points",
+        "operation": "multiply_base_multiplicative",
+        "value": 1.0
+    },
+    "saturation_modifier": {
+        "name": "increase food points",
+        "operation": "multiply_base_multiplicative",
+        "value": 1.0
     },
     "item_condition": {
         "type": "origins:and",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_raw_fish_food_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_raw_fish_food_up.json
@@ -1,10 +1,29 @@
 {
-    "type": "origins:action_on_item_use",
-    "entity_action": {
-        "type": "origins:feed",
-        "food": 4.5,
-        "saturation": 1.2
-    },
+    "type": "origins:modify_food",
+    "food_modifiers": [
+        {
+            "name": "increase food points",
+            "operation": "multiply_base_additive",
+            "value": 1.0
+        },
+        {
+            "name": "increase food points",
+            "operation": "multiply_base_multiplicative",
+            "value": 1.0
+        }
+    ],
+    "saturation_modifiers": [
+        {
+            "name": "increase food points",
+            "operation": "multiply_base_multiplicative",
+            "value": 1.0
+        },
+        {
+            "name": "increase food points",
+            "operation": "min_total",
+            "value": 0.6
+        }
+    ],
     "item_condition": {
         "type": "origins:ingredient",
         "ingredient": {

--- a/src/main/resources/data/shape-shifter-curse/powers/form_raw_meat_food_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_raw_meat_food_up.json
@@ -1,10 +1,29 @@
 {
-    "type": "origins:action_on_item_use",
-    "entity_action": {
-        "type": "origins:feed",
-        "food": 4.0,
-        "saturation": 0.8
-    },
+    "type": "origins:modify_food",
+    "food_modifiers": [
+        {
+            "name": "increase food points",
+            "operation": "multiply_base_additive",
+            "value": 0.5
+        },
+        {
+            "name": "increase food points",
+            "operation": "multiply_base_multiplicative",
+            "value": 1.0
+        }
+    ],
+    "saturation_modifiers": [
+        {
+            "name": "increase food points",
+            "operation": "multiply_base_multiplicative",
+            "value": 1.0
+        },
+        {
+            "name": "increase food points",
+            "operation": "min_total",
+            "value": 0.6
+        }
+    ],
     "item_condition": {
         "type": "origins:ingredient",
         "ingredient": {

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_sweet_berry_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_sweet_berry_up.json
@@ -1,9 +1,14 @@
 {
-    "type": "origins:action_on_item_use",
-    "entity_action": {
-        "type": "origins:feed",
-        "food": 4,
-        "saturation": 0.8
+    "type": "origins:modify_food",
+    "food_modifier": {
+        "name": "increase food points",
+        "operation": "multiply_base_multiplicative",
+        "value": 1.0
+    },
+    "saturation_modifier": {
+        "name": "increase food points",
+        "operation": "multiply_base_multiplicative",
+        "value": 1.0
     },
     "item_condition": {
         "type": "origins:ingredient",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_vegetarian_food_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_vegetarian_food_up.json
@@ -1,9 +1,14 @@
 {
-    "type": "origins:action_on_item_use",
-    "entity_action": {
-        "type": "origins:feed",
-        "food": 2.5,
-        "saturation": 0.4
+    "type": "origins:modify_food",
+    "food_modifier": {
+        "name": "increase food points",
+        "operation": "multiply_base_multiplicative",
+        "value": 1.0
+    },
+    "saturation_modifier": {
+        "name": "increase food points",
+        "operation": "multiply_base_multiplicative",
+        "value": 1.0
     },
     "item_condition": {
         "type": "origins:and",


### PR DESCRIPTION
素食肉食系列: 饱食度翻倍 饱和度系数翻倍 需要后续调整 可能需要调低一点
只能生肉生鱼肉 饱食度+1/+0.5后翻倍 饱和度系数翻倍(最低0.6) 大部分属性比熟肉高一点 我个人认为应该比较平衡了 毕竟只能吃这些食物 回复太低有点弱
具体运算符可以看io.github.apace100.apoli.util.modifier.ModifierOperation