### PR TITLE
更新一下开发环境(移除ForgeConfigApiPort) + 修改azurelib的depends <3.1.0 -> 3.0.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,7 +201,7 @@ dependencies {
     include modImplementation("dev.kosmx.player-anim:player-animation-lib-fabric:${project.player_anim}")
 
     // Fabric forge config api port
-    modLocalRuntime "fuzs.forgeconfigscreens:forgeconfigscreens-fabric:8.0.0"
+    // modLocalRuntime "fuzs.forgeconfigscreens:forgeconfigscreens-fabric:8.0.0"
 
 
     //modImplementation "com.github.eggohito:eggolib:${project.eggolib_version}"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -63,7 +63,7 @@
     "fabricloader": ">=0.12.3",
     "fabric": ">=0.83.0",
     "minecraft": "1.20.1",
-    "azurelib": "<3.1.0",
+    "azurelib": "3.0.x",
     "pehkui": ">=3.7.8",
     "satin": ">=1.14.0"
   },


### PR DESCRIPTION
移除depend需要在fabric.mod.json和开发环境同时移除才行
修改azurelib的depends `<3.1.0` -> `3.0.x` 比较明显说明只支持AzureLib 3.0.* 版本