### PR TITLE
新的CustomEdible缓存方案

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/ShapeShifterCurseFabric.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/ShapeShifterCurseFabric.java
@@ -332,6 +332,9 @@ public class ShapeShifterCurseFabric implements ModInitializer {
             TransformManager.update(player);
             TickManager.tickServerAll();
 
+            // CustomEdiblePower Tick
+            CustomEdiblePower.OnServerTick(player);
+
             // handle transformative effects tick
             PlayerEffectAttachment attachment = player.getAttached(EffectManager.EFFECT_ATTACHMENT);
             if (attachment != null && attachment.currentEffect != null) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/client/ShapeShifterCurseFabricClient.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/client/ShapeShifterCurseFabricClient.java
@@ -17,6 +17,7 @@ import net.minecraft.client.render.entity.model.EntityModelLayer;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Identifier;
 import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+import net.onixary.shapeShifterCurseFabric.additional_power.CustomEdiblePower;
 import net.onixary.shapeShifterCurseFabric.additional_power.LevitatePower;
 import net.onixary.shapeShifterCurseFabric.custom_ui.BookOfShapeShifterScreenV2_P1;
 import net.onixary.shapeShifterCurseFabric.custom_ui.StartBookScreenV2;
@@ -269,6 +270,7 @@ public class ShapeShifterCurseFabricClient implements ClientModInitializer {
 			// 	power.clientTick(clientPlayer);
 			// }
 			PowerHolderComponent.KEY.get(clientPlayer).getPowers().stream().filter(p -> p instanceof LevitatePower).forEach(p -> ((LevitatePower) p).clientTick(clientPlayer));
+			CustomEdiblePower.OnClientTick(clientPlayer);
 		});
 	}
 

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPackets.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPackets.java
@@ -47,6 +47,4 @@ public class ModPackets {
 
     public static final Identifier LOGIN_PACKET = new Identifier(ShapeShifterCurseFabric.MOD_ID, "login_packet");  // 我暂时没找到玩家进入服务去时的Hook，所以暂时由服务器询问来代替
     public static final Identifier UPDATE_CUSTOM_SETTING = new Identifier(ShapeShifterCurseFabric.MOD_ID, "update_custom_setting");
-
-    public static final Identifier UPDATE_CUSTOM_EDIBLE_DATA = new Identifier(ShapeShifterCurseFabric.MOD_ID, "update_custom_edible_data");
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2C.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2C.java
@@ -55,7 +55,6 @@ public class ModPacketsS2C {
         ClientPlayNetworking.registerGlobalReceiver(ModPackets.UPDATE_DYNAMIC_FORM, ModPacketsS2C::handleUpdateDynamicForm);
         ClientPlayNetworking.registerGlobalReceiver(ModPackets.REMOVE_DYNAMIC_FORM_EXCEPT, ModPacketsS2C::handleRemoveDynamicExcept);
         ClientPlayNetworking.registerGlobalReceiver(ModPackets.LOGIN_PACKET, ModPacketsS2C::onPlayerConnectServer);
-        ClientPlayNetworking.registerGlobalReceiver(ModPackets.UPDATE_CUSTOM_EDIBLE_DATA, ModPacketsS2C::handleUpdateCustomEdibleData);
     }
 
     public static void handleSyncEffectAttachment(
@@ -304,24 +303,5 @@ public class ModPacketsS2C {
 
     public static void sendUpdateCustomSetting() {
         sendUpdateCustomSetting(false);
-    }
-
-    public static void handleUpdateCustomEdibleData(MinecraftClient client, ClientPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
-        int UpdateType = buf.readInt();
-        if (client.player == null) return;
-        List<Identifier> items = new LinkedList<>();
-        int itemCount = buf.readInt();
-        for (int i = 0; i < itemCount; i++) {
-            items.add(Identifier.tryParse(buf.readString()));
-        }
-        switch (UpdateType) {
-            case 0:  // Clear
-                CustomEdibleUtils.clearCustomEdibleWithList(client.player, items);
-                return;
-            case 1:  // Add
-                FoodComponent foodComponent = CustomEdibleUtils.ReadFoodComponent(buf);
-                CustomEdibleUtils.addCustomEdibleWithList(client.player, items, foodComponent);
-                return;
-        }
     }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2CServer.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2CServer.java
@@ -175,24 +175,4 @@ public class ModPacketsS2CServer {
         ServerPlayNetworking.send(player, ModPackets.LOGIN_PACKET, buf);
     }
 
-    public static void sendCustomEdibleList(ServerPlayerEntity player, List<Identifier> Items, FoodComponent foodComponent) {
-        PacketByteBuf buf = PacketByteBufs.create();
-        buf.writeInt(1);  // 添加CustomEdible
-        buf.writeInt(Items.size());
-        for (Identifier id : Items) {
-            buf.writeIdentifier(id);
-        }
-        CustomEdibleUtils.WriteFoodComponent(buf, foodComponent);
-        ServerPlayNetworking.send(player, ModPackets.UPDATE_CUSTOM_EDIBLE_DATA, buf);
-    }
-
-    public static void sendClearEdibleList(ServerPlayerEntity player, List<Identifier> Items) {
-        PacketByteBuf buf = PacketByteBufs.create();
-        buf.writeInt(0);  // 清空CustomEdible
-        buf.writeInt(Items.size());
-        for (Identifier id : Items) {
-            buf.writeIdentifier(id);
-        }
-        ServerPlayNetworking.send(player, ModPackets.UPDATE_CUSTOM_EDIBLE_DATA, buf);
-    }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/CustomEdibleUtils.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/CustomEdibleUtils.java
@@ -1,6 +1,7 @@
 package net.onixary.shapeShifterCurseFabric.util;
 
 import com.mojang.datafixers.util.Pair;
+import io.github.apace100.apoli.component.PowerHolderComponent;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.FoodComponent;
@@ -10,6 +11,7 @@ import net.minecraft.nbt.NbtList;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
+import net.onixary.shapeShifterCurseFabric.additional_power.CustomEdiblePower;
 
 import java.util.HashMap;
 import java.util.List;
@@ -48,6 +50,22 @@ public class CustomEdibleUtils {
             for (Identifier itemId : itemIdList) {
                 customEdible.remove(itemId);
             }
+        }
+    }
+
+    public static void ReloadPlayerCustomEdible(PlayerEntity user) {
+        try {
+            customEdibleMap.computeIfAbsent(user.getUuid(), k -> new HashMap<>()).clear();
+            HashMap<Identifier, FoodComponent> customEdible = customEdibleMap.get(user.getUuid());
+            PowerHolderComponent.getPowers(user, CustomEdiblePower.class).forEach(
+                    customEdiblePower -> {
+                        for (Identifier itemId : customEdiblePower.getItemIdList()) {
+                            customEdible.put(itemId, customEdiblePower.getFoodComponent());
+                        }
+                    }
+            );
+        } catch (Exception e) {
+            // ShapeShifterCurseFabric.LOGGER.error("Reload Player Custom Edible Failed", e);
         }
     }
 


### PR DESCRIPTION
我之前提到的新的缓存可食用物品数据方案 每5s进行更新(减少卡顿 其实如果玩家少可以每tick更新)
解决了Apoil先添加后删除能力的问题 **等新版本发布后再合并** 先放一个稳定版本