### PR TITLE
应该修复了 Issues #207

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/OverrideSkinFirstPersonMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/OverrideSkinFirstPersonMixin.java
@@ -98,10 +98,10 @@ public abstract class OverrideSkinFirstPersonMixin extends LivingEntityRenderer<
             }
             var eRA = (IPlayerEntityMixins) EntityRender;
             var acc = (ModelRootAccessor) EntityRender.getModel();
-            OriginFurModel m = (OriginFurModel) fur.getGeoModel();
-            m.preprocess(origin, EntityRender, eRA, acc, player);
+            OFModel.preprocess(origin, EntityRender, eRA, acc, player);
             GeoBone geoBone = OptionalGeoBone.get();
             fur.setPlayer(player);
+            OFModel.setPlayer(player);
             matrices.push();
             matrices.multiply(new Quaternionf().rotateX(180 * MathHelper.RADIANS_PER_DEGREE));
             matrices.translate(0, -1.51f, 0);

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form_render/OriginFurModel.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form_render/OriginFurModel.java
@@ -151,6 +151,10 @@ public class OriginFurModel extends GeoModel<OriginFurAnimatable> {
             }
         });
     }
+    public void setPlayer(PlayerEntity player) {
+        this.entity = player;
+    }
+
     public void preRender$mixinOnly(PlayerEntity player) {
         this.entity = player;
         this.currentOverride = this.getPredicateResources(player);


### PR DESCRIPTION
应该修复了 Issues #207 (没法测试)
OriginFurModel 在PlayerEntityRenderer里设置的entity 没在FurRenderFeature里面 我最早写手部渲染时从`FurRenderFeature`CV来的 没有给OriginFurModel设置玩家

在单人游戏呈现的特征是 在玩家进入游戏直到启动第三人称(渲染玩家自己)后才能在第一人称下看到自己的自定义颜色 我之前测试自定义颜色时没发现