### PR TITLE
Update CustomEdibleItemMixin.java to fix bug when foxes eat berries

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/CustomEdibleItemMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/CustomEdibleItemMixin.java
@@ -118,9 +118,8 @@ public abstract class CustomEdibleItemMixin {
     private boolean finishUsing$isFood(boolean original, ItemStack stack, World world, LivingEntity user) {
         if (user instanceof PlayerEntity) {
             return getPowerFoodComponent((PlayerEntity) user, stack) != null || original;
-        } else {
+        } 
         return original;
-        }
     }
 
 }


### PR DESCRIPTION
When foxes ate berries, they would crash the game since the code tried to cast the entity as a player, which caused issues. This change only runs the code if the entity eating the berry is a player.