### PR TITLE
修复 #219

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/integration/AzureLib_AzProvider.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/integration/AzureLib_AzProvider.java
@@ -1,0 +1,22 @@
+package net.onixary.shapeShifterCurseFabric.mixin.integration;
+
+import mod.azure.azurelib.rewrite.animation.AzAnimator;
+import mod.azure.azurelib.rewrite.render.AzProvider;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.UUID;
+
+@Mixin(value = AzProvider.class, remap = false)
+public class AzureLib_AzProvider<T> {
+    @Inject(method = "provideAnimator", at = @At("HEAD"))
+    public void provideAnimator(T animatable, CallbackInfoReturnable<AzAnimator<T>> cir) {
+        // 真正的Bug位置为 ItemStackMixin_AzItemAnimatorCache.getAnimatorOrNull 但是我不会给Mixin里面注入
+        if (animatable instanceof ItemStack itemStack && !itemStack.getOrCreateNbt().contains("az_id")) {
+            itemStack.getOrCreateNbt().putUuid("az_id", UUID.randomUUID());
+        }
+    }
+}

--- a/src/main/resources/shape-shifter-curse.mixins.json
+++ b/src/main/resources/shape-shifter-curse.mixins.json
@@ -38,7 +38,8 @@
     "projectile.PotionEntityMixin",
     "LoginMixin",
     "SneakEdgeCheckMixin",
-    "integration.AppleSkin"
+    "integration.AppleSkin",
+    "integration.AzureLib_AzProvider"
   ],
   "client": [
     "InventoryScreenMixin",


### PR DESCRIPTION
AzureLib 的神奇代码 报错的位置在`UUID uuid = self.getOrCreateNbt().getUuid("az_id");` 问题非常显而易见
但是我不会给Mixin里的函数注入
```java
public @Nullable AzAnimator<ItemStack> getAnimatorOrNull() {
        ItemStack self = (ItemStack)AzureLibUtil.self(this);
        if (!AzIdentityRegistry.hasIdentity(self.getItem())) {
            return null;
        } else {
            UUID uuid = self.getOrCreateNbt().getUuid("az_id");
            if (!self.getOrCreateNbt().contains("az_id")) {
                self.getOrCreateNbt().putUuid("az_id", UUID.randomUUID());
            }

            return AzIdentifiableItemStackAnimatorCache.getInstance().getOrNull(uuid);
        }
    }
```

比较奇怪的是3.0.19使用相同代码但不会报错 估计是多个bug共同导致的能工作现象

**我建议内嵌AzureLib 以避免一些神奇的Bug**