### PR TITLE
狼形态组件 实现虚拟不死图腾Power

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalPowers.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalPowers.java
@@ -47,6 +47,7 @@ public class AdditionalPowers {
         register(ConditionScalePower.createFactory());
         register(SneakingJumpClashPower.createFactory());
         register(InWaterSpeedModifierPower.createFactory());
+        register(VirtualTotemPower.createFactory());
     }
 
     public static PowerFactory<?> register(PowerFactory<?> powerFactory) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/VirtualTotemPower.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/VirtualTotemPower.java
@@ -1,0 +1,124 @@
+package net.onixary.shapeShifterCurseFabric.additional_power;
+
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.CooldownPower;
+import io.github.apace100.apoli.power.PowerType;
+import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.apoli.util.HudRender;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.particle.ParticleTypes;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.sound.SoundEvents;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+import net.onixary.shapeShifterCurseFabric.networking.ModPacketsS2CServer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+// 由于网络同步问题 仅支持玩家实体 非玩家实体不会触发客户端效果
+public class VirtualTotemPower extends CooldownPower {
+    public int virtualTotemType;  // 用于播放动画
+    public ItemStack totemStack;  // 当VirtualTotemPowerID == 0时 模拟原版不死图腾
+    private final List<Consumer<Entity>> entityAction;
+    private final int totemHealth;
+    private final List<StatusEffectInstance> totemStatusEffects;
+
+    public VirtualTotemPower(PowerType<?> type, LivingEntity entity, SerializableData.Instance data) {
+        super(type, entity, data.get("cooldown"), data.get("hud_render"));
+        this.virtualTotemType = data.get("virtual_totem_type");
+        this.totemStack = data.get("totem_stack");
+        this.entityAction = data.get("entity_actions");
+        this.totemHealth = data.get("totem_health");
+        this.totemStatusEffects = data.get("totem_status_effects");
+    }
+
+    // 应该不用同步配置 Apoli应该会把SerializableData.Instance同步到客户端
+    public NbtElement toTag() {
+        return super.toTag();
+    }
+
+    public void fromTag(NbtElement tag) {
+        super.fromTag(tag);
+    }
+
+    public void use() {
+        if (this.entity == null) {
+            ShapeShifterCurseFabric.LOGGER.error("VirtualTotemPower: entity is null");
+            return;
+        }
+        this.entity.setHealth(this.totemHealth);
+        if (this.totemStatusEffects != null) {
+            for (StatusEffectInstance statusEffectInstance : this.totemStatusEffects) {
+                this.entity.addStatusEffect(statusEffectInstance);
+            }
+        }
+        if (this.entityAction != null) {
+            for (Consumer<Entity> consumer : this.entityAction) {
+                consumer.accept(this.entity);
+            }
+        }
+        if (!this.entity.getWorld().isClient && this.entity instanceof ServerPlayerEntity serverPlayerEntity) {
+            ModPacketsS2CServer.sendActiveVirtualTotem(serverPlayerEntity, this);
+        }
+        super.use();
+    }
+
+    public @Nullable PacketByteBuf create_packet_byte_buf() {
+        if (this.entity instanceof ServerPlayerEntity serverPlayerEntity) {
+            PacketByteBuf packetByteBuf = PacketByteBufs.create();
+            packetByteBuf.writeUuid(serverPlayerEntity.getUuid());
+            packetByteBuf.writeInt(this.virtualTotemType);
+            packetByteBuf.writeItemStack(this.totemStack);
+            return packetByteBuf;
+        }
+        return null;
+    }
+
+    public static void process_virtual_totem_type(@NotNull PlayerEntity entity, int virtualTotemType, @Nullable ItemStack totemStack) {
+        switch (virtualTotemType) {
+            case 0:
+                MinecraftClient client = MinecraftClient.getInstance();
+                if (totemStack == null) {
+                    totemStack = new ItemStack(Items.TOTEM_OF_UNDYING, 1);
+                }
+                if (client.world != null) {
+                    client.particleManager.addEmitter(entity, ParticleTypes.TOTEM_OF_UNDYING, 30);
+                    client.world.playSound(entity.getX(), entity.getY(), entity.getZ(), SoundEvents.ITEM_TOTEM_USE, entity.getSoundCategory(), 1.0f, 1.0f, false);
+                    if (entity != client.player) break;
+                    client.gameRenderer.showFloatingItem(totemStack);
+                }
+                break;
+            default:
+                ShapeShifterCurseFabric.LOGGER.error("VirtualTotemPower: unknown virtualTotemType: {}", virtualTotemType);
+        }
+    }
+
+    public static PowerFactory<?> createFactory() {
+        return new PowerFactory<>(
+                ShapeShifterCurseFabric.identifier("virtual_totem"),
+                new SerializableData()
+                        .add("virtual_totem_type", SerializableDataTypes.INT, 0)  // 默认0
+                        .add("totem_stack", SerializableDataTypes.ITEM_STACK, new ItemStack(Items.TOTEM_OF_UNDYING, 1))
+                        .add("entity_actions", ApoliDataTypes.ENTITY_ACTIONS, null)
+                        .add("totem_health", SerializableDataTypes.INT, 1)  // 默认1
+                        .add("totem_status_effects", SerializableDataTypes.STATUS_EFFECT_INSTANCES, null)
+                        .add("cooldown", SerializableDataTypes.INT, 1200)  // 默认1分钟
+                        .add("hud_render", ApoliDataTypes.HUD_RENDER, HudRender.DONT_RENDER),
+                data -> (powerType, entity) -> new VirtualTotemPower(powerType, entity, data)
+        ).allowCondition();
+    }
+
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/VirtualTotemMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/VirtualTotemMixin.java
@@ -1,0 +1,37 @@
+package net.onixary.shapeShifterCurseFabric.mixin;
+
+import io.github.apace100.apoli.component.PowerHolderComponent;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.registry.tag.DamageTypeTags;
+import net.onixary.shapeShifterCurseFabric.additional_power.VirtualTotemPower;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+@Mixin(value = LivingEntity.class, priority = 10)
+public class VirtualTotemMixin {
+    @Inject(method = "tryUseTotem", at = @At("RETURN"), cancellable = true)
+    public void tryUseTotem(DamageSource source, CallbackInfoReturnable<Boolean> cir) {
+        if (source.isIn(DamageTypeTags.BYPASSES_INVULNERABILITY)) {
+            return;
+        }
+        if (!cir.getReturnValue()) {
+            if ((Object)this instanceof LivingEntity livingEntity) {
+                List<VirtualTotemPower> virtualTotemPowerList = PowerHolderComponent.getPowers(livingEntity, VirtualTotemPower.class);
+                if (virtualTotemPowerList.isEmpty()) {
+                    return;
+                }
+                for (VirtualTotemPower virtualTotemPower : virtualTotemPowerList) {
+                    if (virtualTotemPower.canUse()) {
+                        virtualTotemPower.use();
+                        cir.setReturnValue(true);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPackets.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPackets.java
@@ -47,4 +47,6 @@ public class ModPackets {
 
     public static final Identifier LOGIN_PACKET = new Identifier(ShapeShifterCurseFabric.MOD_ID, "login_packet");  // 我暂时没找到玩家进入服务去时的Hook，所以暂时由服务器询问来代替
     public static final Identifier UPDATE_CUSTOM_SETTING = new Identifier(ShapeShifterCurseFabric.MOD_ID, "update_custom_setting");
+
+    public static final Identifier ACTIVE_VIRTUAL_TOTEM = new Identifier(ShapeShifterCurseFabric.MOD_ID, "active_virtual_totem");
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2CServer.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2CServer.java
@@ -11,6 +11,7 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+import net.onixary.shapeShifterCurseFabric.additional_power.VirtualTotemPower;
 import net.onixary.shapeShifterCurseFabric.player_form.PlayerFormDynamic;
 import net.onixary.shapeShifterCurseFabric.player_form.RegPlayerForms;
 import net.onixary.shapeShifterCurseFabric.status_effects.attachment.PlayerEffectAttachment;
@@ -173,6 +174,17 @@ public class ModPacketsS2CServer {
     public static void sendPlayerLogin(ServerPlayerEntity player) {
         PacketByteBuf buf = PacketByteBufs.create();
         ServerPlayNetworking.send(player, ModPackets.LOGIN_PACKET, buf);
+    }
+
+    public static void sendActiveVirtualTotem(ServerPlayerEntity player, VirtualTotemPower virtualTotemPower) {
+        player.getServerWorld().getPlayers(near_player -> near_player.squaredDistanceTo(player) <= 64 * 64).forEach(
+                nearPlayer -> {
+                    PacketByteBuf buf = virtualTotemPower.create_packet_byte_buf();
+                    if (buf != null) {
+                        ServerPlayNetworking.send(nearPlayer, ModPackets.ACTIVE_VIRTUAL_TOTEM, buf);
+                    }
+                }
+        );
     }
 
 }

--- a/src/main/resources/shape-shifter-curse.mixins.json
+++ b/src/main/resources/shape-shifter-curse.mixins.json
@@ -42,7 +42,8 @@
     "mob.VillagerHostilesSensorMixin",
     "mob.WitchEntityMixin",
     "projectile.EntitySnowballTransformMixin",
-    "projectile.PotionEntityMixin"
+    "projectile.PotionEntityMixin",
+    "VirtualTotemMixin"
   ],
   "client": [
     "AdjustItemHoldFeatureRendererMixin",


### PR DESCRIPTION
测试PowerJson:
```json
{
  "type": "shape-shifter-curse:virtual_totem",
  "virtual_totem_type": 0,
  "totem_stack": {
    "item": "minecraft:stick",
    "count": 1
  },
  "entity_actions": [],
  "totem_health": 5,
  "totem_status_effects": [
    {
      "effect": "minecraft:strength",
      "duration": 200,
      "amplifier": 1,
      "show_particles": false,
      "show_icon": true
    }
  ],
  "cooldown": 200,
  "hud_render": {
    "should_render": false
  }
}
```
测试时要用真正的伤害 比如药水效果 kill不会生效virtual_totem(仿真正的不死图腾)
`virtual_totem_type` 在 `VirtualTotemPower.process_virtual_totem_type`里面处理 默认0为用totem_stack的不死图腾

没有大幅修改运行中代码(仅一个Mixin) 在不使用此功能应该不会出Bug(防止影响可能(希望不会)的1.0.77版本)