### PR TITLE
狼形态组件 实现修改瞬间治疗和瞬间伤害效果Power

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalPowers.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalPowers.java
@@ -48,6 +48,8 @@ public class AdditionalPowers {
         register(SneakingJumpClashPower.createFactory());
         register(InWaterSpeedModifierPower.createFactory());
         register(VirtualTotemPower.createFactory());
+        register(ModifyInstantHealthPower.createFactory());
+        register(ModifyInstantDamagePower.createFactory());
     }
 
     public static PowerFactory<?> register(PowerFactory<?> powerFactory) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/ModifyInstantDamagePower.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/ModifyInstantDamagePower.java
@@ -1,0 +1,31 @@
+package net.onixary.shapeShifterCurseFabric.additional_power;
+
+import io.github.apace100.apoli.power.Power;
+import io.github.apace100.apoli.power.PowerType;
+import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.LivingEntity;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+
+public class ModifyInstantDamagePower extends Power {
+    private final float MulScale;
+
+    public ModifyInstantDamagePower(PowerType<?> type, LivingEntity entity, float MulScale) {
+        super(type, entity);
+        this.MulScale = MulScale;
+    }
+
+    public float ApplyMulScale(float orig_value) {
+        return orig_value * MulScale;
+    }
+
+    public static PowerFactory<?> createFactory() {
+        return new PowerFactory<>(
+                ShapeShifterCurseFabric.identifier("modify_instant_damage_scale"),
+                new SerializableData()
+                        .add("scale", SerializableDataTypes.FLOAT, 1.0f),
+                data -> (powerType, entity) -> new ModifyInstantDamagePower(powerType, entity, data.get("scale"))
+        ).allowCondition();
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/ModifyInstantHealthPower.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/ModifyInstantHealthPower.java
@@ -1,0 +1,31 @@
+package net.onixary.shapeShifterCurseFabric.additional_power;
+
+import io.github.apace100.apoli.power.Power;
+import io.github.apace100.apoli.power.PowerType;
+import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.LivingEntity;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+
+public class ModifyInstantHealthPower extends Power {
+    private final float MulScale;
+
+    public ModifyInstantHealthPower(PowerType<?> type, LivingEntity entity, float MulScale) {
+        super(type, entity);
+        this.MulScale = MulScale;
+    }
+
+    public float ApplyMulScale(float orig_value) {
+        return orig_value * MulScale;
+    }
+
+    public static PowerFactory<?> createFactory() {
+        return new PowerFactory<>(
+                ShapeShifterCurseFabric.identifier("modify_instant_health_scale"),
+                new SerializableData()
+                        .add("scale", SerializableDataTypes.FLOAT, 1.0f),
+                data -> (powerType, entity) -> new ModifyInstantHealthPower(powerType, entity, data.get("scale"))
+        ).allowCondition();
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerDataSaverMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerDataSaverMixin.java
@@ -11,6 +11,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+// TODO 重构EffectManager时记得删掉这个Mixin
+// 其实可以使用 Cardinal-Components-Api 反正之后要删除掉 就不改了
 @Mixin(PlayerEntity.class)
 public abstract class PlayerDataSaverMixin {
 

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerTickMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerTickMixin.java
@@ -9,6 +9,9 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+
+// TODO 重构EffectManager时记得删掉这个Mixin
+// 其实这个可以挂在事件上
 @Mixin(PlayerEntity.class)
 public class PlayerTickMixin {
 

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/StatusEffectMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/StatusEffectMixin.java
@@ -1,34 +1,97 @@
-// StatusEffectMixin.java
 package net.onixary.shapeShifterCurseFabric.mixin;
 
+import io.github.apace100.apoli.component.PowerHolderComponent;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.effect.StatusEffectInstance;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.onixary.shapeShifterCurseFabric.status_effects.BaseTransformativeStatusEffect;
-import net.onixary.shapeShifterCurseFabric.status_effects.attachment.EffectManager;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.entity.effect.StatusEffects;
+import net.onixary.shapeShifterCurseFabric.additional_power.ModifyInstantDamagePower;
+import net.onixary.shapeShifterCurseFabric.additional_power.ModifyInstantHealthPower;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(LivingEntity.class)
+import java.util.List;
+
+@Mixin(StatusEffect.class)
 public class StatusEffectMixin {
-
-    @Inject(method = "onStatusEffectRemoved", at = @At("HEAD"))
-    private void onStatusEffectRemoved(StatusEffectInstance effect, CallbackInfo ci) {
-        if ((Object) this instanceof ServerPlayerEntity player) {
-            // 检查移除的是否是变形效果
-            if (effect.getEffectType() instanceof BaseTransformativeStatusEffect) {
-                player.getServer().execute(() -> {
-                    // 延迟检查，确保效果确实被移除
-                    boolean stillHasTransformEffect = player.getStatusEffects().stream()
-                            .anyMatch(e -> e.getEffectType() instanceof BaseTransformativeStatusEffect);
-
-                    if (!stillHasTransformEffect) {
-                        EffectManager.safeResetAttachment(player);
-                    }
-                });
+    @Unique
+    private boolean applyEffect(StatusEffect realThis, LivingEntity entity, @Nullable Entity source, @Nullable Entity attacker, int amplifier, double proximity, boolean IsInstantEffect) {
+        // 返回值是是否覆盖了原版效果 如果返回false 还会执行原版效果
+        int EffectValue = 4;
+        float FinalValue;
+        if (realThis == StatusEffects.INSTANT_HEALTH) {
+            List<ModifyInstantHealthPower> PowerList = PowerHolderComponent.getPowers(entity, ModifyInstantHealthPower.class);
+            if (PowerList.isEmpty()) {
+                return false;
             }
+            if (entity.isUndead()) {
+                EffectValue = -6;
+            }
+            FinalValue = (float) (EffectValue << amplifier);
+            if (IsInstantEffect) {
+                FinalValue = (float) (proximity * FinalValue + 0.5);
+            }
+            for (ModifyInstantHealthPower power : PowerList) {
+                FinalValue = power.ApplyMulScale(FinalValue);
+            }
+            applyEffectDamage(entity, source, attacker, IsInstantEffect, FinalValue);
+            return true;
+        }
+        if (realThis == StatusEffects.INSTANT_DAMAGE)  {
+            List<ModifyInstantDamagePower> PowerList = PowerHolderComponent.getPowers(entity, ModifyInstantDamagePower.class);
+            if (PowerList.isEmpty()) {
+                return false;
+            }
+            if (!entity.isUndead()) {
+                EffectValue = -6;
+            }
+            FinalValue = (float) (EffectValue << amplifier);
+            if (IsInstantEffect) {
+                FinalValue = (float) (proximity * FinalValue + 0.5);
+            }
+            for (ModifyInstantDamagePower power : PowerList) {
+                FinalValue = power.ApplyMulScale(FinalValue);
+            }
+            applyEffectDamage(entity, source, attacker, IsInstantEffect, FinalValue);
+            return true;
+        }
+        return false;
+    }
+
+    @Unique
+    private void applyEffectDamage(LivingEntity entity, @Nullable Entity source, @Nullable Entity attacker, boolean IsInstantEffect, float finalValue) {
+        if (finalValue == 0.0f) {
+            return;
+        }
+        else if (finalValue > 0.0f) {
+            entity.heal(finalValue);
+        } else {
+            DamageSource damageSource = entity.getDamageSources().magic();
+            if (IsInstantEffect && (source != null && attacker != null)) {
+                damageSource = entity.getDamageSources().indirectMagic(source, attacker);
+            }
+            entity.damage(damageSource, -finalValue);
+        }
+    }
+
+    @Inject(method = "applyUpdateEffect", at = @At("HEAD"), cancellable = true)
+    private void applyUpdateEffect(LivingEntity entity, int amplifier, CallbackInfo ci) {
+        StatusEffect realThis = (StatusEffect)(Object)this;
+        if (applyEffect(realThis, entity, null, null, amplifier, 0.0, false)) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "applyInstantEffect", at = @At("HEAD"), cancellable = true)
+    private void applyInstantEffect(Entity source, Entity attacker, LivingEntity target, int amplifier, double proximity, CallbackInfo ci) {
+        StatusEffect realThis = (StatusEffect)(Object)this;
+        if (applyEffect(realThis, target, source, attacker, amplifier, proximity, true)) {
+            ci.cancel();
         }
     }
 }


### PR DESCRIPTION
测试PowerJson:
反转玩家受到的瞬间治疗/伤害效果(原版伤害为6治疗为4)
```json
{
  "type": "shape-shifter-curse:modify_instant_damage_scale",
  "scale": -0.67
}
```

```json
{
  "type": "shape-shifter-curse:modify_instant_health_scale",
  "scale": -1.5
}
```

Power兼容LivingEntity 设置为0即可禁用瞬间治疗/伤害的效果