### PR TITLE
临时修复#247

### DIFF
--- a/src/main/resources/assets/shape-shifter-curse/models/item/book_of_shape_shifter.json
+++ b/src/main/resources/assets/shape-shifter-curse/models/item/book_of_shape_shifter.json
@@ -102,8 +102,8 @@
 			"translation": [0, 2, 0]
 		},
 		"ground": {
-			"rotation": [90, 0, 0],
-			"translation": [0, -2.5, 4]
+			"rotation": [91, 0, 0],
+			"translation": [0, 3.5, 2.75]
 		},
 		"gui": {
 			"rotation": [60, -45, 0],

--- a/src/main/resources/assets/shape-shifter-curse/models/item/morphscale_core.json
+++ b/src/main/resources/assets/shape-shifter-curse/models/item/morphscale_core.json
@@ -174,7 +174,8 @@
 			"scale": [1.5, 1, 1.5]
 		},
 		"ground": {
-			"translation": [0, 2, 0],
+			"rotation": [90, 0, 0],
+			"translation": [0, 1.75, 4.25],
 			"scale": [1.5, 1, 1.5]
 		},
 		"gui": {


### PR DESCRIPTION
我把幻形者之书和塑形核心的ground改为thirdperson_righthand 现在不会卡在脑袋里了
如果要保留原先的ground效果 我也可以给这两个物品拓展一个接口 让嘴部渲染走其他的ModelTransformationMode