### PR TITLE
modify_food_heal中的food_timer_add_amount支持浮点数 现在可以更精准控制恢复速率了

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/ModifyFoodHealPower.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/ModifyFoodHealPower.java
@@ -13,12 +13,13 @@ public class ModifyFoodHealPower extends Power {
     // 其实这个可以用一种抽象的方式来实现 比如SelfActionPower检查是否可以回血 如果可以就扣饱食度回血
 
     private int LastModifyFoodHealTimer = 0;
-    private final int FoodTimerAddAmount;
+    private float RemainFoodHealTime = 0.0f;
+    private final float FoodTimerAddAmount;
     private final int ModifyFoodTimerTickRate;
 
     public ModifyFoodHealPower(PowerType<?> type, LivingEntity entity, SerializableData.Instance data) {
         super(type, entity);
-        this.FoodTimerAddAmount = data.getInt("food_timer_add_amount");
+        this.FoodTimerAddAmount = data.getFloat("food_timer_add_amount");
         this.ModifyFoodTimerTickRate = data.getInt("modify_food_timer_tick_rate");
     }
 
@@ -26,7 +27,19 @@ public class ModifyFoodHealPower extends Power {
         this.LastModifyFoodHealTimer++;
         if (this.LastModifyFoodHealTimer >= this.ModifyFoodTimerTickRate) {
             this.LastModifyFoodHealTimer = 0;
-            return FoodTick + this.FoodTimerAddAmount;
+            this.RemainFoodHealTime += this.FoodTimerAddAmount;
+            return this.ApplyFoodTick(FoodTick);
+        } else {
+            return FoodTick;
+        }
+    }
+
+    public int ApplyFoodTick(int FoodTick) {
+        int FoodTickerAmount = (int) this.RemainFoodHealTime;
+        if (FoodTickerAmount != 0) {
+            // ShapeShifterCurseFabric.LOGGER.info("FoodTickerAmount: {}, RemainFoodHealTime: {}", FoodTickerAmount, this.RemainFoodHealTime);
+            this.RemainFoodHealTime -= FoodTickerAmount;
+            return Math.max(FoodTick + FoodTickerAmount, 0);
         } else {
             return FoodTick;
         }
@@ -40,7 +53,7 @@ public class ModifyFoodHealPower extends Power {
         return new PowerFactory<>(
                 ShapeShifterCurseFabric.identifier("modify_food_heal"),
                 new SerializableData()
-                        .add("food_timer_add_amount", SerializableDataTypes.INT, 1)
+                        .add("food_timer_add_amount", SerializableDataTypes.FLOAT, 1.0f)
                         .add("modify_food_timer_tick_rate", SerializableDataTypes.INT, 20),
                 data -> (powerType, entity) -> new ModifyFoodHealPower(powerType, entity, data)
         ).allowCondition();

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/TransformativeEntitySpawning.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/TransformativeEntitySpawning.java
@@ -81,10 +81,13 @@ public class TransformativeEntitySpawning {
                 BiomeSelectors.includeByKey(BiomeKeys.DESERT),
                 SpawnGroup.CREATURE,
                 ShapeShifterCurseFabric.T_WOLF,
-                2,  // 1/4 兔子的权重
+                2,  // 1/2 兔子的权重
                 2,
                 3
         );
         // 用数据包的方式来让T_WOLF生成在沙漠神殿 可能会与修改结构的Mod冲突
+        // Weight: 20
+        // MinGroupSize = 3
+        // MaxGroupSize = 5
     }
 }


### PR DESCRIPTION
modify_food_heal中的food_timer_add_amount支持浮点数 现在可以更精准控制恢复速率了 (可以调比如-1%的恢复速率 虽然没什么用) 不过在modify_food_timer_tick_rate<10时还是使用整数 运算速度更快 顺便修了一下可能导致foodTickTimer变成负数的问题

改了一下生成权重的注释 