### PR TITLE
一个小修复

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/minion/MinionBase.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/minion/MinionBase.java
@@ -54,7 +54,7 @@ public abstract class MinionBase extends TameableEntity implements IMinion<Minio
 
     @Override
     public World method_48926() {
-        return this.getWorld();
+        return super.getWorld();
     }
 
     public double getMinionDisappearRange() {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/minion/mobs/AnubisWolfMinionEntity.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/minion/mobs/AnubisWolfMinionEntity.java
@@ -295,7 +295,7 @@ public class AnubisWolfMinionEntity extends WolfEntity implements IMinion<Anubis
 
     @Override
     public World method_48926() {
-        return this.getWorld();
+        return super.getWorld();
     }
 
     class WolfMinionEscapeDangerGoal extends EscapeDangerGoal {


### PR DESCRIPTION
修互联版本时发现的Bug(Fabric版本不会出现问题 因为是Yarn的Bug 在Forge上会崩溃) 但是从逻辑上会导致循环调用 还是修一下吧
具体是getWorld在Yarn中为method_48926(没映射全 Tameable中的getWorld没映射) 由于要实现Tameable接口 所以要实现method_48926 最早使用this.getWorld 但在Forge上会导致 this.getWorld -> this.getWorld -> ......

互联版本更新到1.8.0版本了 尝试把2.9.2版本的Apoli内嵌结果启动不了 真神奇的加载问题