### PR TITLE
忘了给ANUBIS_WOLF_0添加进FormRandomSelector

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/FormRandomSelector.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/FormRandomSelector.java
@@ -13,7 +13,8 @@ public class FormRandomSelector {
             RegPlayerForms.FAMILIAR_FOX_0,
             RegPlayerForms.BAT_0,
             RegPlayerForms.AXOLOTL_0,
-            RegPlayerForms.OCELOT_0
+            RegPlayerForms.OCELOT_0,
+            RegPlayerForms.ANUBIS_WOLF_0
     );
 
     public static PlayerFormBase getRandomFormWithIndexZero() {


### PR DESCRIPTION
之后可以考虑把ALPHA_0这些形态给删了 反正现在可以直接由数据包加 删完后FormRandomSelector就直接筛注册表PlayerFormPhase.PHASE_0 不容易漏形态