### PR TITLE
修复新动画系统Bug

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/v3/AnimSystem.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/v3/AnimSystem.java
@@ -61,6 +61,15 @@ public class AnimSystem {
         this.data = new AnimSystemData(player);
         this.PreProcessControllers = new ArrayList<>();
         this.initPreProcessControllers();
+        this.registerAllPreProcessControllers();
+    }
+
+    public void registerAllPreProcessControllers() {
+        for (AbstractAnimStateController controller : this.PreProcessControllers) {
+            if (!controller.isRegistered(this.player, this.data)) {
+                controller.registerAnim(this.player, this.data);
+            }
+        }
     }
 
     public void initPreProcessControllers() {


### PR DESCRIPTION
测试赞助者分支时发现的Bug 忘了给PreProcessControllers注册了 导致不会播放变身动画(一直返回null)

刚才把PR #281 中的赞助者测试了一下 单人流程应该是没有问题(开了个档通了一次关) 还得测试一下服务器稳定性