### PR TITLE
修复修改形态后trinketPower失效的Bug

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/ability/FormAbilityManager.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/ability/FormAbilityManager.java
@@ -87,7 +87,6 @@ public class FormAbilityManager {
             // 一般是没有对应的origin
             ShapeShifterCurseFabric.LOGGER.error("Failed to apply origin extra power: ", e);
         }
-        TrinketUtils.ReApplyAccessoryPowerOnPlayerFormChange(player);
         //applyPower(player, config.getPowerId());
         // EffectManager.clearTransformativeEffect(player);
         // 清空Status 如果新形态无法获得变形效果
@@ -97,6 +96,8 @@ public class FormAbilityManager {
         RegPlayerFormComponent.PLAYER_FORM.sync(player);
         // 存储
         FormAbilityManager.saveForm(player);
+
+        TrinketUtils.ReApplyAccessoryPowerOnPlayerFormChange(player);
 
         // 添加网络同步：通知客户端形态已变化
         if (!player.getWorld().isClient() && player instanceof ServerPlayerEntity serverPlayer) {


### PR DESCRIPTION
刚才修的时候发现一个Bug 如果删除的是关于装备穿戴的Power会导致退出重进时把对应装备弹出来的Bug 应该是由于是在applyOrigins后再删除 玩家其实会获得<5Tick(再大就进不去游戏了 除非用IDEA的断点功能)的被删除Power 所以不要给一些特殊Power使用饰品Power删除功能