### PR TITLE
完成猫猫哈气功能

### DIFF
--- a/custom_form_pack_example/example_form_datapack/data/example_namespace/origins/form_example.json
+++ b/custom_form_pack_example/example_form_datapack/data/example_namespace/origins/form_example.json
@@ -13,7 +13,8 @@
     "example_namespace:custom_eat_amethyst_shard",
     "example_namespace:custom_night_vision",
     "example_namespace:familiar_fox_mana",
-    "example_namespace:sneak_strength"
+    "example_namespace:sneak_strength",
+    "example_namespace:hiss_phantom"
   ],
   "icon": {
     "item": "minecraft:player_head"

--- a/custom_form_pack_example/example_form_datapack/data/example_namespace/powers/hiss_phantom.json
+++ b/custom_form_pack_example/example_form_datapack/data/example_namespace/powers/hiss_phantom.json
@@ -1,0 +1,10 @@
+{
+  "type": "shape-shifter-curse:hiss_phantom_power",
+  "on_hiss_phantom_action": {
+    "type": "origins:actor_action",
+    "action": {
+      "type": "origins:play_sound",
+      "sound": "minecraft:entity.cat.hiss"
+    }
+  }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalPowers.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalPowers.java
@@ -66,6 +66,7 @@ public class AdditionalPowers {
         register(ManaTypePower.createFactory());
         register(ManaAttributePower.createFactory());
         register(ConditionedManaAttributePower.createFactory());
+        register(HissPhantomPower.createFactory());
     }
 
     public static PowerFactory<?> register(PowerFactory<?> powerFactory) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/HissPhantomPower.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/HissPhantomPower.java
@@ -1,0 +1,40 @@
+package net.onixary.shapeShifterCurseFabric.additional_power;
+
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.Power;
+import io.github.apace100.apoli.power.PowerType;
+import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.apoli.power.factory.action.ActionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.mob.PhantomEntity;
+import net.minecraft.util.Pair;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
+
+public class HissPhantomPower extends Power {
+    private final @Nullable Consumer<Pair<Entity, Entity>> onHissPhantomAction;
+
+    public HissPhantomPower(PowerType<?> type, LivingEntity entity, SerializableData.Instance data) {
+        super(type, entity);
+        this.onHissPhantomAction = data.get("on_hiss_phantom_action");
+    }
+
+    public void invokeAction(LivingEntity powerOwner, PhantomEntity phantom) {
+        if (this.onHissPhantomAction != null) {
+            this.onHissPhantomAction.accept(new Pair<>(powerOwner, phantom));
+        }
+    }
+
+    public static PowerFactory<?> createFactory() {
+        return new PowerFactory<>(
+                ShapeShifterCurseFabric.identifier("hiss_phantom_power"),
+                new SerializableData()
+                        .add("on_hiss_phantom_action", ApoliDataTypes.BIENTITY_ACTION, null),
+                data -> (type, entity) -> new HissPhantomPower(type, entity, data)
+        ).allowCondition();
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/HissPhantomMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/HissPhantomMixin.java
@@ -1,0 +1,35 @@
+package net.onixary.shapeShifterCurseFabric.mixin;
+
+import io.github.apace100.apoli.component.PowerHolderComponent;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.mob.PhantomEntity;
+import net.onixary.shapeShifterCurseFabric.additional_power.HissPhantomPower;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(targets = "net.minecraft.entity.mob.PhantomEntity$SwoopMovementGoal")
+public class HissPhantomMixin {
+    @Unique
+    private PhantomEntity phantomEntity;
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void setPhantomEntity(PhantomEntity phantomEntity, CallbackInfo ci) {
+        this.phantomEntity = phantomEntity;
+    }
+
+    @Inject(method = "shouldContinue", at = @At("RETURN"), cancellable = true)
+    private void shouldContinue(CallbackInfoReturnable<Boolean> cir) {
+        LivingEntity livingEntity = phantomEntity.getTarget();
+        if (cir.getReturnValueZ()) {
+            HissPhantomPower power = PowerHolderComponent.getPowers(livingEntity, HissPhantomPower.class).stream().findFirst().orElse(null);
+            if (power != null && power.isActive()) {
+                power.invokeAction(livingEntity, phantomEntity);
+                cir.setReturnValue(false);
+            }
+        }
+    }
+}

--- a/src/main/resources/shape-shifter-curse.mixins.json
+++ b/src/main/resources/shape-shifter-curse.mixins.json
@@ -55,7 +55,8 @@
     "ArrowEntityMixin",
     "LingeringPotionItemMixin",
     "TippedArrowItemMixin",
-    "BrewingRecipeRegistryMixin"
+    "BrewingRecipeRegistryMixin",
+    "HissPhantomMixin"
   ],
   "client": [
     "AdjustItemHoldFeatureRendererMixin",


### PR DESCRIPTION
具体Power使用方法看数据包样例

具体逻辑和猫哈气不同 猫有哈气距离保护一圈玩家 新逻辑仅保护有Power的玩家(无限距离 只要幻翼的Target为有Power的玩家均会触发)

我看`digestion_fiber_ball`饰品解除了豹猫只能吃生肉的Power 那么可以把生肉加成削一下 我之前为了让豹猫不会在吃的上面太难受就把值填的高了一些