### PR TITLE
添加启用形态随机叫声选项 受伤和特殊叫声不受影响

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalEntityConditions.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalEntityConditions.java
@@ -11,6 +11,8 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.registry.Registry;
 import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
 import net.onixary.shapeShifterCurseFabric.mana.ManaUtils;
+import net.onixary.shapeShifterCurseFabric.player_form.skin.PlayerSkinComponent;
+import net.onixary.shapeShifterCurseFabric.player_form.skin.RegPlayerSkinComponent;
 import net.onixary.shapeShifterCurseFabric.util.ClientUtils;
 
 public class AdditionalEntityConditions {
@@ -27,6 +29,17 @@ public class AdditionalEntityConditions {
                 (data, e) -> {
                     if (FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT) {
                         return ClientUtils.CanDisplayGUI();
+                    }
+                    return true;
+                }
+        ));
+        register(new ConditionFactory<Entity>(
+                ShapeShifterCurseFabric.identifier("enable_random_sound"),
+                new SerializableData(),
+                (data, e) -> {
+                    if (e instanceof PlayerEntity player) {
+                        PlayerSkinComponent skinComponent = RegPlayerSkinComponent.SKIN_SETTINGS.get(e);
+                        return skinComponent.isEnableFormRandomSound();
                     }
                     return true;
                 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/config/PlayerCustomConfig.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/config/PlayerCustomConfig.java
@@ -47,4 +47,7 @@ public class PlayerCustomConfig implements ConfigData {
     public boolean accent1GreyReverse = false;
     @Comment("Accent color 2 reverse grey scale mul. Default: false")
     public boolean accent2GreyReverse = false;
+
+    @Comment("Enable form random sound, Default: true")
+    public boolean enable_form_random_sound = true;
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsC2S.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsC2S.java
@@ -139,12 +139,14 @@ public class ModPacketsC2S {
         boolean primaryGreyReverse = packetByteBuf.readBoolean();
         boolean accent1GreyReverse = packetByteBuf.readBoolean();
         boolean accent2GreyReverse = packetByteBuf.readBoolean();
+        boolean enableFormRandomSound = packetByteBuf.readBoolean();
         minecraftServer.execute(() -> {
             try {
                 PlayerSkinComponent component = RegPlayerSkinComponent.SKIN_SETTINGS.get(playerEntity);
                 component.setKeepOriginalSkin(keepOriginalSkin);
                 component.setEnableFormColor(enableFormColor);
                 component.setFormColor(new FormTextureUtils.ColorSetting(primaryColor, accentColor1Color, accentColor2Color, eyeColorA, eyeColorB, primaryGreyReverse, accent1GreyReverse, accent2GreyReverse));
+                component.setEnableFormRandomSound(enableFormRandomSound);
                 RegPlayerSkinComponent.SKIN_SETTINGS.sync(playerEntity);
             } catch (Exception e) {
                 ShapeShifterCurseFabric.LOGGER.error("Error while updating player custom config", e);

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2C.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2C.java
@@ -309,6 +309,7 @@ public class ModPacketsS2C {
         buf.writeBoolean(ShapeShifterCurseFabric.playerCustomConfig.primaryGreyReverse);
         buf.writeBoolean(ShapeShifterCurseFabric.playerCustomConfig.accent1GreyReverse);
         buf.writeBoolean(ShapeShifterCurseFabric.playerCustomConfig.accent2GreyReverse);
+        buf.writeBoolean(ShapeShifterCurseFabric.playerCustomConfig.enable_form_random_sound);
         ClientPlayNetworking.send(UPDATE_CUSTOM_SETTING, buf);
     }
 

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/skin/PlayerSkinComponent.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/skin/PlayerSkinComponent.java
@@ -11,6 +11,7 @@ public class PlayerSkinComponent implements Component, AutoSyncedComponent {
     private boolean keepOriginalSkin = false;
     private boolean enableFormColor = false;
     private FormTextureUtils.ColorSetting formColor = new FormTextureUtils.ColorSetting(0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFF000000, 0xFF000000, false, false, false);
+    private boolean enableFormRandomSound = true;
 
     public boolean shouldKeepOriginalSkin() {
         return keepOriginalSkin;
@@ -72,17 +73,20 @@ public class PlayerSkinComponent implements Component, AutoSyncedComponent {
 
     @Override
     public void readFromNbt(NbtCompound tag) {
+        // 直接往里面加了 反正在玩家进服务器后会同步 理论上连持久化都没必要
         try {
             this.keepOriginalSkin = tag.getBoolean("KeepOriginalSkin");
             this.enableFormColor = tag.getBoolean("EnableFormColor");
             this.formColor = new FormTextureUtils.ColorSetting(FormTextureUtils.RGBA2ABGR(tag.getInt("PrimaryColor")), FormTextureUtils.RGBA2ABGR(tag.getInt("AccentColor1")), FormTextureUtils.RGBA2ABGR(tag.getInt("AccentColor2")), FormTextureUtils.RGBA2ABGR(tag.getInt("EyeColorA")), FormTextureUtils.RGBA2ABGR(tag.getInt("EyeColorB")),
                     tag.getBoolean("PrimaryGreyReverse"), tag.getBoolean("Accent1GreyReverse"), tag.getBoolean("Accent2GreyReverse"));
+            this.enableFormRandomSound = tag.getBoolean("EnableFormRandomSound");
         }
         catch(IllegalArgumentException e)
         {
             this.keepOriginalSkin = false; // Default to false
             this.enableFormColor = false; // Default to false
             this.formColor = new FormTextureUtils.ColorSetting(0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, false, false, false); // Default to default color
+            this.enableFormRandomSound = true; // Default to true
         }
     }
 
@@ -98,5 +102,14 @@ public class PlayerSkinComponent implements Component, AutoSyncedComponent {
         tag.putBoolean("PrimaryGreyReverse", this.formColor.getPrimaryGreyReverse());
         tag.putBoolean("Accent1GreyReverse", this.formColor.getAccent1GreyReverse());
         tag.putBoolean("Accent2GreyReverse", this.formColor.getAccent2GreyReverse());
+        tag.putBoolean("EnableFormRandomSound", this.enableFormRandomSound);
+    }
+
+    public boolean isEnableFormRandomSound() {
+        return enableFormRandomSound;
+    }
+
+    public void setEnableFormRandomSound(boolean enableFormRandomSound) {
+        this.enableFormRandomSound = enableFormRandomSound;
     }
 }

--- a/src/main/resources/assets/shape-shifter-curse/lang/en_us.json
+++ b/src/main/resources/assets/shape-shifter-curse/lang/en_us.json
@@ -376,5 +376,6 @@
     "text.autoconfig.shape-shifter-curse-custom.option.primaryGreyReverse": "Primary Grayscale Reverse",
     "text.autoconfig.shape-shifter-curse-custom.option.accent1GreyReverse": "Accent 1 Grayscale Reverse",
     "text.autoconfig.shape-shifter-curse-custom.option.accent2GreyReverse": "Accent 2 Grayscale Reverse",
+    "text.autoconfig.shape-shifter-curse-custom.option.enable_form_random_sound": "Enable Form Random Sound",
     "text.autoconfig.shape-shifter-curse-custom.option.auto_sync_config": "Auto Sync Config"
 }

--- a/src/main/resources/assets/shape-shifter-curse/lang/ru_ru.json
+++ b/src/main/resources/assets/shape-shifter-curse/lang/ru_ru.json
@@ -384,5 +384,6 @@
     "tooltip.shape_shifter_curse.potion_target_form": "Target Form: ",
     "itemGroup.shape_shifter_curse.sscitems": "Shape Shifter Curse",
     "category.shape-shifter-curse":"Shape Shifter Curse",
-    "key.shape-shifter-curse.make_sound":"Make Sound"
+    "key.shape-shifter-curse.make_sound":"Make Sound",
+    "text.autoconfig.shape-shifter-curse-custom.option.enable_form_random_sound": "Enable Form Random Sound"
 }

--- a/src/main/resources/assets/shape-shifter-curse/lang/zh_cn.json
+++ b/src/main/resources/assets/shape-shifter-curse/lang/zh_cn.json
@@ -376,5 +376,6 @@
     "text.autoconfig.shape-shifter-curse-custom.option.primaryGreyReverse": "主要色灰度反转",
     "text.autoconfig.shape-shifter-curse-custom.option.accent1GreyReverse": "重点色1灰度反转",
     "text.autoconfig.shape-shifter-curse-custom.option.accent2GreyReverse": "重点色2灰度反转",
+    "text.autoconfig.shape-shifter-curse-custom.option.enable_form_random_sound": "启用形态随机叫声",
     "text.autoconfig.shape-shifter-curse-custom.option.auto_sync_config": "自动向服务器同步配置"
 }

--- a/src/main/resources/assets/shape-shifter-curse/rich_lang/en_us.json
+++ b/src/main/resources/assets/shape-shifter-curse/rich_lang/en_us.json
@@ -661,5 +661,6 @@
   "text.autoconfig.shape-shifter-curse-custom.option.primaryGreyReverse": "Primary Grayscale Reverse",
   "text.autoconfig.shape-shifter-curse-custom.option.accent1GreyReverse": "Accent 1 Grayscale Reverse",
   "text.autoconfig.shape-shifter-curse-custom.option.accent2GreyReverse": "Accent 2 Grayscale Reverse",
+  "text.autoconfig.shape-shifter-curse-custom.option.enable_form_random_sound": "Enable Form Random Sound",
   "text.autoconfig.shape-shifter-curse-custom.option.auto_sync_config": "Auto Sync Config"
 }

--- a/src/main/resources/assets/shape-shifter-curse/rich_lang/ru_ru.json
+++ b/src/main/resources/assets/shape-shifter-curse/rich_lang/ru_ru.json
@@ -655,5 +655,6 @@
   "tooltip.shape_shifter_curse.potion_target_form": "Target Form: ",
   "itemGroup.shape_shifter_curse.sscitems": "Shape Shifter Curse",
   "category.shape-shifter-curse":"Shape Shifter Curse",
-  "key.shape-shifter-curse.make_sound":"Make Sound"
+  "key.shape-shifter-curse.make_sound":"Make Sound",
+  "text.autoconfig.shape-shifter-curse-custom.option.enable_form_random_sound": "Enable Form Random Sound"
 }

--- a/src/main/resources/assets/shape-shifter-curse/rich_lang/zh_cn.json
+++ b/src/main/resources/assets/shape-shifter-curse/rich_lang/zh_cn.json
@@ -649,5 +649,6 @@
   "text.autoconfig.shape-shifter-curse-custom.option.primaryGreyReverse": "主要色灰度反转",
   "text.autoconfig.shape-shifter-curse-custom.option.accent1GreyReverse": "重点色1灰度反转",
   "text.autoconfig.shape-shifter-curse-custom.option.accent2GreyReverse": "重点色2灰度反转",
+  "text.autoconfig.shape-shifter-curse-custom.option.enable_form_random_sound": "启用形态随机叫声",
   "text.autoconfig.shape-shifter-curse-custom.option.auto_sync_config": "自动向服务器同步配置"
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_sound.json
@@ -6,7 +6,15 @@
     },
     "interval": 200,
     "condition": {
-        "type": "shape-shifter-curse:chance",
-        "chance": 0.3
+        "type": "origins:and",
+        "conditions": [
+            {
+                "type": "shape-shifter-curse:enable_random_sound"
+            },
+            {
+                "type": "shape-shifter-curse:chance",
+                "chance": 0.3
+            }
+        ]
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_sound.json
@@ -6,7 +6,15 @@
     },
     "interval": 200,
     "condition": {
-        "type": "shape-shifter-curse:chance",
-        "chance": 0.3
+        "type": "origins:and",
+        "conditions": [
+            {
+                "type": "shape-shifter-curse:enable_random_sound"
+            },
+            {
+                "type": "shape-shifter-curse:chance",
+                "chance": 0.3
+            }
+        ]
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_sound.json
@@ -6,7 +6,15 @@
     },
     "interval": 200,
     "condition": {
-        "type": "shape-shifter-curse:chance",
-        "chance": 0.3
+        "type": "origins:and",
+        "conditions": [
+            {
+                "type": "shape-shifter-curse:enable_random_sound"
+            },
+            {
+                "type": "shape-shifter-curse:chance",
+                "chance": 0.3
+            }
+        ]
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_sound.json
@@ -8,7 +8,15 @@
     },
     "interval": 200,
     "condition": {
-        "type": "shape-shifter-curse:chance",
-        "chance": 0.3
+        "type": "origins:and",
+        "conditions": [
+            {
+                "type": "shape-shifter-curse:enable_random_sound"
+            },
+            {
+                "type": "shape-shifter-curse:chance",
+                "chance": 0.3
+            }
+        ]
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_sound.json
@@ -6,7 +6,15 @@
     },
     "interval": 200,
     "condition": {
-        "type": "shape-shifter-curse:chance",
-        "chance": 0.3
+        "type": "origins:and",
+        "conditions": [
+            {
+                "type": "shape-shifter-curse:enable_random_sound"
+            },
+            {
+                "type": "shape-shifter-curse:chance",
+                "chance": 0.3
+            }
+        ]
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_sound.json
@@ -8,7 +8,15 @@
     },
     "interval": 200,
     "condition": {
-        "type": "shape-shifter-curse:chance",
-        "chance": 0.3
+        "type": "origins:and",
+        "conditions": [
+            {
+                "type": "shape-shifter-curse:enable_random_sound"
+            },
+            {
+                "type": "shape-shifter-curse:chance",
+                "chance": 0.3
+            }
+        ]
     }
 }


### PR DESCRIPTION
暂时放到玩家自定义皮肤Component里 等我之后写一个nbt解析器(通过一个list来实现自动nbt与Component转换 之前我在其他游戏的Mod中用这个技术写了一套config系统)时把Component改个名(那时候也得重置一回) 改成玩家自定义数据Component

已知Bug 加载新版本后会重置自定义形态颜色数据(但是会被自动同步修复 仅对关闭自动同步造成影响)

仅修改形态每200tick发出30%概率的叫声生效 不会对哈气/受伤音效影响
由于声音系统由原版处理 玩家只能控制自己是否发出叫声