### PR TITLE
AzureLib Armor低于2.0.12的版本均与本模组冲突

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -122,6 +122,7 @@
     "optifabric": "*",
     "identity": "<1.14.2-beta",
     "azurelib": ">3.0.19",
+    "azurelibarmor": "<2.0.12",
     "geckolib": "<4.7.0"
   },
   "recommends": {


### PR DESCRIPTION
不知道为什么，它就是炸了