### PR TITLE
修复 Issue 323

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerEntityRendererMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerEntityRendererMixin.java
@@ -173,6 +173,22 @@ public class PlayerEntityRendererMixin {
                 isInvisible = false;
                 PlayerOriginComponent c = (PlayerOriginComponent) ModComponents.ORIGIN.get(abstractClientPlayerEntity);
                 for (var layer : OriginLayers.getLayers()) {
+                    if (abstractClientPlayerEntity.isSpectator()) {
+                        PlayerEntityModel<?> model = (PlayerEntityModel<?>) this.getModel();
+                        model.hat.hidden = false;
+                        model.head.hidden = false;
+                        model.body.hidden = false;
+                        model.jacket.hidden = false;
+                        model.leftArm.hidden = false;
+                        model.leftSleeve.hidden = false;
+                        model.rightArm.hidden = false;
+                        model.rightSleeve.hidden = false;
+                        model.leftLeg.hidden = false;
+                        model.leftPants.hidden = false;
+                        model.rightLeg.hidden = false;
+                        model.rightPants.hidden = false;
+                        return;
+                    }
                     var origin = c.getOrigin(layer);
                     if (origin == null) {
                         return;
@@ -227,6 +243,9 @@ public class PlayerEntityRendererMixin {
                 PlayerOriginComponent c = (PlayerOriginComponent) ModComponents.ORIGIN.get(aCPE);
                 int p = getOverlayMixin(livingEntity, this.getAnimationCounter(livingEntity, g));
                 for (var layer : OriginLayers.getLayers()) {
+                    if (aCPE.isSpectator()) {
+                        return;
+                    }
                     var origin = c.getOrigin(layer);
                     if (origin == null) {
                         return;


### PR DESCRIPTION
我昨天晚上看见那个issue准备今天改 结果今天修完Rich Translatable Text(不严重 没必要更新 什么时候用这个功能再更 主要是为了脚本使用体验 之前的rich_lang不支持格式化文本(`%s`这种) 原版文本组件json不支持 所以类似`"A": "B"`现在是用原版lang处理方式)忘了修了 现在渲染overlay会在观察者模式下禁用