### PR TITLE
修复塑形升级刷物品Bug

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/recipes/UpgradeRecipe.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/recipes/UpgradeRecipe.java
@@ -52,7 +52,9 @@ public abstract class UpgradeRecipe implements SmithingRecipe {
     public ItemStack craft(Inventory inventory, DynamicRegistryManager registryManager) {
         ItemStack itemStack = inventory.getStack(1);
         if (this.base.test(itemStack)) {
-            return this.upgradeResult.apply(itemStack.copy());
+            ItemStack outputStack = itemStack.copy();
+            outputStack.setCount(1);
+            return this.upgradeResult.apply(outputStack);
         }
         return ItemStack.EMPTY;
     }


### PR DESCRIPTION
估计得发布1.8.2了(或者我写一个修复mod) 也可以发一个1.8.1hotfix 这个bug在服务器环境上属于严重Bug(物品复制)