### PR TITLE
修复蝙蝠攀附跨世界会卡攀附Bug

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/BatAttachEventHandler.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/BatAttachEventHandler.java
@@ -1,6 +1,9 @@
 package net.onixary.shapeShifterCurseFabric.additional_power;
 
 import io.github.apace100.apoli.component.PowerHolderComponent;
+import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
+import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
+import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
 import net.minecraft.entity.player.PlayerEntity;
@@ -54,6 +57,13 @@ public class BatAttachEventHandler {
                     attachPower.detach(player, false);
 
                 }
+            }
+        });
+
+        ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.register((player, from, to) -> {
+            BatBlockAttachPower attachPower = getBatAttachPower(player);
+            if (attachPower != null && attachPower.isAttached()) {
+                attachPower.detach(player, false);
             }
         });
     }


### PR DESCRIPTION
比较奇怪的是 只能在创造模式下复现(从地狱出去时复现 进去不会复现) 生存模式会进不去传送门

具体原因是服务器端攀附为true 而客户端为false 所以解除攀附的包不会发送到服务器(客户端在不攀附时不会发送解除攀附的包)