### PR TITLE
修复betterCombat攻击头挡视角问题 但是仍然没有彻底修复

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerEntityRendererMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerEntityRendererMixin.java
@@ -1,6 +1,7 @@
 package net.onixary.shapeShifterCurseFabric.mixin;
 
 
+import net.minecraft.client.network.ClientPlayerEntity;
 import net.onixary.shapeShifterCurseFabric.integration.origins.component.PlayerOriginComponent;
 import net.onixary.shapeShifterCurseFabric.integration.origins.origin.OriginLayers;
 import net.onixary.shapeShifterCurseFabric.integration.origins.registry.ModComponents;
@@ -124,6 +125,9 @@ public class PlayerEntityRendererMixin {
     @Pseudo
     @Mixin(value = LivingEntityRenderer.class, priority = 99999)
     public static abstract class LivingEntityRendererMixin$HidePlayerModelIfNeeded<T extends LivingEntity, M extends EntityModel<T>> implements IPlayerEntityMixins {
+        @Unique
+        private final boolean BetterCombatInstalled = FabricLoader.getInstance().isModLoaded("bettercombat");
+
         @Shadow
         @Final
         protected List<FeatureRenderer<T, M>> features;
@@ -169,6 +173,8 @@ public class PlayerEntityRendererMixin {
                 at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/model/EntityModel;render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumer;IIFFFF)V",
                         shift = At.Shift.BEFORE))
         private void renderPreProcessMixin(T livingEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, CallbackInfo ci) {
+            boolean IsClientNowPlayedPlayer = livingEntity instanceof ClientPlayerEntity;
+            boolean IsFirstPersonView = MinecraftClient.getInstance().options.getPerspective().isFirstPerson();
             if (livingEntity instanceof AbstractClientPlayerEntity abstractClientPlayerEntity) {
                 isInvisible = false;
                 PlayerOriginComponent c = (PlayerOriginComponent) ModComponents.ORIGIN.get(abstractClientPlayerEntity);
@@ -220,6 +226,10 @@ public class PlayerEntityRendererMixin {
                             model.leftPants.visible = !p.contains(OriginFurModel.VMP.leftPants);
                             model.rightLeg.visible = !p.contains(OriginFurModel.VMP.rightLeg);
                             model.rightPants.visible = !p.contains(OriginFurModel.VMP.rightPants);
+                            if (this.BetterCombatInstalled && IsFirstPersonView && IsClientNowPlayedPlayer) {
+                                model.hat.visible = false;
+                                model.head.visible = false;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
当装了betterCombat 视角为第一人称 且渲染的实体为玩家自身时隐藏头部显示 但是betterCombat动画还有其他问题(摄像机比不装靠后) 不知道是哪个Mixin冲突(已测试FOV 不是它的问题) 但至少现在能玩了(之前的攻击就档视角)

#334 里的美西螈正常我猜测是美西螈的动作覆盖了BetterCombat的动画 没法使用这种方法修其他形态