### PR TITLE
修了一个小显示Bug

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/client/ShapeShifterCurseFabricClient.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/client/ShapeShifterCurseFabricClient.java
@@ -164,7 +164,9 @@ public class ShapeShifterCurseFabricClient implements ClientModInitializer {
 			return;
 		}
 		// Mana System
-		ManaUtils.manaTick(minecraftClient.player);
+		if (!MinecraftClient.getInstance().isPaused()) {
+			ManaUtils.manaTick(minecraftClient.player);
+		}
 	}
 
 	public static void emitTransformParticle(int duration) {


### PR DESCRIPTION
在写拓展(在整蝙蝠形态)时发现的Bug SSC仅狐狸在诅咒之月下会自动回复 不太明显
具体Bug: 当玩家客户端暂停时魔力仍会回复 不过只是显示Bug 由于同步机制 在服务器修改魔力时会自动同步
