### PR TITLE
修复发光材质Bug

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form_render/FurRenderFeature.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form_render/FurRenderFeature.java
@@ -134,7 +134,7 @@ public class FurRenderFeature <T extends LivingEntity, M extends BipedEntityMode
                 fur.render(matrixStack, a, vertexConsumerProvider, RenderLayer.getEntityTranslucent(m.getTextureResource(a)), null, light);
 
                 // 虽然重新调整模型动画3次看起来比较不太合适 等我之后研究一下为什么(fur.render)渲染后会重置动画再治本吧
-                ProcessModel(m, eR, entity, limbAngle, limbDistance, headYaw, headPitch);
+                // ProcessModel(m, eR, entity, limbAngle, limbDistance, headYaw, headPitch);
                 // 用Core Shader渲染的尝试，但这玩意儿不兼容Iris，:(
                 // Core shader fur render implementation, but not capable with iris, :(
                 //RenderLayer myLayer2 = FurGradientRenderLayer.furGradientRemap.getRenderLayer(RenderLayer.getEntityTranslucentEmissive(m.getFullbrightTextureResource(a)));
@@ -143,7 +143,7 @@ public class FurRenderFeature <T extends LivingEntity, M extends BipedEntityMode
 
                 if (hasOutline) {
                     // 渲染模型后动作会还原 很神奇
-                    ProcessModel(m, eR, entity, limbAngle, limbDistance, headYaw, headPitch);
+                    // ProcessModel(m, eR, entity, limbAngle, limbDistance, headYaw, headPitch);
                     fur.render(matrixStack, a, vertexConsumerProvider, RenderLayer.getOutline(m.getTextureResource(a)), vertexConsumerProvider.getBuffer(RenderLayer.getOutline(m.getTextureResource(a))), light);
                 }
 

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form_render/OriginFurModel.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form_render/OriginFurModel.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import dev.kosmx.playerAnim.core.util.Vec3f;
 import mod.azure.azurelib.cache.object.GeoBone;
+import mod.azure.azurelib.core.animation.AnimationState;
 import mod.azure.azurelib.model.GeoModel;
 import net.minecraft.util.math.MathHelper;
 import net.onixary.shapeShifterCurseFabric.integration.origins.origin.Origin;
@@ -827,5 +828,12 @@ public class OriginFurModel extends GeoModel<OriginFurAnimatable> {
     }
     public Identifier getHurtSoundResource() {
         return Identifier.tryParse(JsonHelper.getString(json, "hurtSound", "null"));
+    }
+
+    @Override
+    public void handleAnimations(OriginFurAnimatable animatable, long instanceId, AnimationState<OriginFurAnimatable> animationState) {
+        if (json.has("use_azurelib_anim") && json.get("use_azurelib_anim").getAsBoolean()) {
+            super.handleAnimations(animatable, instanceId, animationState);
+        }
     }
 }


### PR DESCRIPTION
~~先治标不治本吧 本来准备等研究透了再写PR(毕竟连续3次改模型动画看上去不太合适)~~ 已经修好了 是AzureLib的动画系统的问题(没动画还改模型动画 按理说没动画就应该不动模型动画) 我拓展先用3回版本(做了一个Mixin 这个修复应该不用发新版本 想用就临时加一个Mixin)
~~没进行测试(有模型但懒得迁移) 不过昨天我用Mixin改了一下在我拓展能正常工作~~ 应该可以生效 我在关闭这个修复后发光就复现之前的Bug 启动修复后就正常了