### PR TITLE
修复一个赞助者更新中的bug

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/PatronUtils.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/PatronUtils.java
@@ -58,7 +58,7 @@ public class PatronUtils {
             // 开启服务器时无论如何都要更新一次
             PatronUtils.UpdateDataPack(server);
         }
-        Thread thread = new Thread(() -> {
+        new Thread(() -> {  // 如果之后有需要持续监控更新(长时间线程) 需要搓一个系统合并一下
             try {
                 long SleepTime = commonConfig.CheckUpdateInterval;
                 if (SleepTime <= 0) {
@@ -72,7 +72,7 @@ public class PatronUtils {
             if (commonConfig.enablePatronFormSystem) {
                 PatronUtils.CheckDataPackUpdate(server);
             }
-        });
+        }).start();
     }
 
     private static List<JsonObject> ReadDataPackZip(byte[] dataPackZip) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/PlayerEventHandler.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/PlayerEventHandler.java
@@ -88,32 +88,31 @@ public class PlayerEventHandler {
 
             ShapeShifterCurseFabric.LOGGER.info("向玩家同步诅咒之月状态: " + currentIsCursedMoon + ", 月相: " + world.getMoonPhase());
             // 添加延迟同步，确保客户端完全加载后再次发送状态
-            server.execute(() -> {
-                // 延迟40个tick（2秒）再次同步
-                new Thread(() -> {
-                    try {
-                        Thread.sleep(2000);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+            // 延迟40个tick（2秒）再次同步
+            // 反正都得延时2秒 先不在主线程处跑了 等新建的线程等完2秒后再切进主线程
+            new Thread(() -> {
+                try {
+                    Thread.sleep(2000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+
+                // 在主线程中执行同步
+                server.execute(() -> {
+                    if (player.networkHandler != null && !player.isDisconnected()) {
+                        ServerWorld currentWorld = player.getServerWorld();
+                        boolean delayedIsCursedMoon = CursedMoon.isCursedMoonByPhase(currentWorld); // 直接使用月相判定
+                        boolean delayedIsNight = CursedMoon.isNight(currentWorld);
+
+                        ModPacketsS2CServer.sendCursedMoonData(player, currentWorld.getTimeOfDay(), CursedMoon.getDay(currentWorld),
+                                delayedIsCursedMoon, delayedIsNight);
+
+                        ShapeShifterCurseFabric.LOGGER.info("延迟同步诅咒之月状态: " + delayedIsCursedMoon +
+                                ", 月相: " + currentWorld.getMoonPhase() +
+                                ", 玩家: " + player.getName().getString());
                     }
-
-                    // 在主线程中执行同步
-                    server.execute(() -> {
-                        if (player.networkHandler != null && !player.isDisconnected()) {
-                            ServerWorld currentWorld = player.getServerWorld();
-                            boolean delayedIsCursedMoon = CursedMoon.isCursedMoonByPhase(currentWorld); // 直接使用月相判定
-                            boolean delayedIsNight = CursedMoon.isNight(currentWorld);
-
-                            ModPacketsS2CServer.sendCursedMoonData(player, currentWorld.getTimeOfDay(), CursedMoon.getDay(currentWorld),
-                                    delayedIsCursedMoon, delayedIsNight);
-
-                            ShapeShifterCurseFabric.LOGGER.info("延迟同步诅咒之月状态: " + delayedIsCursedMoon +
-                                    ", 月相: " + currentWorld.getMoonPhase() +
-                                    ", 玩家: " + player.getName().getString());
-                        }
-                    });
-                }).start();
-            });
+                });
+            }).start();
 
             // reset moon effect
             CursedMoon.resetMoonEffect(player);


### PR DESCRIPTION
看PR时发现赞助者形态的服务器更新检查线程没写start (当时忘了测了 写了个1天检查一次更新后就没管这个功能了)
顺便优化了一下玩家进入时的性能影响(极小 顺带修了)