### PR TITLE
一些小修改

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/WebBridgeAction.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/WebBridgeAction.java
@@ -27,16 +27,13 @@ public class WebBridgeAction {
     public record WebBridgeConfig(int Length, int Width) {}
 
     public static boolean SetWebBlock(World world, BlockPos pos, Block WebBlock, Direction facing) {
-        if (world.getBlockState(pos).isAir()) {
+        BlockState blockState = world.getBlockState(pos);
+        if (blockState.isAir() || blockState.isOf(WebBlock)) {
             BlockState state = WebBlock.getDefaultState().with(TempWebBridgeBlock.HORIZONTAL_FACING, facing);
             world.setBlockState(pos, state);
             return true;
         }
         return false;
-    }
-
-    public static boolean SetWebBlock(World world, BlockPos pos, Block WebBlock) {
-        return SetWebBlock(world, pos, WebBlock, Direction.NORTH);
     }
 
     public static void BuildWebLadder(World world, BlockHitResult blockHitResult, WebLadderConfig config, Block LadderBlock) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/entity/projectile/WebBullet.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/entity/projectile/WebBullet.java
@@ -8,6 +8,7 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.projectile.thrown.ThrownItemEntity;
+import net.minecraft.fluid.WaterFluid;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
@@ -100,6 +101,9 @@ public class WebBullet extends ThrownItemEntity {
                 }
             }
 
+            if (this.getWorld().getBlockState(this.getBlockPos()).isLiquid()) {
+                this.discard();
+            }
         }
     }
 

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/entity/projectile/WebBullet.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/entity/projectile/WebBullet.java
@@ -18,6 +18,7 @@ import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.EntityHitResult;
+import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 import net.onixary.shapeShifterCurseFabric.additional_power.WebBridgeAction;
 import net.onixary.shapeShifterCurseFabric.blocks.RegCustomBlock;
@@ -103,6 +104,10 @@ public class WebBullet extends ThrownItemEntity {
 
             if (this.getWorld().getBlockState(this.getBlockPos()).isLiquid()) {
                 this.discard();
+            }
+
+            if (this.getWorld().getBlockState(this.getBlockPos()).isOf(RegCustomBlock.TEMP_WEB_BRIDGE)) {
+                this.onBlockHit(new BlockHitResult(this.getPos(), Direction.DOWN, this.getBlockPos(), false));
             }
         }
     }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mana/WebResourceBar.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mana/WebResourceBar.java
@@ -56,30 +56,12 @@ public class WebResourceBar implements IManaRender {
         double mana = ManaUtils.getPlayerMana(mc.player);
         double maxMana = ManaUtils.getPlayerMaxMana(mc.player);
         double manaRegen = ManaUtils.getPlayerManaRegen(mc.player);
-        int remainTicks = -1;
-
-        if (manaRegen > (double)0.0F) {
-            remainTicks = (int)Math.ceil((maxMana - mana) / manaRegen);
-        } else if (manaRegen < (double)0.0F) {
-            remainTicks = (int)Math.ceil((mana) / (-manaRegen));
-        } else {
-            remainTicks = 0;
-        }
 
         int manaWidth = (int)Math.ceil((double)80.0F * ManaUtils.getManaPercent(mana, maxMana, (double)0.0F));
         context.drawTexture(BarTexID, x, y, 0.0f, 0, 80, 5, 80, 18);
         context.drawTexture(BarTexID, x, y, 0.0f, 5, manaWidth, 5, 80, 18);
-        StringBuilder manaString = new StringBuilder();
-        manaString.append((int)mana).append("/").append((int)maxMana);
-        if (remainTicks > 0) {
-            manaString.append(" (").append(remainTicks).append(")");
-        } else if (remainTicks < 0) {
-            manaString.append(" (").append("?").append(")");
-        } else {
-            manaString.append(" (").append("∞").append(")");
-        }
 
-        Text manaText = Text.literal(manaString.toString());
+        Text manaText = Text.literal((int) mana + "/" + (int) maxMana);
         context.drawText(mc.textRenderer, manaText, x + 10, y - 8, manaRegen == 0 ? 0xFF7F7F7F : 0xFF00CFFF, false);
 
         int chargeLevel = this.getChargeLevel();

--- a/src/main/resources/data/shape-shifter-curse/origins/form_spider_3.json
+++ b/src/main/resources/data/shape-shifter-curse/origins/form_spider_3.json
@@ -12,7 +12,6 @@
         "shape-shifter-curse:spider_friendly",
         "shape-shifter-curse:hostile_iron_golem",
         "shape-shifter-curse:form_spider_3_low_fall",
-        "shape-shifter-curse:form_spider_3_extra_slot",
         "shape-shifter-curse:form_spider_3_speed_down",
         "shape-shifter-curse:form_spider_3_jump_lower_and_far",
         "shape-shifter-curse:form_spider_3_step_height",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_extra_slot.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_extra_slot.json
@@ -1,8 +1,0 @@
-{
-    "type": "origins:multiple",
-    "main": {
-        "type": "shape-shifter-curse:item_store",
-        "id": "shape-shifter-curse:test_store",
-        "slot": 0
-    }
-}


### PR DESCRIPTION
之前的蛛网弹仅能在顶上击中蛛网桥 现在可以从底下往上击中蛛网桥了(或许可以做出一些自救操作吧)
现在的蛛网弹接触液体自动消失 毕竟入水即化(岩浆更得化)
删除了蜘蛛资源条的剩余时间数显 没有自然恢复就没法使用
移除了item_store的power 目前使用饰品栏而不是这个power 所以就移除了那个json文件