### PR TITLE
修复isExtraHandVenomSpindleEquipped崩溃问题

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/TrinketsConditionAction.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/TrinketsConditionAction.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static net.onixary.shapeShifterCurseFabric.items.accessory.AccessoryUtils.calcAutoMod;
 
@@ -83,7 +84,7 @@ public class TrinketsConditionAction {
         return false;
     }
 
-    public static boolean CheckEquipped(Entity entity, String AccessoryMod, String GroupString, String SlotString, int Slot, ConditionFactory<ItemStack>.Instance conditon, boolean rDefault) {
+    public static boolean CheckEquipped(Entity entity, String AccessoryMod, String GroupString, String SlotString, int Slot, Predicate<ItemStack> conditon, boolean rDefault) {
         if (entity instanceof LivingEntity livingEntity) {
             switch (calcAutoMod(AccessoryMod)) {
                 case "trinkets":
@@ -132,7 +133,7 @@ public class TrinketsConditionAction {
         return rDefault;
     }
 
-    public static void InvokeEquipped(Entity entity, String AccessoryMod, String GroupString, String SlotString, int Slot, ActionFactory<Pair<World, ItemStack>>.Instance action) {
+    public static void InvokeEquipped(Entity entity, String AccessoryMod, String GroupString, String SlotString, int Slot, Consumer<Pair<World, ItemStack>> action) {
         if (entity instanceof LivingEntity livingEntity) {
             switch (calcAutoMod(AccessoryMod)) {
                 case "trinkets":

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/entity/projectile/WebBullet.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/entity/projectile/WebBullet.java
@@ -15,6 +15,7 @@ import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.thrown.ThrownItemEntity;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.particle.ParticleTypes;
@@ -25,6 +26,7 @@ import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import net.onixary.shapeShifterCurseFabric.additional_power.TrinketsConditionAction;
 import net.onixary.shapeShifterCurseFabric.additional_power.WebBridgeAction;
 import net.onixary.shapeShifterCurseFabric.blocks.RegCustomBlock;
 import net.onixary.shapeShifterCurseFabric.items.RegCustomItem;
@@ -123,19 +125,26 @@ public class WebBullet extends ThrownItemEntity {
     }
 
     private boolean isExtraHandVenomSpindleEquipped(PlayerEntity player) {
-        Optional<TrinketComponent> component = TrinketsApi.getTrinketComponent(player);
-        if (component.isEmpty()) {
-            return false;
-        }
-        Map<String, TrinketInventory> groupInv = component.get().getInventory().get("hand");
-        if (groupInv == null) {
-            return false;
-        }
-        TrinketInventory inv = groupInv.get("extra_hand");
-        if (inv == null) {
-            return false;
-        }
-        return inv.getStack(0).isOf(RegCustomItem.VENOM_SPINDLE);
+        // Optional<TrinketComponent> component = TrinketsApi.getTrinketComponent(player);
+        // if (component.isEmpty()) {
+        //     return false;
+        // }
+        // Map<String, TrinketInventory> groupInv = component.get().getInventory().get("hand");
+        // if (groupInv == null) {
+        //     return false;
+        // }
+        // TrinketInventory inv = groupInv.get("extra_hand");
+        // if (inv == null) {
+        //     return false;
+        // }
+        // return inv.getStack(0).isOf(RegCustomItem.VENOM_SPINDLE);
+        return TrinketsConditionAction.CheckEquipped(
+                player, "auto", "hand", "extra_hand", 0,
+                (stack) -> {
+                    return stack.isOf(RegCustomItem.VENOM_SPINDLE);
+                },
+                false
+        );
     }
 
     private void playHitEffects() {


### PR DESCRIPTION
我分支更新的比较晚 测试时还没合并 isExtraHandVenomSpindleEquipped 现在修复了

> 而且Trinkets物品栏也消失了，手动在测试环境添加Trinkets模组也没有作用

我这边测试没问题啊 现在可以在不装Trinkets进入游戏 所以构建脚本里trinket为仅构建依赖 不会在运行时自动添加进环境 (截图环境已外部添加Trinket)
<img width="854" height="480" alt="2026-04-22_11 24 37" src="https://github.com/user-attachments/assets/d744bb68-ba85-42cb-a21b-5cb3379e5757" />
<img width="854" height="480" alt="2026-04-22_11 27 23" src="https://github.com/user-attachments/assets/2afb4445-2d75-42bc-8cc7-4de2741b5df1" />

不过现在要完整体验还得装trinket 直到我研究完特殊Mixin技巧(外部编译后直接以class放进项目)才能支持Curios 现在Curios只有架子 没有功能
