### PR TITLE
修复一点小Bug

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/integration/TacZ_Anim.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/integration/TacZ_Anim.java
@@ -21,7 +21,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(value = AnimationManager.class, remap = false)
 public class TacZ_Anim {
     @Inject(method = "onFire", at = @At("HEAD"), cancellable = true)
-    private static void onFire(GunShootEvent event, CallbackInfo ci) {
+    private void onFire(GunShootEvent event, CallbackInfo ci) {
         if (event.getShooter() instanceof AbstractClientPlayerEntity player) {
             PlayerFormBase form = RegPlayerFormComponent.PLAYER_FORM.get(player).getCurrentForm();
             if (form.getBodyType() == PlayerFormBodyType.FERAL) {
@@ -30,7 +30,7 @@ public class TacZ_Anim {
         }
     }
     @Inject(method = "onReload", at = @At("HEAD"), cancellable = true)
-    private static void onFire(GunReloadEvent event, CallbackInfo ci) {
+    private void onReload(GunReloadEvent event, CallbackInfo ci) {
         if (event.getEntity() instanceof AbstractClientPlayerEntity player) {
             PlayerFormBase form = RegPlayerFormComponent.PLAYER_FORM.get(player).getCurrentForm();
             if (form.getBodyType() == PlayerFormBodyType.FERAL) {
@@ -39,7 +39,7 @@ public class TacZ_Anim {
         }
     }
     @Inject(method = "onMelee", at = @At("HEAD"), cancellable = true)
-    private static void onMelee(GunMeleeEvent event, CallbackInfo ci) {
+    private void onMelee(GunMeleeEvent event, CallbackInfo ci) {
         if (event.getShooter() instanceof AbstractClientPlayerEntity player) {
             PlayerFormBase form = RegPlayerFormComponent.PLAYER_FORM.get(player).getCurrentForm();
             if (form.getBodyType() == PlayerFormBodyType.FERAL) {
@@ -48,7 +48,7 @@ public class TacZ_Anim {
         }
     }
     @Inject(method = "onDraw", at = @At("HEAD"), cancellable = true)
-    private static void onDraw(GunDrawEvent event, CallbackInfo ci) {
+    private void onDraw(GunDrawEvent event, CallbackInfo ci) {
         if (event.getEntity() instanceof AbstractClientPlayerEntity player) {
             PlayerFormBase form = RegPlayerFormComponent.PLAYER_FORM.get(player).getCurrentForm();
             if (form.getBodyType() == PlayerFormBodyType.FERAL) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/render/tech/ItemStorePowerRender.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/render/tech/ItemStorePowerRender.java
@@ -50,6 +50,9 @@ public class ItemStorePowerRender {
             timer = 0;
             NowCol = 0;
             NowRow = 0;
+            for (int i = 0; i < MaxSlot; i++) {
+                tempPower.set(i, null);
+            }
             for(Power power : PowerHolderComponent.KEY.get(mc.player).getPowers()) {
                 if(itemStorePowerRenderInterface.class.isAssignableFrom(power.getClass()) && power.isActive()) {
                     itemStorePowerRenderInterface trueR = (itemStorePowerRenderInterface) power;


### PR DESCRIPTION
修互联版本的Issues时发现的 蜘蛛的槽位power缓存忘了清空 导致在脱离蜘蛛形态时槽位会保留(但是由于清空了`NowCol NowRow` 导致位置计算异常 所以显示的不太明显(副手栏下面有一个小条))