### PR TITLE
修复虚拟盾牌对使魔红狐火球概率失效的Bug

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/LivingEntityMixin.java
@@ -313,20 +313,44 @@ public abstract class LivingEntityMixin {
         return Math.max(0f, finalV);
     }
 
-    @ModifyVariable(method = "damage", at = @At("HEAD"), argsOnly = true, order = 9999)
-    private float modifyDamageTaken(float originalValue, DamageSource source, float amount) {
+    // 旧方案 使用模拟原版盾牌方案 可以避免任何情况下的盾牌损坏问题
+    // @ModifyVariable(method = "damage", at = @At("HEAD"), argsOnly = true, order = 9999)
+    // private float modifyDamageTaken(float originalValue, DamageSource source, float amount) {
+    //     LivingEntity realThis = (LivingEntity) (Object) this;
+    //     float finalDamage = originalValue;
+    //     for (VirtualShieldPower power : PowerHolderComponent.getPowers(realThis, VirtualShieldPower.class)) {
+    //         if (power.blockDamage(source)) {
+    //             finalDamage = 0.0f;
+    //             Entity attacker = source.getAttacker();
+    //             if (!source.isIn(DamageTypeTags.IS_PROJECTILE) && (attacker instanceof LivingEntity ale)) {
+    //                 this.takeShieldHit(ale);
+    //             }
+    //             realThis.getWorld().sendEntityStatus(realThis, (byte)29);
+    //         }
+    //     }
+    //     return finalDamage;
+    // }
+
+    // 新方案 修改原版盾牌检查函数 对于伤害防护兼容性强 但是使用了Redirect(需要防止玩家当前使用的盾牌不会受损) 可能兼容性不太高
+    @Unique
+    private boolean bypassNextShieldDamage = false;
+
+    @Inject(method = "blockedByShield", at = @At("HEAD"), cancellable = true)
+    private void blockedByShield(DamageSource source, CallbackInfoReturnable<Boolean> cir) {
         LivingEntity realThis = (LivingEntity) (Object) this;
-        float finalDamage = originalValue;
         for (VirtualShieldPower power : PowerHolderComponent.getPowers(realThis, VirtualShieldPower.class)) {
             if (power.blockDamage(source)) {
-                finalDamage = 0.0f;
-                Entity attacker = source.getAttacker();
-                if (!source.isIn(DamageTypeTags.IS_PROJECTILE) && (attacker instanceof LivingEntity ale)) {
-                    this.takeShieldHit(ale);
-                }
-                realThis.getWorld().sendEntityStatus(realThis, (byte)29);
+                this.bypassNextShieldDamage = true;
+                cir.setReturnValue(true);
             }
         }
-        return finalDamage;
+    }
+
+    @Redirect(method = "damage", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;damageShield(F)V"))
+    private void damageShield(LivingEntity instance, float amount) {
+        if (!this.bypassNextShieldDamage) {
+            instance.damageShield(amount);
+        }
+        this.bypassNextShieldDamage = false;
     }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/LivingEntityMixin.java
@@ -313,7 +313,7 @@ public abstract class LivingEntityMixin {
         return Math.max(0f, finalV);
     }
 
-    @ModifyVariable(method = "damage", at = @At("HEAD"), argsOnly = true)
+    @ModifyVariable(method = "damage", at = @At("HEAD"), argsOnly = true, order = 9999)
     private float modifyDamageTaken(float originalValue, DamageSource source, float amount) {
         LivingEntity realThis = (LivingEntity) (Object) this;
         float finalDamage = originalValue;

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/v3/AnimStateControllerDP/UseOtherStateAnimController.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/v3/AnimStateControllerDP/UseOtherStateAnimController.java
@@ -56,9 +56,9 @@ public class UseOtherStateAnimController extends AbstractAnimStateControllerDP {
             }
             return otherStateController.getAnimation(player, data);
         }
-        if (ShapeShifterCurseFabric.IsDevelopmentEnvironment()) {  // 由于otherStateId nullable但是逻辑上不推荐为null 所以在开发环境下提示
-            ShapeShifterCurseFabric.LOGGER.warn("UseOtherStateAnimController State Not Found: {}", this.otherStateId);
-        }
+        // if (ShapeShifterCurseFabric.IsDevelopmentEnvironment()) {  // 由于otherStateId nullable但是逻辑上不推荐为null 所以在开发环境下提示
+        //     ShapeShifterCurseFabric.LOGGER.warn("UseOtherStateAnimController State Not Found: {}", this.otherStateId);
+        // }
         return null;
     }
 


### PR DESCRIPTION
由于Apoli的修改投掷物伤害的注入点和虚拟盾牌的一样 导致可能出现先被虚拟盾牌防住 再被增加伤害的Power修改回去 导致虚拟盾牌失效(看同优先度mixin的加载顺序 所以说是概率性失效)
现在使用inject blockedByShield函数(原版盾牌判断函数) 位置靠下 只要原版盾牌能防住的 虚拟盾牌也能防 不过为了防止触发虚拟盾牌后原版盾牌也受损 所以使用了Redirect了damageShield函数 可能会有兼容性问题(2个mixin无法同时Redirect同一个函数 不过mixin这个函数很少见 应该不会出大问题)