### PR TITLE
add sounds for spider forms

### DIFF
--- a/src/main/resources/data/shape-shifter-curse/origins/form_spider_0.json
+++ b/src/main/resources/data/shape-shifter-curse/origins/form_spider_0.json
@@ -14,7 +14,11 @@
     "shape-shifter-curse:form_spider_0_dew_covered_cobweb_instinct",
     "shape-shifter-curse:form_spider_0_dew_covered_cobweb_particle",
     "shape-shifter-curse:form_spider_0_instinct_max_particle",
-    "shape-shifter-curse:form_instinct_use_golden_apple"
+    "shape-shifter-curse:form_instinct_use_golden_apple",
+
+    "shape-shifter-curse:form_spider_sound",
+    "shape-shifter-curse:form_spider_sound_hurt",
+    "shape-shifter-curse:form_spider_sound_key"
   ],
   "icon": {
     "item": "minecraft:player_head"

--- a/src/main/resources/data/shape-shifter-curse/origins/form_spider_2.json
+++ b/src/main/resources/data/shape-shifter-curse/origins/form_spider_2.json
@@ -25,7 +25,11 @@
     "shape-shifter-curse:form_spider_2_meat_and_fluid_cocoon_only",
     "shape-shifter-curse:form_spider_3_poison_immunity",
     "shape-shifter-curse:form_spider_3_make_cobweb",
-    "shape-shifter-curse:form_spider_3_make_web_composter"
+    "shape-shifter-curse:form_spider_3_make_web_composter",
+
+    "shape-shifter-curse:form_spider_sound",
+    "shape-shifter-curse:form_spider_sound_hurt",
+    "shape-shifter-curse:form_spider_sound_key"
   ],
   "icon": {
     "item": "minecraft:player_head"

--- a/src/main/resources/data/shape-shifter-curse/origins/form_spider_3.json
+++ b/src/main/resources/data/shape-shifter-curse/origins/form_spider_3.json
@@ -31,7 +31,12 @@
         "shape-shifter-curse:form_spider_3_extra_slot_render",
         "shape-shifter-curse:form_spider_3_make_web_composter",
         "shape-shifter-curse:form_spider_3_mana_attack_cocooned_enemy",
-        "shape-shifter-curse:form_spider_3_auto_feed"
+        "shape-shifter-curse:form_spider_3_auto_feed",
+
+        "shape-shifter-curse:form_spider_sound",
+        "shape-shifter-curse:form_spider_sound_hurt",
+        "shape-shifter-curse:form_spider_sound_key",
+        "shape-shifter-curse:form_spider_sound_walk"
     ],
     "icon": {
         "item": "minecraft:player_head"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound.json
@@ -1,0 +1,21 @@
+{
+    "type": "origins:action_over_time",
+    "entity_action": {
+        "type": "origins:play_sound",
+        "sound": "minecraft:entity.spider.ambient",
+        "volume": 0.15
+    },
+    "interval": 200,
+    "condition": {
+        "type": "origins:and",
+        "conditions": [
+            {
+                "type": "shape-shifter-curse:enable_random_sound"
+            },
+            {
+                "type": "shape-shifter-curse:chance",
+                "chance": 0.3
+            }
+        ]
+    }
+}

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound_hurt.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound_hurt.json
@@ -1,0 +1,12 @@
+{
+    "type": "origins:self_action_when_hit",
+    "entity_action": {
+        "type": "origins:play_sound",
+        "sound": "minecraft:entity.spider.hurt",
+        "volume": 0.2
+    },
+    "condition": {
+        "type": "shape-shifter-curse:chance",
+        "chance": 0.8
+    }
+}

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound_key.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound_key.json
@@ -1,0 +1,16 @@
+{
+    "type": "origins:active_self",
+    "entity_action": {
+        "type": "origins:play_sound",
+        "sound": "minecraft:entity.spider.ambient",
+        "volume": 0.15
+    },
+    "cooldown": 5,
+    "hud_render": {
+        "should_render": false
+    },
+    "key": {
+        "key": "key.shape-shifter-curse.make_sound",
+        "continuous": false
+    }
+}

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound_walk.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound_walk.json
@@ -1,0 +1,53 @@
+{
+    "type": "origins:action_over_time",
+    "entity_action": {
+        "type": "origins:play_sound",
+        "sound": "minecraft:entity.spider.step",
+        "volume": 0.075
+    },
+    "interval": 10,
+    "condition": {
+        "type": "origins:or",
+        "conditions": [
+            {
+                "type": "origins:and",
+                "conditions": [
+                    {
+                        "type": "origins:moving",
+                        "horizontally": false,
+                        "vertically": true
+                    },
+                    {
+                        "type": "origins:or",
+                        "conditions": [
+                            {
+                                "type": "origins:block_collision",
+                                "offset_x": 0.1,
+                                "offset_z": 0.1
+                            },
+                            {
+                                "type": "origins:block_collision",
+                                "offset_x": -0.1,
+                                "offset_z": -0.1
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "type": "origins:and",
+                "conditions": [
+                    {
+                        "type": "origins:moving",
+                        "horizontally": true,
+                        "vertically": false
+                    },
+                    {
+                        "type": "origins:block_collision",
+                        "offset_y": -0.1
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
"entity.spider.ambient" for key press and random interval
"entity.spider.hurt" for taking damage
"entity.spider.step" for walking and climbing in permanent form (interval set to 10 ticks, since all the spider step sounds are exactly 0.5 seconds long)

Just thought the spider form could use some sounds like some of the other forms, though if you'd rather not hear the spider walking sounds, you can exclude that part