### PR TITLE
修复无法使用盾牌power失效Bug

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/RegPlayerForms.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/RegPlayerForms.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import net.minecraft.util.Identifier;
 import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
 import net.onixary.shapeShifterCurseFabric.player_form.forms.*;
+import net.onixary.shapeShifterCurseFabric.player_form.new_form_system.IForm;
 
 import java.util.*;
 
@@ -18,6 +19,10 @@ public class RegPlayerForms {
 
     // Builtin PlayerForms
     // 在Java中null不能使用equals方法
+    // 新系统用占位符 别用 后续会改变量名
+    public static IForm N_ORIGINAL_BEFORE_ENABLE = null;
+    public static IForm N_ORIGINAL_SHIFTER = null;
+
     // Original
     public static PlayerFormBase ORIGINAL_BEFORE_ENABLE = registerPlayerForm(new PlayerFormBase(new Identifier(ShapeShifterCurseFabric.MOD_ID, "original_before_enable")));
     public static PlayerFormBase ORIGINAL_SHIFTER = registerPlayerForm(new PlayerFormBase(new Identifier(ShapeShifterCurseFabric.MOD_ID, "original_shifter")));

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/CursedMoon.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/CursedMoon.java
@@ -2,10 +2,13 @@ package net.onixary.shapeShifterCurseFabric.player_form.new_form_system;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.world.World;
 import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+import net.onixary.shapeShifterCurseFabric.player_form.RegPlayerForms;
+import net.onixary.shapeShifterCurseFabric.player_form.ability.FormAbilityManager;
 
 import java.util.Arrays;
 
@@ -46,13 +49,80 @@ public class CursedMoon {
     }
 
     public static void applyStartCursedMoonEffect(World world, PlayerEntity player) {
-        // 先检查flag 后执行逻辑
-        // TODO
+        // java16+ 真神奇的写法
+        if (!(player instanceof ServerPlayerEntity serverPlayer)) {
+            return;
+        }
+        if (PlayerFormComponent.COMPONENT.get(player).isCursedMoonApplied) {
+            return;
+        }
+        boolean isOverworld = player.getWorld().getRegistryKey() == World.OVERWORLD;
+        if (RegPlayerForms.N_ORIGINAL_BEFORE_ENABLE.isPlayerForm(player)) {
+            if (isOverworld) {
+                player.sendMessage(Text.translatable("info.shape-shifter-curse.on_cursed_moon_before_enable").formatted(Formatting.LIGHT_PURPLE));
+            }
+        } else {
+            if(isOverworld){
+                player.sendMessage(Text.translatable("info.shape-shifter-curse.on_cursed_moon").formatted(Formatting.LIGHT_PURPLE));
+            }
+            else{
+                player.sendMessage(Text.translatable("info.shape-shifter-curse.on_cursed_moon_nether").formatted(Formatting.LIGHT_PURPLE));
+            }
+            ShapeShifterCurseFabric.ON_TRIGGER_CURSED_MOON.trigger(serverPlayer);
+        }
+        PlayerFormComponent component = PlayerFormComponent.COMPONENT.get(player);
+        component.isCursedMoonApplied = true;
+        component.lastTransformByCure = false;
+        component.BeforeCursedMoonAppliedForm = null;
+        component.AfterCursedMoonAppliedForm = null;
+        if (!RegPlayerForms.N_ORIGINAL_BEFORE_ENABLE.isPlayerForm(player)) {
+            IForm nowForm = component.nowForm;
+            IForm targetForm = component.nowForm._getNextForm(player, ITransformReason.CursedMoon);
+            if (!nowForm.isEquals(targetForm)) {
+                component.BeforeCursedMoonAppliedForm = nowForm;
+                component.AfterCursedMoonAppliedForm = targetForm;
+                TransformManager.startTransform(player, targetForm, null);
+            }
+        }
+        component.sync();
     }
 
     public static void applyEndCursedMoonEffect(World world, PlayerEntity player) {
-        // 先检查flag 后执行逻辑
-        // TODO
+        if (!(player instanceof ServerPlayerEntity serverPlayer)) {
+            return;
+        }
+        if (!PlayerFormComponent.COMPONENT.get(player).isCursedMoonApplied) {
+            return;
+        }
+        boolean isOverworld = player.getWorld().getRegistryKey() == World.OVERWORLD;
+        PlayerFormComponent component = PlayerFormComponent.COMPONENT.get(player);
+        if (RegPlayerForms.N_ORIGINAL_BEFORE_ENABLE.isPlayerForm(player)) {
+            if (isOverworld) {
+                player.sendMessage(Text.translatable("info.shape-shifter-curse.end_cursed_moon_before_enable").formatted(Formatting.LIGHT_PURPLE));
+            }
+        } else {
+            // 要不是可以用别的手段降级(比如我拓展的幻形石) 我直接查当前形态与AfterCursedMoonAppliedForm的等级差就行
+            if (component.lastTransformByCure) {
+                player.sendMessage(Text.translatable("info.shape-shifter-curse.end_cursed_moon_by_cure").formatted(Formatting.LIGHT_PURPLE));
+                ShapeShifterCurseFabric.ON_END_CURSED_MOON_CURED.trigger(serverPlayer);
+                if (component.AfterCursedMoonAppliedForm != null && component.AfterCursedMoonAppliedForm.getFormTier() == 1) {
+                    ShapeShifterCurseFabric.ON_END_CURSED_MOON_CURED_FORM_2.trigger(serverPlayer);
+                }
+            } else if(RegPlayerForms.N_ORIGINAL_SHIFTER.isPlayerForm(player)){
+                player.sendMessage(Text.translatable("info.shape-shifter-curse.end_cursed_moon_special").formatted(Formatting.LIGHT_PURPLE));
+            } else if (component.BeforeCursedMoonAppliedForm != null && component.AfterCursedMoonAppliedForm != null && component.AfterCursedMoonAppliedForm.isPlayerForm(player)) {
+                player.sendMessage(Text.translatable("info.shape-shifter-curse.end_cursed_moon").formatted(Formatting.LIGHT_PURPLE));
+                ShapeShifterCurseFabric.ON_END_CURSED_MOON.trigger(serverPlayer);
+            }
+        }
+        component.isCursedMoonApplied = false;
+        component.lastTransformByCure = false;
+        if (component.BeforeCursedMoonAppliedForm != null && component.AfterCursedMoonAppliedForm != null && component.AfterCursedMoonAppliedForm.isPlayerForm(player)) {
+            TransformManager.startTransform(player, component.BeforeCursedMoonAppliedForm, null);
+        }
+        component.BeforeCursedMoonAppliedForm = null;
+        component.AfterCursedMoonAppliedForm = null;
+        component.sync();
     }
 
     public static void serverTick(World world) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/FormUtils.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/FormUtils.java
@@ -11,9 +11,7 @@ import net.onixary.shapeShifterCurseFabric.integration.origins.origin.OriginLaye
 import net.onixary.shapeShifterCurseFabric.integration.origins.origin.OriginLayers;
 import net.onixary.shapeShifterCurseFabric.integration.origins.origin.OriginRegistry;
 import net.onixary.shapeShifterCurseFabric.integration.origins.registry.ModComponents;
-import net.onixary.shapeShifterCurseFabric.networking.ModPacketsS2CServer;
 import net.onixary.shapeShifterCurseFabric.player_animation.v3.AnimUtils;
-import net.onixary.shapeShifterCurseFabric.player_form.ability.RegPlayerFormComponent;
 import net.onixary.shapeShifterCurseFabric.util.TrinketUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -53,19 +51,26 @@ public class FormUtils {
         return Set.copyOf(flagSet);
     }
 
-    public static @NotNull IForm getPlayerForm(PlayerEntity player) {
-        // 未完工
+    public static @Nullable IForm getForm(@NotNull Identifier formID) {
         return null;
+    }
+
+    public static @NotNull IForm parseForm(@Nullable Identifier formID, IForm defaultForm) {
+        if (formID == null) return defaultForm;
+        IForm form = getForm(formID);
+        return form != null ? form : defaultForm;
+    }
+
+    public static @NotNull IForm getPlayerForm(PlayerEntity player) {
+        return PlayerFormComponent.COMPONENT.get(player).nowForm;
     }
 
     public static @NotNull List<IForm> getPlayerFormHistory(PlayerEntity player) {
-        // 未完工
-        return null;
+        return PlayerFormComponent.COMPONENT.get(player).formHistory;
     }
 
     public static void savePlayerFormHistory(PlayerEntity player) {
-        // 未完工
-        return;
+        PlayerFormComponent.COMPONENT.sync(player);
     }
 
     public static boolean isFormEqual(@Nullable IForm form1, @Nullable IForm form2) {
@@ -90,6 +95,7 @@ public class FormUtils {
     }
 
     public static void _loadForm(PlayerEntity player, IForm form) {
+        // 临时 等移除Origins后再重新这部分
         OriginComponent component = ModComponents.ORIGIN.get(player);
         Pair<Identifier, Identifier> layerPair = form.getFormLayer();
         OriginLayer layer = OriginLayers.getLayer(layerPair.getLeft());
@@ -100,16 +106,19 @@ public class FormUtils {
                 component.sync();
             }
         }
+
         // applyExtraPower
         // checkAndClearTransformativeEffect
 
-        // component.setCurrentForm(newForm);
-        // RegPlayerFormComponent.PLAYER_FORM.sync(player);
+        PlayerFormComponent playerFormComponent = PlayerFormComponent.COMPONENT.get(player);
+        playerFormComponent.nowForm = form;
+        playerFormComponent.sync();
 
         AnimUtils.stopPowerAnim(player, AnimUtils.AnimationSendSideType.ONLY_SERVER);
         TrinketUtils.ReApplyAccessoryPowerOnPlayerFormChange(player);
         if (!player.getWorld().isClient() && player instanceof ServerPlayerEntity serverPlayer) {
             try {
+                // 改成Identifier
                 // ModPacketsS2CServer.sendFormChange(serverPlayer, form.getFormID());
             } catch (Exception e) {
                 ShapeShifterCurseFabric.LOGGER.error("Failed to send form change notification: ", e);
@@ -133,25 +142,30 @@ public class FormUtils {
         savePlayerFormHistory(player);
     }
 
-    public static void setFormNextLevel(PlayerEntity player, ITransformReason reason) {
-        IForm form = getPlayerForm(player);
-        IForm nextForm = form._getNextForm(player, reason);
-        _setForm(player, nextForm);
-        getPlayerFormHistory(player).add(nextForm);
+    public static void pushFormHistory(PlayerEntity player, IForm form) {
+        List<IForm> formHistory = getPlayerFormHistory(player);
+        formHistory.add(form);
         savePlayerFormHistory(player);
     }
 
-    public static void setFormPrevLevel(PlayerEntity player, ITransformReason reason) {
-        IForm form = getPlayerForm(player);
-        IForm prevForm = form._getPrevForm(player, reason);
-        _setForm(player, prevForm);
+    public static void checkAndPullFormHistory(PlayerEntity player, IForm lastForm, IForm prevForm) {
         List<IForm> formHistory = getPlayerFormHistory(player);
-        if (formHistory.size() > 1 && isFormEqual(formHistory.get(formHistory.size() - 1), form) && isFormEqual(formHistory.get(formHistory.size() - 2), prevForm)) {
+        if (formHistory.size() > 1 && isFormEqual(formHistory.get(formHistory.size() - 1), lastForm) && isFormEqual(formHistory.get(formHistory.size() - 2), prevForm)) {
             formHistory.remove(formHistory.size() - 1);
         } else {
             formHistory.clear();
-            ShapeShifterCurseFabric.LOGGER.warn("Player " + player.getName().getString() + " prev form data error. clear prev form data.");
+            ShapeShifterCurseFabric.LOGGER.warn("Player " + player.getName().getString() + " form history data error. clear form history data.");
         }
         savePlayerFormHistory(player);
+    }
+
+    public static @NotNull IForm getFormNextLevel(PlayerEntity player, ITransformReason reason) {
+        IForm form = getPlayerForm(player);
+        return form._getNextForm(player, reason);
+    }
+
+    public static @NotNull IForm getFormPrevLevel(PlayerEntity player, ITransformReason reason) {
+        IForm form = getPlayerForm(player);
+        return form._getPrevForm(player, reason);
     }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/FormUtils.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/FormUtils.java
@@ -159,6 +159,17 @@ public class FormUtils {
         savePlayerFormHistory(player);
     }
 
+    public static void updateFormHistory(PlayerEntity player, IForm formA, IForm formB) {
+        // 如果History为[C, B, A] formA == A formB == B History -> [C, B] 否则向后增加 formB
+        List<IForm> formHistory = getPlayerFormHistory(player);
+        if (formHistory.size() > 1 && isFormEqual(formHistory.get(formHistory.size() - 1), formA) && isFormEqual(formHistory.get(formHistory.size() - 2), formB)) {
+            formHistory.remove(formHistory.size() - 1);
+        } else {
+            formHistory.add(formB);
+        }
+        savePlayerFormHistory(player);
+    }
+
     public static @NotNull IForm getFormNextLevel(PlayerEntity player, ITransformReason reason) {
         IForm form = getPlayerForm(player);
         return form._getNextForm(player, reason);

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/IForm.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/IForm.java
@@ -136,4 +136,9 @@ public interface IForm {
     default boolean isEquals(IForm form) {
         return form != null && this.getFormID().equals(form.getFormID());
     }
+
+    default boolean isPlayerForm(PlayerEntity player) {
+        IForm playerForm = FormUtils.getPlayerForm(player);
+        return this.isEquals(playerForm);
+    }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/NormalForm.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/NormalForm.java
@@ -107,4 +107,13 @@ public class NormalForm implements IForm {
         this.applyScaleFunc = func;
         return this;
     }
+
+    // 所有形态必须重载 equals 函数 由于IForm是接口 没法重载Object的函数
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof IForm iForm) {
+            return this.isEquals(iForm);
+        }
+        return false;
+    }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/PlayerFormComponent.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/PlayerFormComponent.java
@@ -10,6 +10,7 @@ import net.minecraft.nbt.NbtList;
 import net.minecraft.nbt.NbtString;
 import net.minecraft.util.Identifier;
 import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+import net.onixary.shapeShifterCurseFabric.player_form.RegPlayerForms;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,10 +21,11 @@ import java.util.List;
 public class PlayerFormComponent implements AutoSyncedComponent {
     public static final ComponentKey<PlayerFormComponent> COMPONENT = ComponentRegistry.getOrCreate(ShapeShifterCurseFabric.identifier("player_form"), PlayerFormComponent.class);
 
-    public @NotNull IForm nowForm;
+    public @NotNull IForm nowForm = RegPlayerForms.N_ORIGINAL_BEFORE_ENABLE;
     public final List<IForm> formHistory = new ArrayList<>();
     // 诅咒之月逻辑
     public boolean isCursedMoonApplied = false;
+    public boolean lastTransformByCure = false;  // 仅用于诅咒之月 进入和退出诅咒之月时会清空
     public @Nullable IForm BeforeCursedMoonAppliedForm = null;
     public @Nullable IForm AfterCursedMoonAppliedForm = null;
     // 变形系统
@@ -40,9 +42,9 @@ public class PlayerFormComponent implements AutoSyncedComponent {
     public void readFromNbt(NbtCompound tag) {
         // 目前没写形态注册表 先用null凑活一下
         if (tag.contains("nowForm")) {
-            nowForm = FormUtils.parseForm(Identifier.tryParse(tag.getString("nowForm")), null);
+            nowForm = FormUtils.parseForm(Identifier.tryParse(tag.getString("nowForm")), RegPlayerForms.N_ORIGINAL_BEFORE_ENABLE);
         } else {
-            nowForm = null;
+            nowForm = RegPlayerForms.N_ORIGINAL_BEFORE_ENABLE;
         }
         if (tag.contains("formHistory")) {
             NbtList history = tag.getList("formHistory", NbtElement.STRING_TYPE);
@@ -58,6 +60,11 @@ public class PlayerFormComponent implements AutoSyncedComponent {
         } else {
             isCursedMoonApplied = false;
         }
+        if (tag.contains("lastTransformByCure")) {
+            lastTransformByCure = tag.getBoolean("lastTransformByCure");
+        } else {
+            lastTransformByCure = false;
+        }
         if (tag.contains("BeforeCursedMoonAppliedForm")) {
             BeforeCursedMoonAppliedForm = FormUtils.parseForm(Identifier.tryParse(tag.getString("BeforeCursedMoonAppliedForm")), null);
         } else {
@@ -67,6 +74,11 @@ public class PlayerFormComponent implements AutoSyncedComponent {
             AfterCursedMoonAppliedForm = FormUtils.parseForm(Identifier.tryParse(tag.getString("AfterCursedMoonAppliedForm")), null);
         } else {
             AfterCursedMoonAppliedForm = null;
+        }
+        if (tag.contains("transformTargetForm")) {
+            transformTargetForm = FormUtils.parseForm(Identifier.tryParse(tag.getString("transformTargetForm")), null);
+        } else {
+            transformTargetForm = null;
         }
     }
 
@@ -79,6 +91,7 @@ public class PlayerFormComponent implements AutoSyncedComponent {
         }
         tag.put("formHistory", history);
         tag.putBoolean("isCursedMoonApplied", isCursedMoonApplied);
+        tag.putBoolean("lastTransformByCure", lastTransformByCure);
         if (BeforeCursedMoonAppliedForm != null) {
             tag.putString("BeforeCursedMoonAppliedForm", BeforeCursedMoonAppliedForm.getFormID().toString());
         }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/PlayerFormComponent.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/PlayerFormComponent.java
@@ -1,0 +1,96 @@
+package net.onixary.shapeShifterCurseFabric.player_form.new_form_system;
+
+import dev.onyxstudios.cca.api.v3.component.ComponentKey;
+import dev.onyxstudios.cca.api.v3.component.ComponentRegistry;
+import dev.onyxstudios.cca.api.v3.component.sync.AutoSyncedComponent;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtList;
+import net.minecraft.nbt.NbtString;
+import net.minecraft.util.Identifier;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class PlayerFormComponent implements AutoSyncedComponent {
+    public static final ComponentKey<PlayerFormComponent> COMPONENT = ComponentRegistry.getOrCreate(ShapeShifterCurseFabric.identifier("player_form"), PlayerFormComponent.class);
+
+    public @NotNull IForm nowForm;
+    public final List<IForm> formHistory = new ArrayList<>();
+    // 诅咒之月逻辑
+    public boolean isCursedMoonApplied = false;
+    public @Nullable IForm BeforeCursedMoonAppliedForm = null;
+    public @Nullable IForm AfterCursedMoonAppliedForm = null;
+    // 变形系统
+    public @Nullable IForm transformTargetForm = null;
+
+    // 临时变量
+    public PlayerEntity player = null;
+
+    public PlayerFormComponent(PlayerEntity player) {
+        this.player = player;
+    }
+
+    @Override
+    public void readFromNbt(NbtCompound tag) {
+        // 目前没写形态注册表 先用null凑活一下
+        if (tag.contains("nowForm")) {
+            nowForm = FormUtils.parseForm(Identifier.tryParse(tag.getString("nowForm")), null);
+        } else {
+            nowForm = null;
+        }
+        if (tag.contains("formHistory")) {
+            NbtList history = tag.getList("formHistory", NbtElement.STRING_TYPE);
+            for (NbtElement element : history) {
+                IForm form = FormUtils.parseForm(Identifier.tryParse(element.asString()), null);
+                if (form != null) {
+                    formHistory.add(form);
+                }
+            }
+        }
+        if (tag.contains("isCursedMoonApplied")) {
+            isCursedMoonApplied = tag.getBoolean("isCursedMoonApplied");
+        } else {
+            isCursedMoonApplied = false;
+        }
+        if (tag.contains("BeforeCursedMoonAppliedForm")) {
+            BeforeCursedMoonAppliedForm = FormUtils.parseForm(Identifier.tryParse(tag.getString("BeforeCursedMoonAppliedForm")), null);
+        } else {
+            BeforeCursedMoonAppliedForm = null;
+        }
+        if (tag.contains("AfterCursedMoonAppliedForm")) {
+            AfterCursedMoonAppliedForm = FormUtils.parseForm(Identifier.tryParse(tag.getString("AfterCursedMoonAppliedForm")), null);
+        } else {
+            AfterCursedMoonAppliedForm = null;
+        }
+    }
+
+    @Override
+    public void writeToNbt(NbtCompound tag) {
+        tag.putString("nowForm", nowForm.getFormID().toString());
+        NbtList history = new NbtList();
+        for (IForm form : formHistory) {
+            history.add(NbtString.of(form.getFormID().toString()));
+        }
+        tag.put("formHistory", history);
+        tag.putBoolean("isCursedMoonApplied", isCursedMoonApplied);
+        if (BeforeCursedMoonAppliedForm != null) {
+            tag.putString("BeforeCursedMoonAppliedForm", BeforeCursedMoonAppliedForm.getFormID().toString());
+        }
+        if (AfterCursedMoonAppliedForm != null) {
+            tag.putString("AfterCursedMoonAppliedForm", AfterCursedMoonAppliedForm.getFormID().toString());
+        }
+        if (transformTargetForm != null) {
+            tag.putString("transformTargetForm", transformTargetForm.getFormID().toString());
+        }
+    }
+
+    public void sync() {
+        COMPONENT.sync(this.player);
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/TransformManager.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/TransformManager.java
@@ -1,0 +1,84 @@
+package net.onixary.shapeShifterCurseFabric.player_form.new_form_system;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.MinecraftServer;
+import net.onixary.shapeShifterCurseFabric.data.StaticParams;
+import net.onixary.shapeShifterCurseFabric.screen_effect.TransformOverlay;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+public class TransformManager {
+    // Server Side
+    public HashMap<UUID, Integer> playerTransformTimer = new HashMap<>();  // 默认值为-1 当大于等于0时开始每Tick递增 并且进入变形 当PlayerFormComponent.transformTargetForm != null且playerTransformTimer<0时开始变形
+    // Client Side
+    public int transformTimer = -1;  // 处理 nauesaStrength 和 blackStrength
+
+    public void startTransform(PlayerEntity player, IForm form) {
+        PlayerFormComponent.COMPONENT.get(player).transformTargetForm = form;
+        playerTransformTimer.put(player.getUuid(), 0);
+    }
+
+    public void setForm(PlayerEntity player, IForm form) {
+        PlayerFormComponent.COMPONENT.get(player).transformTargetForm = null;
+        playerTransformTimer.put(player.getUuid(), -1);
+        // TODO
+    }
+
+    private void startPlayerTransform(PlayerEntity player) {
+
+    }
+
+    private void middlePlayerTransform(PlayerEntity player) {
+
+    }
+
+    private void endPlayerTransform(PlayerEntity player) {
+
+    }
+
+    public void clientTick() {
+        if (transformTimer < 0) {
+            return;
+        }
+        float nauesaStrength = 0.0f;
+        float blackStrength = 0.0f;
+        if (transformTimer < StaticParams.TRANSFORM_FX_DURATION_IN) {
+            nauesaStrength = 1.0f - (transformTimer / (float) StaticParams.TRANSFORM_FX_DURATION_IN);
+            blackStrength = Math.max(nauesaStrength - 0.8f, 0.0f) * 5;
+        } else if (transformTimer < StaticParams.TRANSFORM_FX_DURATION_IN + StaticParams.TRANSFORM_FX_DURATION_OUT) {
+            nauesaStrength = 1.0f - ((transformTimer - StaticParams.TRANSFORM_FX_DURATION_IN) / (float) StaticParams.TRANSFORM_FX_DURATION_IN);
+            blackStrength = Math.min(1.0f, nauesaStrength / 0.6f);
+        } else {
+            transformTimer = -1;
+        }
+        TransformOverlay.INSTANCE.setNauesaStrength(nauesaStrength);
+        TransformOverlay.INSTANCE.setBlackStrength(blackStrength);
+        transformTimer++;
+    }
+
+    public void serverTick(MinecraftServer server) {
+        for (PlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            IForm form = PlayerFormComponent.COMPONENT.get(player).transformTargetForm;
+            if (form == null) {
+                continue;
+            }
+            int timer = playerTransformTimer.getOrDefault(player.getUuid(), -1);
+            if (timer < 0) {
+                continue;
+            }
+            if (timer == 0) {
+                startPlayerTransform(player);  // 需要写一个同步包到客户端
+            } else if (timer == StaticParams.TRANSFORM_FX_DURATION_IN) {
+                middlePlayerTransform(player);
+            } else if (timer == StaticParams.TRANSFORM_FX_DURATION_IN + StaticParams.TRANSFORM_FX_DURATION_OUT) {
+                endPlayerTransform(player);  // 此处调用 setForm 会清空playerTransformTimer
+            }
+            timer = playerTransformTimer.getOrDefault(player.getUuid(), -1);
+            if (timer >= 0) {
+                playerTransformTimer.put(player.getUuid(), timer + 1);
+            }
+        }
+    }
+
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/TransformManager.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/TransformManager.java
@@ -165,4 +165,5 @@ public class TransformManager {
             }
         }
     }
+
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/TransformManager.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/new_form_system/TransformManager.java
@@ -2,42 +2,125 @@ package net.onixary.shapeShifterCurseFabric.player_form.new_form_system;
 
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.onixary.shapeShifterCurseFabric.data.StaticParams;
+import net.onixary.shapeShifterCurseFabric.networking.ModPacketsS2CServer;
+import net.onixary.shapeShifterCurseFabric.player_form.RegPlayerForms;
+import net.onixary.shapeShifterCurseFabric.player_form.effect.PlayerTransformEffectManager;
+import net.onixary.shapeShifterCurseFabric.player_form.instinct.InstinctTicker;
 import net.onixary.shapeShifterCurseFabric.screen_effect.TransformOverlay;
+import net.onixary.shapeShifterCurseFabric.status_effects.attachment.EffectManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 public class TransformManager {
+    public static class PlayerTransformData {
+        public @NotNull PlayerEntity player;
+        public int transformTimer = -1;
+        public @Nullable IForm transformStartForm = null;
+        public @Nullable IForm transformEndForm = null;
+        // 注意 当玩家退出重进时此逻辑失效
+        public @Nullable Consumer<PlayerTransformData> onTransformComplete = null;
+    }
+
     // Server Side
-    public HashMap<UUID, Integer> playerTransformTimer = new HashMap<>();  // 默认值为-1 当大于等于0时开始每Tick递增 并且进入变形 当PlayerFormComponent.transformTargetForm != null且playerTransformTimer<0时开始变形
+    private static final HashMap<UUID, PlayerTransformData> playerData = new HashMap<>();  // 默认值为-1 当大于等于0时开始每Tick递增 并且进入变形 当PlayerFormComponent.transformTargetForm != null且playerTransformTimer<0时开始变形
     // Client Side
-    public int transformTimer = -1;  // 处理 nauesaStrength 和 blackStrength
+    private static int transformTimer = -1;  // 处理 nauesaStrength 和 blackStrength
 
-    public void startTransform(PlayerEntity player, IForm form) {
+    private static PlayerTransformData getPlayerData(PlayerEntity player) {
+        PlayerTransformData data = playerData.get(player.getUuid());
+        if (data == null) {
+            data = new PlayerTransformData();
+            data.player = player;
+            playerData.put(player.getUuid(), data);
+        }
+        return data;
+    }
+
+    public static void startTransform(PlayerEntity player, IForm form, @Nullable Consumer<PlayerTransformData> onTransformComplete) {
         PlayerFormComponent.COMPONENT.get(player).transformTargetForm = form;
-        playerTransformTimer.put(player.getUuid(), 0);
+        PlayerTransformData data = getPlayerData(player);
+        data.transformTimer = 0;
+        data.transformStartForm = FormUtils.getPlayerForm(player);
+        data.transformEndForm = form;
+        data.onTransformComplete = onTransformComplete;
+        // 瞬间变形配置
+        // if (XXXX) {
+        //     data.transformTimer = -1;
+        //     setForm(player);
+        // }
     }
 
-    public void setForm(PlayerEntity player, IForm form) {
-        PlayerFormComponent.COMPONENT.get(player).transformTargetForm = null;
-        playerTransformTimer.put(player.getUuid(), -1);
-        // TODO
+    public static void immediatelyTransform(PlayerEntity player, IForm form) {
+        PlayerFormComponent.COMPONENT.get(player).transformTargetForm = form;
+        PlayerTransformData data = getPlayerData(player);
+        data.transformTimer = -1;
+        data.transformStartForm = FormUtils.getPlayerForm(player);
+        data.transformEndForm = form;
+        data.onTransformComplete = null;
+        setForm(player);
     }
 
-    private void startPlayerTransform(PlayerEntity player) {
-
+    public static void setForm(PlayerEntity player) {
+        PlayerFormComponent component = PlayerFormComponent.COMPONENT.get(player);
+        component.transformTargetForm = null;
+        PlayerTransformData data = getPlayerData(player);
+        IForm form = data.transformEndForm;
+        data.transformTimer = -1;
+        EffectManager.clearTransformativeEffect(player);
+        FormUtils._setForm(player, form);
+        FormUtils.updateFormHistory(player, data.transformStartForm, form);
     }
 
-    private void middlePlayerTransform(PlayerEntity player) {
-
+    private static void startPlayerTransform(PlayerEntity player) {
+        // 向客户端同步数据
+        PlayerTransformData data = getPlayerData(player);
+        IForm nowForm = data.transformStartForm;
+        IForm targetForm = data.transformEndForm;
+        // 改成 Identifier
+        // ModPacketsS2CServer.sendTransformState(player, true, nowForm.getFormID(), targetForm.getFormID());
+        // 顺便把同步transformTimer挂在SYNC_TRANSFORM_STATE上
+        // 顺便把playClientTransformEffect逻辑也挂上
+        InstinctTicker.isPausing = true;
+        if (player instanceof ServerPlayerEntity serverPlayerEntity) {
+            PlayerTransformEffectManager.applyStartTransformEffect(serverPlayerEntity, StaticParams.TRANSFORM_FX_DURATION_IN);
+        }
     }
 
-    private void endPlayerTransform(PlayerEntity player) {
-
+    private static void middlePlayerTransform(PlayerEntity player) {
+        PlayerTransformData data = getPlayerData(player);
+        // 清空本能值挂在本能值触发变形时
+        setForm(player);
+        if (player instanceof ServerPlayerEntity serverPlayerEntity) {
+            PlayerTransformEffectManager.applyEndTransformEffect(serverPlayerEntity, StaticParams.TRANSFORM_FX_DURATION_OUT);
+        }
     }
 
-    public void clientTick() {
+    private static void endPlayerTransform(PlayerEntity player) {
+        PlayerTransformData data = getPlayerData(player);
+        IForm nowForm = data.transformStartForm;
+        IForm targetForm = data.transformEndForm;
+        // 改成 Identifier
+        // ModPacketsS2CServer.sendTransformState(player, false, nowForm.getFormID(), nowForm.getFormID());
+        // 顺便把executeClientTransformCompleteEffect逻辑挂上
+        InstinctTicker.isPausing = false;
+        if (player instanceof ServerPlayerEntity serverPlayerEntity) {
+            PlayerTransformEffectManager.applyFinaleTransformEffect(serverPlayerEntity, 5);
+        }
+        if (data.onTransformComplete != null) {
+            data.onTransformComplete.accept(data);
+            data.onTransformComplete = null;
+        }
+    }
+
+    public static void clientTick() {
         if (transformTimer < 0) {
             return;
         }
@@ -57,28 +140,29 @@ public class TransformManager {
         transformTimer++;
     }
 
-    public void serverTick(MinecraftServer server) {
+    public static void serverTick(MinecraftServer server) {
         for (PlayerEntity player : server.getPlayerManager().getPlayerList()) {
             IForm form = PlayerFormComponent.COMPONENT.get(player).transformTargetForm;
             if (form == null) {
                 continue;
             }
-            int timer = playerTransformTimer.getOrDefault(player.getUuid(), -1);
+            PlayerTransformData data = getPlayerData(player);
+            int timer = data.transformTimer;
             if (timer < 0) {
+                startTransform(player, form, null);
                 continue;
             }
             if (timer == 0) {
-                startPlayerTransform(player);  // 需要写一个同步包到客户端
+                startPlayerTransform(player);
             } else if (timer == StaticParams.TRANSFORM_FX_DURATION_IN) {
                 middlePlayerTransform(player);
             } else if (timer == StaticParams.TRANSFORM_FX_DURATION_IN + StaticParams.TRANSFORM_FX_DURATION_OUT) {
-                endPlayerTransform(player);  // 此处调用 setForm 会清空playerTransformTimer
+                endPlayerTransform(player);
+                data.transformTimer = -1;
             }
-            timer = playerTransformTimer.getOrDefault(player.getUuid(), -1);
-            if (timer >= 0) {
-                playerTransformTimer.put(player.getUuid(), timer + 1);
+            if (data.transformTimer >= 0) {
+                data.transformTimer++;
             }
         }
     }
-
 }

--- a/src/main/resources/data/origins/tags/items/shields.json
+++ b/src/main/resources/data/origins/tags/items/shields.json
@@ -32,7 +32,8 @@
       "required": false
     },
     {
-      "id": "twilightforest:knightmetal_shield"
+      "id": "twilightforest:knightmetal_shield",
+      "required": false
 	}
   ]
 }


### PR DESCRIPTION
尝试复现时发现在测试环境power也失效了(一般互联版bug在测试环境都不会复现 能复现的都是主线的Bug) 最后发现盾牌tag的最后一项缺失`"required": false` 导致未加载暮色森林时禁止盾牌Power失效 看git记录 估计是1.8.3版本就有这个Bug了(看 https://github.com/onixary/shape-shifter-curse-fabric/pull/333 合并时间 如果合的晚就1.9.0)