### PR TITLE
将Origins的NameSpace迁移至Apoli 迁移被使用的Tag 修改版本号为1.10.0

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
 #### 标记一些需要在后续版本更新中需要修改项 尽可能让拓展大约能跨小版本兼容(仅跨1个小版本)
 
 ### 1.9.x:
-- (1) Power 中的 Origins Namespace 迁移至 Apoli Namespace
-- (2) 将 Origins 的 Tag 转成 SSC 的 Tag (复制)
+- (1) Power 中的 Origins Namespace 迁移至 Apoli Namespace [√]
+- (2) 将 Origins 的 Tag 转成 SSC 的 Tag (复制) [√]
 - 移除 Origins 的 Lang
 - 移除 Origins 的数据包和资源包(除了`origins_layers`)
 - 移除 `net.onixary.shapeShifterCurseFabric.integration.origins.Origins` 里的 `NamespaceAlias.addAlias(MODID, "apoli");` 需要 (1) 完成后等1个小版本

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,7 @@
 ### 1.9.x:
 - (1) Power 中的 Origins Namespace 迁移至 Apoli Namespace [√]
 - (2) 将 Origins 的 Tag 转成 SSC 的 Tag (复制) [√]
+- 迁移 Origins 的 Damage Type
 - 移除 Origins 的 Lang
 - 移除 Origins 的数据包和资源包(除了`origins_layers`)
 - 移除 `net.onixary.shapeShifterCurseFabric.integration.origins.Origins` 里的 `NamespaceAlias.addAlias(MODID, "apoli");` 需要 (1) 完成后等1个小版本

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx8G
 	loader_version=0.16.10
 
 # Mod Properties
-	mod_version = 1.10.1
+	mod_version = 1.10.0
 	maven_group = net.onixary
 	archives_base_name = shape-shifter-curse-fabric
 

--- a/src/main/resources/data/shape-shifter-curse/powers/air_from_potions.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/air_from_potions.json
@@ -1,14 +1,14 @@
 {
-  "type": "origins:action_on_item_use",
+  "type": "apoli:action_on_item_use",
   "hidden": true,
   "item_condition": {
-    "type": "origins:ingredient",
+    "type": "apoli:ingredient",
     "ingredient": {
       "item": "minecraft:potion"
     }
   },
   "entity_action": {
-    "type": "origins:gain_air",
+    "type": "apoli:gain_air",
     "value": 300
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/air_from_splash_potions.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/air_from_splash_potions.json
@@ -2,7 +2,7 @@
   "type": "shape-shifter-curse:action_on_splash_potion_take_effect",
   "trigger_on_no_effect": true,
   "entity_action": {
-    "type": "origins:gain_air",
+    "type": "apoli:gain_air",
     "value": 150
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/always_harvest.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/always_harvest.json
@@ -1,4 +1,4 @@
 {
-    "type": "origins:modify_harvest",
+    "type": "apoli:modify_harvest",
     "allow": true
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/aqua_affinity.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/aqua_affinity.json
@@ -1,20 +1,20 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
   "underwater": {
-    "type": "origins:modify_break_speed",
+    "type": "apoli:modify_break_speed",
     "modifier": {
       "operation": "multiply_total",
       "value": 4
     },
     "condition": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:submerged_in",
+          "type": "apoli:submerged_in",
           "fluid": "minecraft:water"
         },
         {
-          "type": "origins:enchantment",
+          "type": "apoli:enchantment",
           "enchantment": "minecraft:aqua_affinity",
           "comparison": "==",
           "compare_to": 0
@@ -23,22 +23,22 @@
     }
   },
   "ungrounded": {
-    "type": "origins:modify_break_speed",
+    "type": "apoli:modify_break_speed",
     "modifier": {
       "operation": "multiply_total",
       "value": 4
     },
     "condition": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:fluid_height",
+          "type": "apoli:fluid_height",
           "fluid": "minecraft:water",
           "comparison": ">",
           "compare_to": 0
         },
         {
-          "type": "origins:on_block",
+          "type": "apoli:on_block",
           "inverted": true
         }
       ]

--- a/src/main/resources/data/shape-shifter-curse/powers/aquatic.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/aquatic.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:entity_group",
+  "type": "apoli:entity_group",
   "group": "aquatic",
   "hidden": true
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/barehand_attack_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/barehand_attack_up.json
@@ -1,10 +1,10 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:inventory",
+                "type": "apoli:inventory",
                 "process_mode": "items",
                 "item_condition": {
                     "type": "shape-shifter-curse:is_weapon"
@@ -15,7 +15,7 @@
                 "inverted": true
             },
             {
-                "type": "origins:inventory",
+                "type": "apoli:inventory",
                 "process_mode": "items",
                 "comparison": "==",
                 "compare_to": 0,

--- a/src/main/resources/data/shape-shifter-curse/powers/barehand_digging_speed_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/barehand_digging_speed_up.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_break_speed",
+    "type": "apoli:modify_break_speed",
     "condition": {
         "type": "shape-shifter-curse:barehand_digging"
     },

--- a/src/main/resources/data/shape-shifter-curse/powers/bat_vision.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/bat_vision.json
@@ -1,8 +1,8 @@
 {
-    "type": "origins:night_vision",
+    "type": "apoli:night_vision",
     "strength": 0.4,
     "condition": {
-        "type": "origins:submerged_in",
+        "type": "apoli:submerged_in",
         "fluid": "minecraft:water",
         "inverted": true
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/can_fly.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/can_fly.json
@@ -1,3 +1,3 @@
 {
-    "type": "origins:creative_flight"
+    "type": "apoli:creative_flight"
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/can_loot_spider_fluid_cocoon.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/can_loot_spider_fluid_cocoon.json
@@ -1,3 +1,3 @@
 {
-  "type": "origins:simple"
+  "type": "apoli:simple"
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/cat_vision.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/cat_vision.json
@@ -1,8 +1,8 @@
 {
-  "type": "origins:night_vision",
+  "type": "apoli:night_vision",
   "strength": 0.4,
   "condition": {
-    "type": "origins:submerged_in",
+    "type": "apoli:submerged_in",
     "fluid": "minecraft:water",
     "inverted": true
   }

--- a/src/main/resources/data/shape-shifter-curse/powers/damage_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/damage_up.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_damage_dealt",
+    "type": "apoli:modify_damage_dealt",
     "modifier": {
         "name": "Extra damage when submerged",
         "operation": "addition",

--- a/src/main/resources/data/shape-shifter-curse/powers/drop_tool_after_digging.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/drop_tool_after_digging.json
@@ -1,12 +1,12 @@
 {
-    "type": "origins:action_on_block_break",
+    "type": "apoli:action_on_block_break",
     "entity_action": {
-        "type": "origins:drop_inventory",
+        "type": "apoli:drop_inventory",
         "item_condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:harvest_level",
+                    "type": "apoli:harvest_level",
                     "comparison": ">=",
                     "compare_to": 1
                 },
@@ -21,7 +21,7 @@
         ]
     },
     "block_condition": {
-        "type": "origins:blast_resistance",
+        "type": "apoli:blast_resistance",
         "comparison": ">",
         "compare_to": 0.2
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/drop_weapon_after_hit.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/drop_weapon_after_hit.json
@@ -1,23 +1,23 @@
 {
-    "type": "origins:self_action_on_hit",
+    "type": "apoli:self_action_on_hit",
     "entity_action": {
-        "type": "origins:drop_inventory",
+        "type": "apoli:drop_inventory",
         "item_condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:or",
+                    "type": "apoli:or",
                     "conditions": [
                         {
-                            "type": "origins:ingredient",
+                            "type": "apoli:ingredient",
                             "ingredient": {
-                                "tag": "origins:melee_weapons"
+                                "tag": "shape-shifter-curse:melee_weapons"
                             }
                         },
                         {
-                            "type": "origins:ingredient",
+                            "type": "apoli:ingredient",
                             "ingredient": {
-                                "tag": "origins:tools"
+                                "tag": "shape-shifter-curse:tools"
                             }
                         }
                     ]

--- a/src/main/resources/data/shape-shifter-curse/powers/elytra_no_render.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/elytra_no_render.json
@@ -1,4 +1,4 @@
 {
-    "type": "origins:elytra_flight",
+    "type": "apoli:elytra_flight",
     "render_elytra": false
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/fall_immunity.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/fall_immunity.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:invulnerability",
+  "type": "apoli:invulnerability",
   "damage_condition": {
-    "type": "origins:name",
+    "type": "apoli:name",
     "name": "fall"
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/fire_and_lava_immunity.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/fire_and_lava_immunity.json
@@ -1,3 +1,3 @@
 {
-    "type": "origins:fire_immunity"
+    "type": "apoli:fire_immunity"
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/five_hearts.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/five_hearts.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:attribute",
+    "type": "apoli:attribute",
     "modifier": {
         "name": "Nine lives health reduction",
         "attribute": "minecraft:generic.max_health",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_all_food_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_all_food_down.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifier": {
         "name": "Decreased food points",
         "operation": "multiply_base_multiplicative",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_all_food_down2.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_all_food_down2.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifier": {
         "name": "Decreased food points",
         "operation": "multiply_base_multiplicative",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_all_food_down3.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_all_food_down3.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:modify_food",
+  "type": "apoli:modify_food",
   "food_modifier": {
     "name": "Decreased food points",
     "operation": "multiply_base_multiplicative",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_amethyst_shard_from_block.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_amethyst_shard_from_block.json
@@ -1,13 +1,13 @@
 {
-    "type": "origins:item_on_item",
+    "type": "apoli:item_on_item",
     "using_item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:amethyst_block"
         }
     },
     "on_item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:amethyst_block"
         }
@@ -17,15 +17,15 @@
         "amount": 3
     },
     "using_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "on_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.amethyst_block.break",
         "volume": 0.45
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_amethyst_shard_only.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_amethyst_shard_only.json
@@ -1,15 +1,15 @@
 {
-    "type": "origins:prevent_item_use",
+    "type": "apoli:prevent_item_use",
     "item_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:food"
+                "type": "apoli:food"
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:ignore_diet"
+                    "tag": "shape-shifter-curse:ignore_diet"
                 },
                 "inverted": true
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_attack_heal.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_attack_heal.json
@@ -1,11 +1,11 @@
 {
-    "type": "origins:self_action_on_hit",
+    "type": "apoli:self_action_on_hit",
     "entity_action": {
-        "type": "origins:heal",
+        "type": "apoli:heal",
         "amount": 2.0
     },
     "damage_condition": {
-        "type": "origins:amount",
+        "type": "apoli:amount",
         "comparison": ">=",
         "compare_to": 4.0
     },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_digging_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_digging_speed_down.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:modify_break_speed",
+    "type": "apoli:modify_break_speed",
     "block_condition": {
-        "type": "origins:hardness",
+        "type": "apoli:hardness",
         "comparison": ">=",
         "compare_to": 1
     },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_fly_hunger.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_fly_hunger.json
@@ -1,9 +1,9 @@
 {
-    "type": "origins:exhaust",
+    "type": "apoli:exhaust",
     "interval": 5,
     "exhaustion": 1.333,
     "condition": {
-        "type": "origins:power_active",
+        "type": "apoli:power_active",
         "power": "shape-shifter-curse:form_allay_sp_levitate"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_fly_speed_low_food.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_fly_speed_low_food.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "multiply_total",
@@ -8,13 +8,13 @@
     },
     "tick_rate": 1,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:creative_flying"
+                "type": "apoli:creative_flying"
             },
             {
-                "type": "origins:food_level",
+                "type": "apoli:food_level",
                 "comparison": "<",
                 "compare_to": 6
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_health.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:attribute",
+    "type": "apoli:attribute",
     "modifier": {
         "name": "Form ocelot0 health reduction",
         "attribute": "minecraft:generic.max_health",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_jukebox_heal.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_jukebox_heal.json
@@ -1,21 +1,21 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:heal",
+        "type": "apoli:heal",
         "amount": 2
     },
     "interval": 40,
     "condition": {
-        "type": "origins:block_in_radius",
+        "type": "apoli:block_in_radius",
         "block_condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:jukebox"
                 },
                 {
-                    "type": "origins:block_state",
+                    "type": "apoli:block_state",
                     "property": "has_record",
                     "value": true
                 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_levitate_speed_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_levitate_speed_up.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "multiply_total",
@@ -8,7 +8,7 @@
     },
     "tick_rate": 1,
     "condition": {
-        "type": "origins:power_active",
+        "type": "apoli:power_active",
         "power": "shape-shifter-curse:form_allay_sp_levitate"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_melee_damage_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_melee_damage_down.json
@@ -1,15 +1,15 @@
 {
-    "type": "origins:modify_damage_dealt",
+    "type": "apoli:modify_damage_dealt",
     "bientity_condition": {
-        "type": "origins:actor_condition",
+        "type": "apoli:actor_condition",
         "condition": {
-            "type": "origins:or",
+            "type": "apoli:or",
             "conditions": [
                 {
-                    "type": "origins:inventory",
+                    "type": "apoli:inventory",
                     "process_mode": "items",
                     "item_condition": {
-                        "type": "origins:harvest_level",
+                        "type": "apoli:harvest_level",
                         "comparison": ">",
                         "compare_to": 1
                     },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_mob_glow_in_range.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_mob_glow_in_range.json
@@ -1,15 +1,15 @@
 {
-    "type": "origins:entity_glow",
+    "type": "apoli:entity_glow",
     "bientity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:distance",
+                "type": "apoli:distance",
                 "comparison": "<=",
                 "compare_to": 20
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
                     "type": "shape-shifter-curse:can_render_gui"
                 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_prevent_digging_when_fly.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_prevent_digging_when_fly.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:modify_break_speed",
+    "type": "apoli:modify_break_speed",
     "condition": {
-        "type": "origins:creative_flying"
+        "type": "apoli:creative_flying"
     },
     "modifier": {
         "operation": "multiply_base",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_projectile_damage_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_projectile_damage_up.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_projectile_damage",
+    "type": "apoli:modify_projectile_damage",
     "modifier": {
         "operation": "addition",
         "value": 6.0

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_resonant_core_trinket.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_resonant_core_trinket.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
 
   "eat_amethyst_shard": {
     "type": "shape-shifter-curse:custom_edible",
@@ -12,21 +12,21 @@
   },
 
   "eat_amethyst_shard_effect": {
-    "type": "origins:action_on_item_use",
+    "type": "apoli:action_on_item_use",
     "trigger": "finish",
     "entity_action": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "actions": [
         {
           "type": "shape-shifter-curse:explosion_damage_entity",
           "power": 3,
           "entity_condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
               {
-                "type": "origins:target_condition",
+                "type": "apoli:target_condition",
                 "condition": {
-                  "type": "origins:in_tag",
+                  "type": "apoli:in_tag",
                   "tag": "shape-shifter-curse:water_explode_immune"
                 },
                 "inverted": true
@@ -35,7 +35,7 @@
           },
           "entity_action":
           {
-            "type": "origins:apply_effect",
+            "type": "apoli:apply_effect",
             "effect": {
               "effect": "minecraft:regeneration",
               "duration": 160,
@@ -61,7 +61,7 @@
       ]
     },
     "item_condition": {
-      "type": "origins:ingredient",
+      "type": "apoli:ingredient",
       "ingredient": {
         "item": "minecraft:amethyst_shard"
       }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_slipperiness.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_slipperiness.json
@@ -1,11 +1,11 @@
 {
-    "type": "origins:modify_slipperiness",
+    "type": "apoli:modify_slipperiness",
     "modifier": {
         "operation": "multiply_total",
         "value": 0.3
     },
     "block_condition": {
-        "type": "origins:in_tag",
+        "type": "apoli:in_tag",
         "tag": "minecraft:ice",
         "inverted": true
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_slow_falling.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_slow_falling.json
@@ -3,32 +3,32 @@
     "velocity": 0.015,
     "take_fall_damage": false,
     "condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:and",
+                "type": "apoli:and",
                 "conditions": [
                     {
-                        "type": "origins:sneaking"
+                        "type": "apoli:sneaking"
                     },
                     {
-                        "type": "origins:fall_flying"
+                        "type": "apoli:fall_flying"
                     }
                 ]
             },
             {
-                "type": "origins:and",
+                "type": "apoli:and",
                 "conditions": [
                     {
-                        "type": "origins:sneaking",
+                        "type": "apoli:sneaking",
                         "inverted": true
                     },
                     {
-                        "type": "origins:fall_flying",
+                        "type": "apoli:fall_flying",
                         "inverted": true
                     },
                     {
-                        "type": "origins:on_block",
+                        "type": "apoli:on_block",
                         "inverted": true
                     }
                 ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_sound.json
@@ -1,12 +1,12 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "entity.allay.ambient_without_item"
     },
     "interval": 200,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:enable_random_sound"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_sound_hurt.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_sound_hurt.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:self_action_when_hit",
+    "type": "apoli:self_action_when_hit",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.allay.hurt"
     },
     "condition": {

--- a/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_sound_key.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_allay_sp_sound_key.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:active_self",
+    "type": "apoli:active_self",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "entity.allay.ambient_without_item"
     },
     "cooldown": 5,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_0_undead_damage_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_0_undead_damage_down.json
@@ -1,19 +1,19 @@
 {
-    "type": "origins:modify_damage_dealt",
+    "type": "apoli:modify_damage_dealt",
     "bientity_condition": {
-        "type": "origins:target_condition",
+        "type": "apoli:target_condition",
         "condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:entity_group",
+                    "type": "apoli:entity_group",
                     "group": "undead"
                 }
             ]
         }
     },
     "damage_condition": {
-        "type": "origins:amount",
+        "type": "apoli:amount",
         "comparison": ">=",
         "compare_to": 2
     },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_0_wither_attack.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_0_wither_attack.json
@@ -1,15 +1,15 @@
 {
-    "type": "origins:action_on_hit",
+    "type": "apoli:action_on_hit",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:apply_effect",
+                            "type": "apoli:apply_effect",
                             "effect": {
                                 "effect": "minecraft:wither",
                                 "duration": 40,
@@ -17,7 +17,7 @@
                             }
                         },
                         {
-                            "type": "origins:spawn_particles",
+                            "type": "apoli:spawn_particles",
                             "particle": {
                                 "type": "minecraft:dust",
                                 "params": "0.07 0.07 0.07 2"
@@ -32,7 +32,7 @@
                             }
                         },
                         {
-                            "type": "origins:spawn_particles",
+                            "type": "apoli:spawn_particles",
                             "particle": {
                                 "type": "minecraft:soul_fire_flame"
                             },
@@ -51,12 +51,12 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:actor_condition",
+        "type": "apoli:actor_condition",
         "condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:status_effect",
+                    "type": "apoli:status_effect",
                     "effect": "minecraft:wither"
                 }
             ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_0_wither_on_hit.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_0_wither_on_hit.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:self_action_when_hit",
+  "type": "apoli:self_action_when_hit",
   "entity_action": {
-    "type": "origins:apply_effect",
+    "type": "apoli:apply_effect",
     "effect": {
       "effect": "minecraft:wither",
       "duration": 50,
@@ -10,6 +10,6 @@
     }
   },
   "damage_condition": {
-    "type": "origins:attacker"
+    "type": "apoli:attacker"
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_crop_to_sand.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_crop_to_sand.json
@@ -1,7 +1,7 @@
 {
   "type": "shape-shifter-curse:modify_block_drop",
   "block_condition": {
-    "type": "origins:in_tag",
+    "type": "apoli:in_tag",
     "tag": "minecraft:crops"
   },
   "chance": 0.1,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_meat_to_rotten_flesh.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_meat_to_rotten_flesh.json
@@ -1,15 +1,15 @@
 {
   "type": "shape-shifter-curse:modify_entity_loot",
   "from_item_condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:food"
+        "type": "apoli:food"
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-          "tag": "origins:raw_meat"
+          "tag": "shape-shifter-curse:raw_meat"
         }
       }
     ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_summon_wolf_when_hit.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_summon_wolf_when_hit.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:action_when_hit",
+  "type": "apoli:action_when_hit",
   "bientity_action": {
     "type": "shape-shifter-curse:bi_summon_anubis_wolf_minion",
     "minion_level": 1,
@@ -9,6 +9,6 @@
     "reverse": true
   },
   "damage_condition": {
-    "type": "origins:attacker"
+    "type": "apoli:attacker"
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_undead_damage_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_undead_damage_down.json
@@ -1,19 +1,19 @@
 {
-    "type": "origins:modify_damage_dealt",
+    "type": "apoli:modify_damage_dealt",
     "bientity_condition": {
-        "type": "origins:target_condition",
+        "type": "apoli:target_condition",
         "condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:entity_group",
+                    "type": "apoli:entity_group",
                     "group": "undead"
                 }
             ]
         }
     },
     "damage_condition": {
-        "type": "origins:amount",
+        "type": "apoli:amount",
         "comparison": ">=",
         "compare_to": 2
     },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_vegetarian_saturation_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_vegetarian_saturation_down.json
@@ -1,33 +1,33 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "saturation_modifier": {
         "name": "Decreased saturation points",
         "operation": "multiply_base_multiplicative",
         "value": -0.2
     },
     "item_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:meat"
+                    "tag": "shape-shifter-curse:meat"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:meat",
+                "type": "apoli:meat",
                 "inverted": true
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:ignore_diet"
+                    "tag": "shape-shifter-curse:ignore_diet"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
                     "tag": "shape-shifter-curse:ignore_vc_eat"
                 },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_wither_attack.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_wither_attack.json
@@ -1,12 +1,12 @@
 {
-  "type": "origins:action_on_hit",
+  "type": "apoli:action_on_hit",
   "bientity_action": {
-    "type": "origins:target_action",
+    "type": "apoli:target_action",
     "action": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "actions": [
         {
-          "type": "origins:apply_effect",
+          "type": "apoli:apply_effect",
           "effect": {
             "effect": "minecraft:wither",
             "duration": 20,
@@ -14,7 +14,7 @@
           }
         },
         {
-          "type": "origins:spawn_particles",
+          "type": "apoli:spawn_particles",
           "particle": {
             "type": "minecraft:dust",
             "params": "0.07 0.07 0.07 2"
@@ -29,7 +29,7 @@
           }
         },
         {
-          "type": "origins:spawn_particles",
+          "type": "apoli:spawn_particles",
           "particle": "minecraft:soul_fire_flame",
           "count": 4,
           "speed": 0,
@@ -44,9 +44,9 @@
     }
   },
   "bientity_condition": {
-    "type": "origins:actor_condition",
+    "type": "apoli:actor_condition",
     "condition": {
-      "type": "origins:status_effect",
+      "type": "apoli:status_effect",
       "effect": "minecraft:wither"
     }
   }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_wither_attack_heal.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_wither_attack_heal.json
@@ -1,15 +1,15 @@
 {
-    "type": "origins:action_on_hit",
+    "type": "apoli:action_on_hit",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:heal",
+                            "type": "apoli:heal",
                             "amount": 1
                         }
                     ]
@@ -18,19 +18,19 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:actor_condition",
+        "type": "apoli:actor_condition",
         "condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:status_effect",
+                    "type": "apoli:status_effect",
                     "effect": "minecraft:wither"
                 }
             ]
         }
     },
     "damage_condition": {
-        "type": "origins:amount",
+        "type": "apoli:amount",
         "comparison": ">",
         "compare_to": 1
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_wither_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_wither_health.json
@@ -10,7 +10,7 @@
     "updateHealth": true,
     "delay": 1,
     "condition": {
-        "type": "origins:status_effect",
+        "type": "apoli:status_effect",
         "effect": "minecraft:wither"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_wither_on_hit.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_1_wither_on_hit.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:self_action_when_hit",
+  "type": "apoli:self_action_when_hit",
   "entity_action": {
-    "type": "origins:apply_effect",
+    "type": "apoli:apply_effect",
     "effect": {
       "effect": "minecraft:wither",
       "duration": 90,
@@ -10,6 +10,6 @@
     }
   },
   "damage_condition": {
-    "type": "origins:attacker"
+    "type": "apoli:attacker"
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_crop_to_sand.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_crop_to_sand.json
@@ -1,7 +1,7 @@
 {
   "type": "shape-shifter-curse:modify_block_drop",
   "block_condition": {
-    "type": "origins:in_tag",
+    "type": "apoli:in_tag",
     "tag": "minecraft:crops"
   },
   "chance": 0.2,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_meat_to_rotten_flesh.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_meat_to_rotten_flesh.json
@@ -1,15 +1,15 @@
 {
   "type": "shape-shifter-curse:modify_entity_loot",
   "from_item_condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:food"
+        "type": "apoli:food"
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-          "tag": "origins:raw_meat"
+          "tag": "shape-shifter-curse:raw_meat"
         }
       }
     ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_summon_wolf_when_hit.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_summon_wolf_when_hit.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:action_when_hit",
+  "type": "apoli:action_when_hit",
   "bientity_action": {
     "type": "shape-shifter-curse:bi_summon_anubis_wolf_minion",
     "minion_level": 2,
@@ -15,6 +15,6 @@
     }
   },
   "damage_condition": {
-    "type": "origins:attacker"
+    "type": "apoli:attacker"
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_undead_damage_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_undead_damage_down.json
@@ -1,19 +1,19 @@
 {
-    "type": "origins:modify_damage_dealt",
+    "type": "apoli:modify_damage_dealt",
     "bientity_condition": {
-        "type": "origins:target_condition",
+        "type": "apoli:target_condition",
         "condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:entity_group",
+                    "type": "apoli:entity_group",
                     "group": "undead"
                 }
             ]
         }
     },
     "damage_condition": {
-        "type": "origins:amount",
+        "type": "apoli:amount",
         "comparison": ">=",
         "compare_to": 3
     },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_undead_dealt_damage_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_undead_dealt_damage_down.json
@@ -1,24 +1,24 @@
 {
-    "type": "origins:self_action_on_hit",
+    "type": "apoli:self_action_on_hit",
     "damage_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:attacker",
+                "type": "apoli:attacker",
                 "entity_condition": {
-                    "type": "origins:entity_group",
+                    "type": "apoli:entity_group",
                     "group": "undead"
                 }
             },
             {
-                "type": "origins:amount",
+                "type": "apoli:amount",
                 "comparison": ">=",
                 "compare_to": 1
             }
         ]
     },
     "entity_action": {
-        "type": "origins:heal",
+        "type": "apoli:heal",
         "amount": 1
     },
     "cooldown": 5

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_undead_effect_in_range.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_undead_effect_in_range.json
@@ -1,21 +1,21 @@
 {
     "type": "shape-shifter-curse:action_on_entity_in_range",
     "entity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:entity_group",
+                "type": "apoli:entity_group",
                 "group": "undead"
             },
             {
-                "type": "origins:status_effect",
+                "type": "apoli:status_effect",
                 "effect": "minecraft:weakness",
                 "inverted": true
             }
         ]
     },
     "entity_action": {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
             "effect": "minecraft:weakness",
             "duration": 20,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_vegetarian_saturation_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_vegetarian_saturation_down.json
@@ -1,33 +1,33 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "saturation_modifier": {
         "name": "Decreased saturation points",
         "operation": "multiply_base_multiplicative",
         "value": -0.5
     },
     "item_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:meat"
+                    "tag": "shape-shifter-curse:meat"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:meat",
+                "type": "apoli:meat",
                 "inverted": true
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:ignore_diet"
+                    "tag": "shape-shifter-curse:ignore_diet"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
                     "tag": "shape-shifter-curse:ignore_vc_eat"
                 },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_wither_attack.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_wither_attack.json
@@ -1,15 +1,15 @@
 {
-    "type": "origins:action_on_hit",
+    "type": "apoli:action_on_hit",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:apply_effect",
+                            "type": "apoli:apply_effect",
                             "effect": {
                                 "effect": "minecraft:wither",
                                 "duration": 40,
@@ -17,7 +17,7 @@
                             }
                         },
                         {
-                            "type": "origins:spawn_particles",
+                            "type": "apoli:spawn_particles",
                             "particle": {
                                 "type": "minecraft:dust",
                                 "params": "0.07 0.07 0.07 2"
@@ -32,7 +32,7 @@
                             }
                         },
                         {
-                            "type": "origins:spawn_particles",
+                            "type": "apoli:spawn_particles",
                             "particle": {
                                 "type": "minecraft:soul_fire_flame"
                             },
@@ -51,12 +51,12 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:actor_condition",
+        "type": "apoli:actor_condition",
         "condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:status_effect",
+                    "type": "apoli:status_effect",
                     "effect": "minecraft:wither"
                 }
             ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_wither_attack_heal.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_wither_attack_heal.json
@@ -1,15 +1,15 @@
 {
-    "type": "origins:action_on_hit",
+    "type": "apoli:action_on_hit",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:heal",
+                            "type": "apoli:heal",
                             "amount": 2
                         }
                     ]
@@ -18,19 +18,19 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:actor_condition",
+        "type": "apoli:actor_condition",
         "condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:status_effect",
+                    "type": "apoli:status_effect",
                     "effect": "minecraft:wither"
                 }
             ]
         }
     },
     "damage_condition": {
-        "type": "origins:amount",
+        "type": "apoli:amount",
         "comparison": ">",
         "compare_to": 1
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_wither_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_wither_health.json
@@ -10,7 +10,7 @@
   "updateHealth": true,
   "delay": 1,
   "condition": {
-    "type": "origins:status_effect",
+    "type": "apoli:status_effect",
     "effect": "minecraft:wither"
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_wither_on_hit.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_wither_on_hit.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:self_action_when_hit",
+  "type": "apoli:self_action_when_hit",
   "entity_action": {
-    "type": "origins:apply_effect",
+    "type": "apoli:apply_effect",
     "effect": {
       "effect": "minecraft:wither",
       "duration": 50,
@@ -10,6 +10,6 @@
     }
   },
   "damage_condition": {
-    "type": "origins:attacker"
+    "type": "apoli:attacker"
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_withered_bandage_trinket.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_2_withered_bandage_trinket.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:self_action_when_hit",
+  "type": "apoli:self_action_when_hit",
   "entity_action": {
-    "type": "origins:apply_effect",
+    "type": "apoli:apply_effect",
     "effect": {
       "effect": "minecraft:wither",
       "duration": 100,
@@ -10,6 +10,6 @@
     }
   },
   "damage_condition": {
-    "type": "origins:attacker"
+    "type": "apoli:attacker"
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_crop_to_sand.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_crop_to_sand.json
@@ -1,7 +1,7 @@
 {
   "type": "shape-shifter-curse:modify_block_drop",
   "block_condition": {
-    "type": "origins:in_tag",
+    "type": "apoli:in_tag",
     "tag": "minecraft:crops"
   },
   "chance": 0.35,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_immune_regeneration.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_immune_regeneration.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:effect_immunity",
+  "type": "apoli:effect_immunity",
   "effects": [
     "minecraft:regeneration",
     "minecraft:instant_health"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_meat_to_rotten_flesh.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_meat_to_rotten_flesh.json
@@ -1,15 +1,15 @@
 {
   "type": "shape-shifter-curse:modify_entity_loot",
   "from_item_condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:food"
+        "type": "apoli:food"
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-          "tag": "origins:raw_meat"
+          "tag": "shape-shifter-curse:raw_meat"
         }
       }
     ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_summon_wolf_on_hit.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_summon_wolf_on_hit.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:action_on_hit",
+  "type": "apoli:action_on_hit",
   "bientity_action": {
     "type": "shape-shifter-curse:bi_summon_anubis_wolf_minion",
     "minion_level": 3,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_summon_wolf_when_hit.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_summon_wolf_when_hit.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:action_when_hit",
+  "type": "apoli:action_when_hit",
   "bientity_action": {
     "type": "shape-shifter-curse:bi_summon_anubis_wolf_minion",
     "minion_level": 3,
@@ -9,6 +9,6 @@
     "reverse": true
   },
   "damage_condition": {
-    "type": "origins:attacker"
+    "type": "apoli:attacker"
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_undead_damage_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_undead_damage_down.json
@@ -1,19 +1,19 @@
 {
-    "type": "origins:modify_damage_dealt",
+    "type": "apoli:modify_damage_dealt",
     "bientity_condition": {
-        "type": "origins:target_condition",
+        "type": "apoli:target_condition",
         "condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:entity_group",
+                    "type": "apoli:entity_group",
                     "group": "undead"
                 }
             ]
         }
     },
     "damage_condition": {
-        "type": "origins:amount",
+        "type": "apoli:amount",
         "comparison": ">=",
         "compare_to": 4
     },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_undead_dealt_damage_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_undead_dealt_damage_down.json
@@ -1,24 +1,24 @@
 {
-    "type": "origins:self_action_on_hit",
+    "type": "apoli:self_action_on_hit",
     "damage_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:attacker",
+                "type": "apoli:attacker",
                 "entity_condition": {
-                    "type": "origins:entity_group",
+                    "type": "apoli:entity_group",
                     "group": "undead"
                 }
             },
             {
-                "type": "origins:amount",
+                "type": "apoli:amount",
                 "comparison": ">=",
                 "compare_to": 2
             }
         ]
     },
     "entity_action": {
-        "type": "origins:heal",
+        "type": "apoli:heal",
         "amount": 2
     },
     "cooldown": 5

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_undead_effect_in_range.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_undead_effect_in_range.json
@@ -1,24 +1,24 @@
 {
     "type": "shape-shifter-curse:action_on_entity_in_range",
     "entity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:entity_group",
+                "type": "apoli:entity_group",
                 "group": "undead"
             },
             {
-                "type": "origins:status_effect",
+                "type": "apoli:status_effect",
                 "effect": "minecraft:weakness",
                 "inverted": true
             }
         ]
     },
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:apply_effect",
+                "type": "apoli:apply_effect",
                 "effect": {
                     "effect": "minecraft:weakness",
                     "duration": 20,
@@ -26,7 +26,7 @@
                 }
             },
             {
-                "type": "origins:apply_effect",
+                "type": "apoli:apply_effect",
                 "effect": {
                     "effect": "minecraft:slowness",
                     "duration": 20,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_vegetarian_saturation_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_vegetarian_saturation_down.json
@@ -1,33 +1,33 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "saturation_modifier": {
         "name": "Decreased saturation points",
         "operation": "multiply_base_multiplicative",
         "value": -1
     },
     "item_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:meat"
+                    "tag": "shape-shifter-curse:meat"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:meat",
+                "type": "apoli:meat",
                 "inverted": true
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:ignore_diet"
+                    "tag": "shape-shifter-curse:ignore_diet"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
                     "tag": "shape-shifter-curse:ignore_vc_eat"
                 },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_wither_attack.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_wither_attack.json
@@ -1,15 +1,15 @@
 {
-    "type": "origins:action_on_hit",
+    "type": "apoli:action_on_hit",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:apply_effect",
+                            "type": "apoli:apply_effect",
                             "effect": {
                                 "effect": "minecraft:wither",
                                 "duration": 60,
@@ -17,7 +17,7 @@
                             }
                         },
                         {
-                            "type": "origins:apply_effect",
+                            "type": "apoli:apply_effect",
                             "effect": {
                                 "effect": "minecraft:slowness",
                                 "duration": 60,
@@ -25,7 +25,7 @@
                             }
                         },
                         {
-                            "type": "origins:spawn_particles",
+                            "type": "apoli:spawn_particles",
                             "particle": {
                                 "type": "minecraft:dust",
                                 "params": "0.07 0.07 0.07 2"
@@ -40,7 +40,7 @@
                             }
                         },
                         {
-                            "type": "origins:spawn_particles",
+                            "type": "apoli:spawn_particles",
                             "particle": {
                                 "type": "minecraft:soul_fire_flame"
                             },
@@ -59,12 +59,12 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:actor_condition",
+        "type": "apoli:actor_condition",
         "condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:status_effect",
+                    "type": "apoli:status_effect",
                     "effect": "minecraft:wither"
                 }
             ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_wither_attack_heal.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_wither_attack_heal.json
@@ -1,15 +1,15 @@
 {
-    "type": "origins:action_on_hit",
+    "type": "apoli:action_on_hit",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:heal",
+                            "type": "apoli:heal",
                             "amount": 3
                         }
                     ]
@@ -18,19 +18,19 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:actor_condition",
+        "type": "apoli:actor_condition",
         "condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:status_effect",
+                    "type": "apoli:status_effect",
                     "effect": "minecraft:wither"
                 }
             ]
         }
     },
     "damage_condition": {
-        "type": "origins:amount",
+        "type": "apoli:amount",
         "comparison": ">",
         "compare_to": 1
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_wither_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_wither_health.json
@@ -10,7 +10,7 @@
     "updateHealth": true,
     "delay": 1,
     "condition": {
-        "type": "origins:status_effect",
+        "type": "apoli:status_effect",
         "effect": "minecraft:wither"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_wither_instant_kill.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_wither_instant_kill.json
@@ -1,28 +1,28 @@
 {
-  "type": "origins:action_on_hit",
+  "type": "apoli:action_on_hit",
   "bientity_action": {
-    "type": "origins:target_action",
+    "type": "apoli:target_action",
     "action": {
-      "type": "origins:damage",
+      "type": "apoli:damage",
       "amount": 10,
       "damage_type": "minecraft:player_attack"
     }
   },
   "bientity_condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:target_condition",
+        "type": "apoli:target_condition",
         "condition": {
-          "type": "origins:and",
+          "type": "apoli:and",
           "conditions": [
             {
-              "type": "origins:health",
+              "type": "apoli:health",
               "comparison": "<",
               "compare_to": 10
             },
             {
-              "type": "origins:status_effect",
+              "type": "apoli:status_effect",
               "effect": "minecraft:wither"
             }
           ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_wither_on_hit.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_wither_on_hit.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:self_action_when_hit",
+  "type": "apoli:self_action_when_hit",
   "entity_action": {
-    "type": "origins:apply_effect",
+    "type": "apoli:apply_effect",
     "effect": {
       "effect": "minecraft:wither",
       "duration": 70,
@@ -10,6 +10,6 @@
     }
   },
   "damage_condition": {
-    "type": "origins:attacker"
+    "type": "apoli:attacker"
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_withered_bandage_trinket.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_3_withered_bandage_trinket.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:self_action_when_hit",
+  "type": "apoli:self_action_when_hit",
   "entity_action": {
-    "type": "origins:apply_effect",
+    "type": "apoli:apply_effect",
     "effect": {
       "effect": "minecraft:wither",
       "duration": 130,
@@ -10,6 +10,6 @@
     }
   },
   "damage_condition": {
-    "type": "origins:attacker"
+    "type": "apoli:attacker"
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_instinct_biome.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_instinct_biome.json
@@ -4,7 +4,7 @@
     "value": 0.003,
     "duration": 1,
     "condition": {
-        "type": "origins:biome",
+        "type": "apoli:biome",
         "biome": "minecraft:desert"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_instinct_eat_rotten_flesh.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_instinct_eat_rotten_flesh.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:action_on_item_use",
+    "type": "apoli:action_on_item_use",
     "entity_action": {
         "type": "shape-shifter-curse:add_instinct",
         "instinct_effect_id": "shape-shifter-curse:form_anubis_wolf_eat_rotten_flesh",
@@ -7,7 +7,7 @@
         "duration": 20
     },
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:rotten_flesh"
         }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_instinct_wither_effect.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_instinct_wither_effect.json
@@ -4,7 +4,7 @@
     "value": 0.008,
     "duration": 1,
     "condition": {
-        "type": "origins:status_effect",
+        "type": "apoli:status_effect",
         "effect": "minecraft:wither"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_rotten_flesh_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_rotten_flesh_up.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifiers": [
         {
             "name": "increase food points",
@@ -15,7 +15,7 @@
         }
     ],
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:rotten_flesh"
         }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_sound.json
@@ -1,12 +1,12 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.wolf.pant"
     },
     "interval": 200,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:enable_random_sound"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_sound_hurt.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_sound_hurt.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:self_action_when_hit",
+    "type": "apoli:self_action_when_hit",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.wolf.hurt",
         "pitch": 0.8
     },
@@ -10,7 +10,7 @@
         "chance": 0.8
     },
     "damage_condition": {
-        "type": "origins:in_tag",
+        "type": "apoli:in_tag",
         "tag": "shape-shifter-curse:is_wither",
         "inverted": true
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_sound_key.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_anubis_wolf_sound_key.json
@@ -1,9 +1,9 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
   "form_anubis_wolf_sound_key_normal": {
-    "type": "origins:active_self",
+    "type": "apoli:active_self",
     "entity_action": {
-      "type": "origins:play_sound",
+      "type": "apoli:play_sound",
       "sound": "minecraft:entity.wolf.ambient"
     },
     "cooldown": 5,
@@ -15,14 +15,14 @@
       "continuous": false
     },
     "condition": {
-      "type": "origins:sneaking",
+      "type": "apoli:sneaking",
       "inverted": true
     }
   },
   "form_anubis_wolf_sound_key_hiss": {
-    "type": "origins:active_self",
+    "type": "apoli:active_self",
     "entity_action": {
-      "type": "origins:play_sound",
+      "type": "apoli:play_sound",
       "sound": "minecraft:entity.wolf.growl"
     },
     "cooldown": 5,
@@ -34,7 +34,7 @@
       "continuous": false
     },
     "condition": {
-      "type": "origins:sneaking"
+      "type": "apoli:sneaking"
     }
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_0_new_puff_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_0_new_puff_speed_down.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "multiply_total",
@@ -8,19 +8,19 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:on_block",
+                "type": "apoli:on_block",
                 "block_condition": {
-                    "type": "origins:in_tag",
-                    "tag": "origins:puff_block"
+                    "type": "apoli:in_tag",
+                    "tag": "shape-shifter-curse:puff_block"
                 }
             },
             {
-                "type": "origins:on_block",
+                "type": "apoli:on_block",
                 "block_condition": {
-                    "type": "origins:block_state",
+                    "type": "apoli:block_state",
                     "property": "snowy",
                     "value": true
                 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_0_sand_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_0_sand_speed_down.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "multiply_total",
@@ -8,19 +8,19 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:on_block",
+                "type": "apoli:on_block",
                 "block_condition": {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:sand"
                 }
             },
             {
-                "type": "origins:on_block",
+                "type": "apoli:on_block",
                 "block_condition": {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:red_sand"
                 }
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_0_swim_speed.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_0_swim_speed.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:attribute",
+    "type": "apoli:attribute",
     "modifier": {
         "attribute": "additionalentityattributes:generic.water_speed",
         "name": "Additional swim speed",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_1_new_water_flexibility.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_1_new_water_flexibility.json
@@ -2,9 +2,9 @@
     "type": "shape-shifter-curse:water_flexibility",
     "water_flex": 0.5,
     "condition": {
-        "type": "origins:in_block",
+        "type": "apoli:in_block",
         "block_condition": {
-            "type": "origins:block",
+            "type": "apoli:block",
             "block": "minecraft:water"
         }
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_1_swim_speed.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_1_swim_speed.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:attribute",
+    "type": "apoli:attribute",
     "modifier": {
         "attribute": "additionalentityattributes:generic.water_speed",
         "name": "Additional swim speed",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_dry_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_dry_health.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "name": "Decrease max health when not having air(moist)",
         "attribute": "minecraft:generic.max_health",
@@ -8,7 +8,7 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:air",
+        "type": "apoli:air",
         "comparison": "<=",
         "compare_to": 0
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_dry_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_dry_speed_down.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "name": "Decrease speed when not having air(moist)",
         "attribute": "minecraft:generic.movement_speed",
@@ -8,7 +8,7 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:air",
+        "type": "apoli:air",
         "comparison": "<=",
         "compare_to": 0
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_0.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_0.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "name": "Oxygen health",
         "attribute": "minecraft:generic.max_health",
@@ -8,7 +8,7 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:air",
+        "type": "apoli:air",
         "comparison": ">=",
         "compare_to": 270
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_1.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_1.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "name": "Oxygen health",
         "attribute": "minecraft:generic.max_health",
@@ -8,15 +8,15 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": "<",
                 "compare_to": 270
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">=",
                 "compare_to": 240
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_2.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_2.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "name": "Oxygen health",
         "attribute": "minecraft:generic.max_health",
@@ -8,15 +8,15 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": "<",
                 "compare_to": 240
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">=",
                 "compare_to": 210
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_3.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_3.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "name": "Oxygen health",
         "attribute": "minecraft:generic.max_health",
@@ -8,15 +8,15 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": "<",
                 "compare_to": 210
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">=",
                 "compare_to": 180
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_4.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_4.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "name": "Oxygen health",
         "attribute": "minecraft:generic.max_health",
@@ -8,15 +8,15 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": "<",
                 "compare_to": 180
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">=",
                 "compare_to": 150
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_5.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_5.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "name": "Oxygen health",
         "attribute": "minecraft:generic.max_health",
@@ -8,15 +8,15 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": "<",
                 "compare_to": 150
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">=",
                 "compare_to": 120
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_6.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_6.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "name": "Oxygen health",
         "attribute": "minecraft:generic.max_health",
@@ -8,15 +8,15 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": "<",
                 "compare_to": 120
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">=",
                 "compare_to": 90
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_7.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_7.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "name": "Oxygen health",
         "attribute": "minecraft:generic.max_health",
@@ -8,15 +8,15 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": "<",
                 "compare_to": 90
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">=",
                 "compare_to": 60
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_8.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_8.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "name": "Oxygen health",
         "attribute": "minecraft:generic.max_health",
@@ -8,15 +8,15 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": "<",
                 "compare_to": 60
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">=",
                 "compare_to": 30
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_9.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_health_9.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "name": "Oxygen health",
         "attribute": "minecraft:generic.max_health",
@@ -8,7 +8,7 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:air",
+        "type": "apoli:air",
         "comparison": "<",
         "compare_to": 30
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_regeneration.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_oxygen_regeneration.json
@@ -1,25 +1,25 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:heal",
+        "type": "apoli:heal",
         "amount": 1
     },
     "interval": 200,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:food_level",
+                "type": "apoli:food_level",
                 "comparison": ">=",
                 "compare_to": 6
             },
             {
-                "type": "origins:health",
+                "type": "apoli:health",
                 "comparison": "<",
                 "compare_to": 32
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">",
                 "compare_to": 150
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_water_flexibility.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_new_water_flexibility.json
@@ -2,9 +2,9 @@
     "type": "shape-shifter-curse:water_flexibility",
     "water_flex": 0.93,
     "condition": {
-        "type": "origins:in_block",
+        "type": "apoli:in_block",
         "block_condition": {
-            "type": "origins:block",
+            "type": "apoli:block",
             "block": "minecraft:water"
         }
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_regeneration.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_regeneration.json
@@ -1,20 +1,20 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:heal",
+        "type": "apoli:heal",
         "amount": 1
     },
     "interval": 400,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:food_level",
+                "type": "apoli:food_level",
                 "comparison": ">=",
                 "compare_to": 6
             },
             {
-                "type": "origins:health",
+                "type": "apoli:health",
                 "comparison": "<",
                 "compare_to": 30
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_water_spurt.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_water_spurt.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:active_self",
+  "type": "apoli:active_self",
   "entity_action": {
-    "type": "origins:add_velocity",
+    "type": "apoli:add_velocity",
     "z": 1.6,
     "space": "local"
   },
@@ -14,10 +14,10 @@
     "continuous": false
   },
   "condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:fluid_height",
+        "type": "apoli:fluid_height",
         "fluid": "minecraft:water",
         "comparison": ">=",
         "compare_to": 1

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_wet_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_2_wet_health.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "name": "Gain health when having air(moist)",
         "attribute": "minecraft:generic.max_health",
@@ -8,7 +8,7 @@
     },
     "tick_rate": 40,
     "condition": {
-        "type": "origins:air",
+        "type": "apoli:air",
         "comparison": ">",
         "compare_to": 0
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_ground_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_ground_speed_down.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "multiply_total",
@@ -7,25 +7,25 @@
     },
     "tick_rate": 5,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:on_block"
+                "type": "apoli:on_block"
             },
             {
-                "type": "origins:in_block",
+                "type": "apoli:in_block",
                 "block_condition": {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:water"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:sneaking",
+                "type": "apoli:sneaking",
                 "inverted": true
             },
             {
-                "type": "origins:sprinting",
+                "type": "apoli:sprinting",
                 "inverted": true
             }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_keep_sneaking_no_air.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_keep_sneaking_no_air.json
@@ -1,10 +1,10 @@
 {
     "type": "shape-shifter-curse:keep_sneaking",
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": "<=",
                 "compare_to": 0
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_no_render_arm.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_no_render_arm.json
@@ -1,13 +1,13 @@
 {
     "type": "shape-shifter-curse:no_render_arm",
     "condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:sneaking"
+                "type": "apoli:sneaking"
             },
             {
-                "type": "origins:swimming"
+                "type": "apoli:swimming"
             }
         ]
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_particle.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_particle.json
@@ -1,10 +1,10 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:spawn_particles",
+                "type": "apoli:spawn_particles",
                 "particle": "minecraft:nautilus",
                 "count": 8,
                 "speed": 0.0,
@@ -16,7 +16,7 @@
                 }
             },
             {
-                "type": "origins:spawn_particles",
+                "type": "apoli:spawn_particles",
                 "particle": "minecraft:splash",
                 "count": 8,
                 "speed": 0.0,
@@ -31,22 +31,22 @@
     },
     "interval": 5,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:sprinting"
+                "type": "apoli:sprinting"
             },
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0
             },
             {
-                "type": "origins:on_block"
+                "type": "apoli:on_block"
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">",
                 "compare_to": 0
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_slipperiness.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_slipperiness.json
@@ -2,24 +2,24 @@
     "type": "shape-shifter-curse:conditioned_modify_slipperiness",
     "modifier": 0.35,
     "block_condition": {
-        "type": "origins:in_tag",
+        "type": "apoli:in_tag",
         "tag": "minecraft:ice",
         "inverted": true
     },
     "entity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0
             },
             {
-                "type": "origins:sprinting"
+                "type": "apoli:sprinting"
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">",
                 "compare_to": 0
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sneaking_speed.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sneaking_speed.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "addition",
@@ -7,19 +7,19 @@
     },
     "tick_rate": 1,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0
             },
             {
-                "type": "origins:sneaking"
+                "type": "apoli:sneaking"
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">",
                 "compare_to": 0
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprint_step_height.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprint_step_height.json
@@ -2,6 +2,6 @@
     "type": "shape-shifter-curse:modify_step_height",
     "step_height_scale": 2.0,
     "condition": {
-        "type": "origins:sprinting"
+        "type": "apoli:sprinting"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_attack.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_attack.json
@@ -1,25 +1,25 @@
 {
-    "type": "origins:action_on_hit",
+    "type": "apoli:action_on_hit",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:add_velocity",
+                "type": "apoli:add_velocity",
                 "z": 4.0
             },
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:play_sound",
+                            "type": "apoli:play_sound",
                             "sound": "minecraft:entity.axolotl.splash",
                             "volume": 0.5,
                             "pitch": 0.8
                         },
                         {
-                            "type": "origins:spawn_particles",
+                            "type": "apoli:spawn_particles",
                             "particle": "minecraft:rain",
                             "count": 8,
                             "speed": 0.0,
@@ -31,7 +31,7 @@
                             }
                         },
                         {
-                            "type": "origins:spawn_particles",
+                            "type": "apoli:spawn_particles",
                             "particle": {
                                 "type": "minecraft:dust",
                                 "params": "0.11 0.18 0.69 2"
@@ -49,33 +49,33 @@
                 }
             },
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:gain_air",
+                    "type": "apoli:gain_air",
                     "value": -10
                 }
             }
         ]
     },
     "bientity_condition": {
-        "type": "origins:actor_condition",
+        "type": "apoli:actor_condition",
         "condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:sprinting"
+                    "type": "apoli:sprinting"
                 },
                 {
-                    "type": "origins:fluid_height",
+                    "type": "apoli:fluid_height",
                     "fluid": "minecraft:water",
                     "comparison": "<=",
                     "compare_to": 0
                 },
                 {
-                    "type": "origins:on_block"
+                    "type": "apoli:on_block"
                 },
                 {
-                    "type": "origins:air",
+                    "type": "apoli:air",
                     "comparison": ">",
                     "compare_to": 0
                 }
@@ -83,14 +83,14 @@
         }
     },
     "damage_condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:in_tag",
+                "type": "apoli:in_tag",
                 "tag": "minecraft:is_explosion"
             },
             {
-                "type": "origins:in_tag",
+                "type": "apoli:in_tag",
                 "tag": "shape-shifter-curse:is_thorns"
             }
         ],

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_cost_oxygen.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_cost_oxygen.json
@@ -1,24 +1,24 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:gain_air",
+        "type": "apoli:gain_air",
         "value": -1
     },
     "interval": 14,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0
             },
             {
-                "type": "origins:sprinting"
+                "type": "apoli:sprinting"
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">",
                 "compare_to": 0
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_jump.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_jump.json
@@ -1,25 +1,25 @@
 {
     "type": "shape-shifter-curse:action_on_jump",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:add_velocity",
+                "type": "apoli:add_velocity",
                 "z": 0.3,
                 "space": "local_horizontal_normalized"
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.axolotl.splash",
                 "volume": 0.5,
                 "pitch": 0.8
             },
             {
-                "type": "origins:gain_air",
+                "type": "apoli:gain_air",
                 "value": -3
             },
             {
-                "type": "origins:spawn_particles",
+                "type": "apoli:spawn_particles",
                 "particle": "minecraft:rain",
                 "count": 16,
                 "speed": 0.0,
@@ -31,7 +31,7 @@
                 }
             },
             {
-                "type": "origins:spawn_particles",
+                "type": "apoli:spawn_particles",
                 "particle": {
                     "type": "minecraft:dust",
                     "params": "0.11 0.18 0.69 2"
@@ -48,22 +48,22 @@
         ]
     },
     "entity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:sprinting"
+                "type": "apoli:sprinting"
             },
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0
             },
             {
-                "type": "origins:on_block"
+                "type": "apoli:on_block"
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">",
                 "compare_to": 0
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_jump_high.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_jump_high.json
@@ -1,27 +1,27 @@
 {
-    "type": "origins:modify_jump",
+    "type": "apoli:modify_jump",
     "modifier": {
         "name": "Bonus jump force while sneaking",
         "operation": "multiply_base",
         "value": 0.1
     },
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:sprinting"
+                "type": "apoli:sprinting"
             },
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0
             },
             {
-                "type": "origins:on_block"
+                "type": "apoli:on_block"
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">",
                 "compare_to": 0
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_sneaking_rush.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_sneaking_rush.json
@@ -1,32 +1,32 @@
 {
     "type": "shape-shifter-curse:action_on_sprinting_to_sneaking",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:add_velocity",
+                "type": "apoli:add_velocity",
                 "z": 1.4,
                 "y": 0.6,
                 "space": "local_horizontal_normalized"
             },
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "playsound minecraft:entity.axolotl.splash player @s ~ ~ ~ 1 1"
             },
             {
-                "type": "origins:gain_air",
+                "type": "apoli:gain_air",
                 "value": -10
             }
         ]
     },
     "entity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:on_block"
+                "type": "apoli:on_block"
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">",
                 "compare_to": 0
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_sneaking_water_explode.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_sneaking_water_explode.json
@@ -1,22 +1,22 @@
 {
     "type": "shape-shifter-curse:action_on_sprinting_to_sneaking",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:add_velocity",
+                "type": "apoli:add_velocity",
                 "y": 0.6,
                 "z": -0.3,
                 "space": "local_horizontal_normalized"
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.axolotl.splash",
                 "volume": 0.5,
                 "pitch": 0.8
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.wither.break_block",
                 "volume": 0.5,
                 "pitch": 0.8
@@ -25,29 +25,29 @@
                 "type": "shape-shifter-curse:explosion_damage_entity",
                 "power": 2,
                 "entity_condition": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "conditions": [
                         {
-                            "type": "origins:target_condition",
+                            "type": "apoli:target_condition",
                             "condition": {
-                                "type": "origins:in_tag",
+                                "type": "apoli:in_tag",
                                 "tag": "shape-shifter-curse:water_explode_immune"
                             },
                             "inverted": true
                         },
                         {
-                            "type": "origins:owner",
+                            "type": "apoli:owner",
                             "inverted": true
                         }
                     ]
                 }
             },
             {
-                "type": "origins:gain_air",
+                "type": "apoli:gain_air",
                 "value": -15
             },
             {
-                "type": "origins:spawn_particles",
+                "type": "apoli:spawn_particles",
                 "particle": "minecraft:rain",
                 "count": 32,
                 "speed": 0.0,
@@ -59,7 +59,7 @@
                 }
             },
             {
-                "type": "origins:spawn_particles",
+                "type": "apoli:spawn_particles",
                 "particle": {
                     "type": "minecraft:dust",
                     "params": "0.11 0.18 0.69 2"
@@ -76,13 +76,13 @@
         ]
     },
     "entity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:on_block"
+                "type": "apoli:on_block"
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">",
                 "compare_to": 0
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_speed.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_3_sprinting_speed.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "multiply_total",
@@ -7,19 +7,19 @@
     },
     "tick_rate": 1,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0
             },
             {
-                "type": "origins:sprinting"
+                "type": "apoli:sprinting"
             },
             {
-                "type": "origins:air",
+                "type": "apoli:air",
                 "comparison": ">",
                 "compare_to": 0
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_fountain_belt_trinket.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_fountain_belt_trinket.json
@@ -1,24 +1,24 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
   "fountain": {
     "type": "shape-shifter-curse:action_on_sprinting_to_sneaking",
     "entity_action": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "actions": [
         {
-          "type": "origins:add_velocity",
+          "type": "apoli:add_velocity",
           "y": 1.2,
           "z": 0.1,
           "space": "local_horizontal_normalized"
         },
         {
-          "type": "origins:play_sound",
+          "type": "apoli:play_sound",
           "sound": "minecraft:entity.axolotl.splash",
           "volume": 0.5,
           "pitch": 0.8
         },
         {
-          "type": "origins:play_sound",
+          "type": "apoli:play_sound",
           "sound": "minecraft:entity.wither.break_block",
           "volume": 0.5,
           "pitch": 0.8
@@ -27,27 +27,27 @@
           "type": "shape-shifter-curse:explosion_damage_entity",
           "power": 3,
           "entity_condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
               {
-                "type": "origins:target_condition",
+                "type": "apoli:target_condition",
                 "condition": {
-                  "type": "origins:in_tag",
+                  "type": "apoli:in_tag",
                   "tag": "shape-shifter-curse:water_explode_immune"
                 },
                 "inverted": true
               },
               {
-                "type": "origins:owner",
+                "type": "apoli:owner",
                 "inverted": true
               }
             ]
           },
           "entity_action": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "actions": [
               {
-                "type": "origins:add_velocity",
+                "type": "apoli:add_velocity",
                 "y": 1,
                 "space": "world"
               }
@@ -56,11 +56,11 @@
           "explosion_damage_entity": false
         },
         {
-          "type": "origins:gain_air",
+          "type": "apoli:gain_air",
           "value": -15
         },
         {
-          "type": "origins:spawn_particles",
+          "type": "apoli:spawn_particles",
           "particle": "minecraft:rain",
           "count": 32,
           "speed": 0,
@@ -72,7 +72,7 @@
           }
         },
         {
-          "type": "origins:spawn_particles",
+          "type": "apoli:spawn_particles",
           "particle": {
             "type": "minecraft:dust",
             "params": "0.11 0.18 0.69 2"
@@ -89,13 +89,13 @@
       ]
     },
     "entity_condition": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:on_block"
+          "type": "apoli:on_block"
         },
         {
-          "type": "origins:air",
+          "type": "apoli:air",
           "comparison": ">",
           "compare_to": 0
         }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_instinct_attack_fish.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_instinct_attack_fish.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:self_action_on_hit",
+    "type": "apoli:self_action_on_hit",
     "entity_action": {
         "type": "shape-shifter-curse:add_instinct",
         "instinct_effect_id": "shape-shifter-curse:form_axolotl_attack_fish",
@@ -7,7 +7,7 @@
         "duration": 0
     },
     "target_condition": {
-        "type": "origins:in_tag",
-        "tag": "origins:fish"
+        "type": "apoli:in_tag",
+        "tag": "shape-shifter-curse:fish"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_instinct_biome.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_instinct_biome.json
@@ -4,7 +4,7 @@
     "value": 0.003,
     "duration": 1,
     "condition": {
-        "type": "origins:biome",
+        "type": "apoli:biome",
         "biome": "minecraft:lush_caves"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_instinct_eat_fish.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_instinct_eat_fish.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:action_on_item_use",
+    "type": "apoli:action_on_item_use",
     "entity_action": {
         "type": "shape-shifter-curse:add_instinct",
         "instinct_effect_id": "shape-shifter-curse:form_axolotl_eat_fish",
@@ -7,9 +7,9 @@
         "duration": 20
     },
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-            "tag": "origins:fish"
+            "tag": "shape-shifter-curse:fish"
         }
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_instinct_in_water.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_instinct_in_water.json
@@ -4,7 +4,7 @@
     "value": 0.004,
     "duration": 1,
     "condition": {
-        "type": "origins:fluid_height",
+        "type": "apoli:fluid_height",
         "fluid": "minecraft:water",
         "comparison": ">",
         "compare_to": 0

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_instinct_near_dripleaf.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_instinct_near_dripleaf.json
@@ -4,20 +4,20 @@
     "value": 0.008,
     "duration": 1,
     "condition": {
-        "type": "origins:block_in_radius",
+        "type": "apoli:block_in_radius",
         "block_condition": {
-            "type": "origins:or",
+            "type": "apoli:or",
             "conditions": [
                 {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:big_dripleaf"
                 },
                 {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:big_dripleaf_stem"
                 },
                 {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:small_dripleaf"
                 }
             ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_keep_sneaking_when_head_collide.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_keep_sneaking_when_head_collide.json
@@ -1,13 +1,13 @@
 {
     "type": "shape-shifter-curse:keep_sneaking",
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:must_crawling"
             },
             {
-                "type": "origins:swimming",
+                "type": "apoli:swimming",
                 "inverted": true
             }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_sound.json
@@ -1,12 +1,12 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.axolotl.idle_air"
     },
     "interval": 200,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:enable_random_sound"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_sound_hurt.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_sound_hurt.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:self_action_when_hit",
+    "type": "apoli:self_action_when_hit",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.axolotl.hurt"
     },
     "condition": {

--- a/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_sound_key.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_axolotl_sound_key.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:active_self",
+    "type": "apoli:active_self",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.axolotl.idle_air"
     },
     "cooldown": 5,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_0_sun_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_0_sun_health.json
@@ -10,6 +10,6 @@
     "updateHealth": true,
     "delay": 100,
     "condition": {
-        "type": "origins:exposed_to_sun"
+        "type": "apoli:exposed_to_sun"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_1_sun_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_1_sun_health.json
@@ -10,6 +10,6 @@
     "updateHealth": true,
     "delay": 100,
     "condition": {
-        "type": "origins:exposed_to_sun"
+        "type": "apoli:exposed_to_sun"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_1_sun_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_1_sun_speed_down.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "multiply_total",
@@ -8,6 +8,6 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:exposed_to_sun"
+        "type": "apoli:exposed_to_sun"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_2_sun_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_2_sun_health.json
@@ -10,6 +10,6 @@
     "updateHealth": true,
     "delay": 100,
     "condition": {
-        "type": "origins:exposed_to_sun"
+        "type": "apoli:exposed_to_sun"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_2_sun_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_2_sun_speed_down.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "multiply_total",
@@ -8,6 +8,6 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:exposed_to_sun"
+        "type": "apoli:exposed_to_sun"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_3_block_attach.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_3_block_attach.json
@@ -1,13 +1,13 @@
 {
     "type": "shape-shifter-curse:bat_block_attach",
     "attach_condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:inventory",
+                "type": "apoli:inventory",
                 "process_mode": "items",
                 "item_condition": {
-                    "type": "origins:ingredient",
+                    "type": "apoli:ingredient",
                     "ingredient": {
                         "item": "shape-shifter-curse:diamond_mining_claw"
                     }
@@ -17,7 +17,7 @@
                 ]
             },
             {
-                "type": "origins:inventory",
+                "type": "apoli:inventory",
                 "process_mode": "items",
                 "comparison": "==",
                 "compare_to": 0,
@@ -28,29 +28,29 @@
         ]
     },
     "block_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:replacable",
+                "type": "apoli:replacable",
                 "inverted": true
             }
         ]
     },
     "side_attach_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 5"
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.goat.long_jump"
             }
         ]
     },
     "bottom_attach_action": {
-        "type": "origins:heal",
+        "type": "apoli:heal",
         "amount": 1
     },
     "bottom_attach_interval": 40

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_3_damage_up_when_no_sun.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_3_damage_up_when_no_sun.json
@@ -1,9 +1,9 @@
 {
-    "type": "origins:multiple",
+    "type": "apoli:multiple",
     "normal": {
-        "type": "origins:conditioned_attribute",
+        "type": "apoli:conditioned_attribute",
         "condition": {
-            "type": "origins:exposed_to_sun",
+            "type": "apoli:exposed_to_sun",
             "inverted": true
         },
         "modifier": {
@@ -15,19 +15,19 @@
         "tick_rate": 1
     },
     "barehand": {
-        "type": "origins:conditioned_attribute",
+        "type": "apoli:conditioned_attribute",
         "condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:exposed_to_sun",
+                    "type": "apoli:exposed_to_sun",
                     "inverted": true
                 },
                 {
-                    "type": "origins:or",
+                    "type": "apoli:or",
                     "conditions": [
                         {
-                            "type": "origins:inventory",
+                            "type": "apoli:inventory",
                             "process_mode": "items",
                             "item_condition": {
                                 "type": "shape-shifter-curse:is_weapon"
@@ -38,7 +38,7 @@
                             "inverted": true
                         },
                         {
-                            "type": "origins:inventory",
+                            "type": "apoli:inventory",
                             "process_mode": "items",
                             "comparison": "==",
                             "compare_to": 0,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_3_ground_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_3_ground_speed_down.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "multiply_total",
@@ -7,6 +7,6 @@
     },
     "tick_rate": 5,
     "condition": {
-        "type": "origins:on_block"
+        "type": "apoli:on_block"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_3_jump_boost.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_3_jump_boost.json
@@ -1,11 +1,11 @@
 {
     "type": "shape-shifter-curse:action_on_jump",
     "entity_action": {
-        "type": "origins:add_velocity",
+        "type": "apoli:add_velocity",
         "space": "local_horizontal_normalized",
         "z": 0.35
     },
     "entity_condition": {
-        "type": "origins:sprinting"
+        "type": "apoli:sprinting"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_3_jump_high.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_3_jump_high.json
@@ -1,14 +1,14 @@
 {
-    "type": "origins:modify_jump",
+    "type": "apoli:modify_jump",
     "modifier": {
         "operation": "addition",
         "value": 0.2
     },
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "particle cloud ~ ~ ~ 0.3 0.3 0.3 0.01 16 normal @a"
             }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_3_sky_speed.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_3_sky_speed.json
@@ -1,29 +1,29 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:add_velocity",
+        "type": "apoli:add_velocity",
         "space": "local_horizontal_normalized",
         "z": 0.05
     },
     "interval": 1,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0
             },
             {
-                "type": "origins:on_block",
+                "type": "apoli:on_block",
                 "inverted": true
             },
             {
-                "type": "origins:sprinting"
+                "type": "apoli:sprinting"
             },
             {
-                "type": "origins:fall_flying",
+                "type": "apoli:fall_flying",
                 "inverted": true
             }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_attach_hook_trinket.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_attach_hook_trinket.json
@@ -1,22 +1,22 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
 
   "damage_on_block_break": {
-    "type": "origins:action_on_block_break",
+    "type": "apoli:action_on_block_break",
     "entity_action": {
-      "type": "origins:equipped_item_action",
+      "type": "apoli:equipped_item_action",
       "equipment_slot": "mainhand",
       "action": {
-        "type": "origins:damage",
+        "type": "apoli:damage",
         "amount": 1,
         "ignore_unbreaking": false
       }
     },
     "condition": {
-      "type": "origins:inventory",
+      "type": "apoli:inventory",
       "process_mode": "items",
       "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "shape-shifter-curse:diamond_mining_claw"
         }
@@ -29,21 +29,21 @@
   },
 
   "damage_on_attack_entity": {
-    "type": "origins:self_action_on_hit",
+    "type": "apoli:self_action_on_hit",
     "entity_action": {
-      "type": "origins:equipped_item_action",
+      "type": "apoli:equipped_item_action",
       "equipment_slot": "mainhand",
       "action": {
-        "type": "origins:damage",
+        "type": "apoli:damage",
         "amount": 2,
         "ignore_unbreaking": false
       }
     },
     "condition": {
-      "type": "origins:inventory",
+      "type": "apoli:inventory",
       "process_mode": "items",
       "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "shape-shifter-curse:diamond_mining_claw"
         }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_charm_of_hollow_fang_trinket.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_charm_of_hollow_fang_trinket.json
@@ -1,32 +1,32 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
 
   "vampire": {
-    "type": "origins:self_action_on_hit",
+    "type": "apoli:self_action_on_hit",
     "entity_action": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "actions": [
         {
-          "type": "origins:heal",
+          "type": "apoli:heal",
           "amount": 3.0
         },
         {
-          "type": "origins:feed",
+          "type": "apoli:feed",
           "food": 4,
           "saturation": 0.4
         }
       ]
     },
     "damage_condition": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:amount",
+          "type": "apoli:amount",
           "comparison": ">=",
           "compare_to": 4.0
         },
         {
-          "type": "origins:projectile",
+          "type": "apoli:projectile",
           "inverted": true
         }
       ]
@@ -35,7 +35,7 @@
   },
 
   "no_food": {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifiers": [
       {
         "operation": "set_total",
@@ -49,25 +49,25 @@
       }
     ],
     "item_condition": {
-      "type": "origins:or",
+      "type": "apoli:or",
       "conditions": [
         {
-          "type": "origins:and",
+          "type": "apoli:and",
           "conditions": [
             {
-              "type": "origins:food"
+              "type": "apoli:food"
             },
             {
-              "type": "origins:ingredient",
+              "type": "apoli:ingredient",
               "ingredient": {
-                "tag": "origins:ignore_diet"
+                "tag": "shape-shifter-curse:ignore_diet"
               },
               "inverted": true
             }
           ]
         },
         {
-          "type": "origins:ingredient",
+          "type": "apoli:ingredient",
           "ingredient": {
             "item": "minecraft:golden_carrot"
           }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_diamond_mining_claw_tool.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_diamond_mining_claw_tool.json
@@ -1,13 +1,13 @@
 {
-    "type": "origins:multiple",
+    "type": "apoli:multiple",
 
     "mining_claw_digging_up": {
-        "type": "origins:modify_break_speed",
+        "type": "apoli:modify_break_speed",
         "condition": {
-            "type": "origins:inventory",
+            "type": "apoli:inventory",
             "process_mode": "items",
             "item_condition": {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
                     "item": "shape-shifter-curse:diamond_mining_claw"
                 }
@@ -23,12 +23,12 @@
     },
 
     "mining_claw_attack_up": {
-        "type": "origins:modify_damage_dealt",
+        "type": "apoli:modify_damage_dealt",
         "condition": {
-            "type": "origins:inventory",
+            "type": "apoli:inventory",
             "process_mode": "items",
             "item_condition": {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
                     "item": "shape-shifter-curse:diamond_mining_claw"
                 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_hit_wall_damage_reduce.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_hit_wall_damage_reduce.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:modify_damage_taken",
+  "type": "apoli:modify_damage_taken",
   "damage_condition": {
-    "type": "origins:in_tag",
+    "type": "apoli:in_tag",
     "tag": "shape-shifter-curse:bat_immune_damage_tag"
   },
   "modifier": {

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_instinct_biome.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_instinct_biome.json
@@ -4,7 +4,7 @@
     "value": 0.002,
     "duration": 1,
     "condition": {
-        "type": "origins:biome",
+        "type": "apoli:biome",
         "biome": "minecraft:dripstone_caves"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_instinct_eat_fruit.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_instinct_eat_fruit.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:action_on_item_use",
+    "type": "apoli:action_on_item_use",
     "entity_action": {
         "type": "shape-shifter-curse:add_instinct",
         "instinct_effect_id": "shape-shifter-curse:form_bat_eat_fruit",
@@ -7,9 +7,9 @@
         "duration": 20
     },
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-            "tag": "origins:fruit"
+            "tag": "shape-shifter-curse:fruit"
         }
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_instinct_in_air.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_instinct_in_air.json
@@ -4,16 +4,16 @@
     "value": 0.008,
     "duration": 1,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0
             },
             {
-                "type": "origins:on_block",
+                "type": "apoli:on_block",
                 "inverted": true
             }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_instinct_in_dark.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_instinct_in_dark.json
@@ -4,7 +4,7 @@
     "value": 0.004,
     "duration": 1,
     "condition": {
-        "type": "origins:brightness",
+        "type": "apoli:brightness",
         "comparison": "<=",
         "compare_to": 0.25
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_instinct_near_dripstone.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_instinct_near_dripstone.json
@@ -4,16 +4,16 @@
     "value": 0.006,
     "duration": 1,
     "condition": {
-        "type": "origins:block_in_radius",
+        "type": "apoli:block_in_radius",
         "block_condition": {
-            "type": "origins:or",
+            "type": "apoli:or",
             "conditions": [
                 {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:dripstone_block"
                 },
                 {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:pointed_dripstone"
                 }
             ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_sound.json
@@ -1,14 +1,14 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.bat.ambient",
         "pitch": 0.5,
         "volume": 0.15
     },
     "interval": 200,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:enable_random_sound"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_sound_hurt.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_sound_hurt.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:self_action_when_hit",
+    "type": "apoli:self_action_when_hit",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.bat.hurt",
         "pitch": 0.5,
         "volume": 0.35

--- a/src/main/resources/data/shape-shifter-curse/powers/form_bat_sound_key.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_bat_sound_key.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:active_self",
+    "type": "apoli:active_self",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.bat.ambient",
         "pitch": 0.5,
         "volume": 0.15

--- a/src/main/resources/data/shape-shifter-curse/powers/form_carnivore.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_carnivore.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:modify_food",
+  "type": "apoli:modify_food",
   "food_modifiers": [
     {
       "operation": "set_total",
@@ -13,35 +13,35 @@
     }
   ],
   "item_condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
           {
-            "type": "origins:ingredient",
+            "type": "apoli:ingredient",
             "ingredient": {
-              "tag": "origins:meat"
+              "tag": "shape-shifter-curse:meat"
             }
           },
           {
-            "type": "origins:meat"
+            "type": "apoli:meat"
           }
         ],
         "inverted": true
       },
       {
-        "type": "origins:food"
+        "type": "apoli:food"
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-          "tag": "origins:ignore_diet"
+          "tag": "shape-shifter-curse:ignore_diet"
         },
         "inverted": true
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "tag": "shape-shifter-curse:ignore_vc_eat"
         },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_dark_speed_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_dark_speed_up.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "multiply_total",
@@ -8,7 +8,7 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:brightness",
+        "type": "apoli:brightness",
         "comparison": "<=",
         "compare_to": 0.25
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_disable_chest_armor.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_disable_chest_armor.json
@@ -1,22 +1,22 @@
 {
-    "type": "origins:restrict_armor",
+    "type": "apoli:restrict_armor",
     "chest": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:armor_value",
+                "type": "apoli:armor_value",
                 "comparison": ">",
                 "compare_to": -1
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
                     "item": "minecraft:elytra"
                 },
                 "inverted": true
             },
             {
-              "type": "origins:ingredient",
+              "type": "apoli:ingredient",
               "ingredient": {
                 "tag": "shape-shifter-curse:ignore_armor_restriction"
               },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_disable_feet_armor.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_disable_feet_armor.json
@@ -1,10 +1,10 @@
 {
-    "type": "origins:restrict_armor",
+    "type": "apoli:restrict_armor",
     "feet": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:armor_value",
+          "type": "apoli:armor_value",
           "comparison": ">",
           "compare_to": -1
         },
@@ -13,7 +13,7 @@
           "inverted": true
         },
         {
-          "type": "origins:ingredient",
+          "type": "apoli:ingredient",
           "ingredient": {
             "tag": "shape-shifter-curse:ignore_armor_restriction"
           },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_disable_head_armor.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_disable_head_armor.json
@@ -1,10 +1,10 @@
 {
-    "type": "origins:restrict_armor",
+    "type": "apoli:restrict_armor",
     "head": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:armor_value",
+          "type": "apoli:armor_value",
           "comparison": ">",
           "compare_to": -1
         },
@@ -13,7 +13,7 @@
           "inverted": true
         },
         {
-          "type": "origins:ingredient",
+          "type": "apoli:ingredient",
           "ingredient": {
             "tag": "shape-shifter-curse:ignore_armor_restriction"
           },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_disable_leg_armor.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_disable_leg_armor.json
@@ -1,10 +1,10 @@
 {
-    "type": "origins:restrict_armor",
+    "type": "apoli:restrict_armor",
     "legs": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:armor_value",
+          "type": "apoli:armor_value",
           "comparison": ">",
           "compare_to": -1
         },
@@ -13,7 +13,7 @@
           "inverted": true
         },
         {
-          "type": "origins:ingredient",
+          "type": "apoli:ingredient",
           "ingredient": {
             "tag": "shape-shifter-curse:ignore_armor_restriction"
           },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_0_dizzy_when_attack_witch.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_0_dizzy_when_attack_witch.json
@@ -1,10 +1,10 @@
 {
-    "type": "origins:self_action_on_hit",
+    "type": "apoli:self_action_on_hit",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:apply_effect",
+                "type": "apoli:apply_effect",
                 "effect": {
                     "effect": "minecraft:nausea",
                     "amplifier": 1,
@@ -12,7 +12,7 @@
                 }
             },
             {
-                "type": "origins:apply_effect",
+                "type": "apoli:apply_effect",
                 "effect": {
                     "effect": "minecraft:darkness",
                     "amplifier": 1,
@@ -20,7 +20,7 @@
                 }
             },
             {
-                "type": "origins:add_velocity",
+                "type": "apoli:add_velocity",
                 "z": -0.5,
                 "y": 0.5,
                 "space": "local_horizontal_normalized"
@@ -28,14 +28,14 @@
         ]
     },
     "target_condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:witch"
             },
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:evoker"
             }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_0_sprint_speed_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_0_sprint_speed_up.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "multiply_total",
@@ -8,6 +8,6 @@
     },
     "tick_rate": 4,
     "condition": {
-        "type": "origins:sprinting"
+        "type": "apoli:sprinting"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_1_dizzy_when_attack_illager.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_1_dizzy_when_attack_illager.json
@@ -1,10 +1,10 @@
 {
-    "type": "origins:self_action_on_hit",
+    "type": "apoli:self_action_on_hit",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:apply_effect",
+                "type": "apoli:apply_effect",
                 "effect": {
                     "effect": "minecraft:nausea",
                     "amplifier": 1,
@@ -12,7 +12,7 @@
                 }
             },
             {
-                "type": "origins:apply_effect",
+                "type": "apoli:apply_effect",
                 "effect": {
                     "effect": "minecraft:darkness",
                     "amplifier": 1,
@@ -20,7 +20,7 @@
                 }
             },
             {
-                "type": "origins:add_velocity",
+                "type": "apoli:add_velocity",
                 "z": -0.5,
                 "y": 0.5,
                 "space": "local_horizontal_normalized"
@@ -28,34 +28,34 @@
         ]
     },
     "target_condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:witch"
             },
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:vex"
             },
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:evoker"
             },
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:illusioner"
             },
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:pillager"
             },
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:vindicator"
             },
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:ravager"
             }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_1_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_1_health.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:attribute",
+    "type": "apoli:attribute",
     "modifier": {
         "name": "Form ocelot0 health reduction",
         "attribute": "minecraft:generic.max_health",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_1_use_normal_creature.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_1_use_normal_creature.json
@@ -1,32 +1,32 @@
 {
-    "type": "origins:action_on_entity_use",
+    "type": "apoli:action_on_entity_use",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:heal",
+                            "type": "apoli:heal",
                             "amount": -7
                         },
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "particle soul_fire_flame ~ ~0.5 ~ 0.3 0.3 0.3 0.009 10 normal @a"
                         },
                         {
-                            "type": "origins:play_sound",
+                            "type": "apoli:play_sound",
                             "sound": "minecraft:entity.evoker.cast_spell"
                         }
                     ]
                 }
             },
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
                             "type": "shape-shifter-curse:add_instinct",
@@ -35,12 +35,12 @@
                             "duration": 0
                         },
                         {
-                            "type": "origins:feed",
+                            "type": "apoli:feed",
                             "food": 6,
                             "saturation": 0.3
                         },
                         {
-                            "type": "origins:trigger_cooldown",
+                            "type": "apoli:trigger_cooldown",
                             "power": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown"
                         },
                         {
@@ -53,19 +53,19 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:target_condition",
+                "type": "apoli:target_condition",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "shape-shifter-curse:familiar_normal_target"
                 }
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
-                    "type": "origins:resource",
+                    "type": "apoli:resource",
                     "resource": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown",
                     "comparison": "<",
                     "compare_to": 1
@@ -74,7 +74,7 @@
         ]
     },
     "item_condition": {
-        "type": "origins:empty"
+        "type": "apoli:empty"
     },
     "hands": [
         "main_hand"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_attract_to_witch.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_attract_to_witch.json
@@ -1,15 +1,15 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:add_velocity",
+                "type": "apoli:add_velocity",
                 "z": 0.085,
                 "space": "local_horizontal_normalized"
             },
             {
-                "type": "origins:apply_effect",
+                "type": "apoli:apply_effect",
                 "effect": {
                     "effect": "minecraft:nausea",
                     "amplifier": 1,
@@ -20,33 +20,33 @@
     },
     "interval": 1,
     "condition": {
-        "type": "origins:raycast",
+        "type": "apoli:raycast",
         "distance": 20,
         "block": false,
         "entity": true,
         "shape_type": "visual",
         "fluid_handling": "any",
         "hit_bientity_condition": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "conditions": [
                 {
-                    "type": "origins:target_condition",
+                    "type": "apoli:target_condition",
                     "condition": {
-                        "type": "origins:or",
+                        "type": "apoli:or",
                         "conditions": [
                             {
-                                "type": "origins:entity_type",
+                                "type": "apoli:entity_type",
                                 "entity_type": "minecraft:witch"
                             },
                             {
-                                "type": "origins:entity_type",
+                                "type": "apoli:entity_type",
                                 "entity_type": "minecraft:evoker"
                             }
                         ]
                     }
                 },
                 {
-                    "type": "origins:distance",
+                    "type": "apoli:distance",
                     "comparison": ">=",
                     "compare_to": 1.5
                 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_charm_paper_fireball.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_charm_paper_fireball.json
@@ -1,18 +1,18 @@
 {
-    "type": "origins:action_on_item_use",
+    "type": "apoli:action_on_item_use",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:fire_projectile",
+                "type": "apoli:fire_projectile",
                 "entity_type": "minecraft:small_fireball",
                 "divergence": 1.0,
                 "count": 1,
                 "projectile_action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:spawn_particles",
+                            "type": "apoli:spawn_particles",
                             "particle": "minecraft:soul_fire_flame",
                             "count": 8,
                             "speed": 0.0,
@@ -27,7 +27,7 @@
                 }
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.blaze.shoot"
             },
             {
@@ -35,11 +35,11 @@
                 "mana": 2.5
             },
             {
-                "type": "origins:trigger_cooldown",
+                "type": "apoli:trigger_cooldown",
                 "power": "shape-shifter-curse:form_familiar_fox_fire_arrow_cooldown"
             },
             {
-                "type": "origins:modify_resource",
+                "type": "apoli:modify_resource",
                 "modifier": {
                     "operation": "set_total",
                     "value": 1
@@ -49,10 +49,10 @@
         ]
     },
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:resource",
+                "type": "apoli:resource",
                 "resource": "shape-shifter-curse:form_familiar_fox_fire_arrow_cooldown",
                 "comparison": "<",
                 "compare_to": 1
@@ -64,13 +64,13 @@
         ]
     },
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "shape-shifter-curse:fire_charm_paper"
         }
     },
     "item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "trigger": "instant"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_charm_paper_fireball_damage.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_charm_paper_fireball_damage.json
@@ -1,13 +1,13 @@
 {
-    "type": "origins:modify_projectile_damage",
+    "type": "apoli:modify_projectile_damage",
     "condition": {
-        "type": "origins:resource",
+        "type": "apoli:resource",
         "resource": "shape-shifter-curse:form_familiar_fox_fireball_kind_boolean_resource",
         "comparison": "==",
         "compare_to": 1
     },
     "damage_condition": {
-        "type": "origins:projectile",
+        "type": "apoli:projectile",
         "projectile": "minecraft:small_fireball"
     },
     "modifier": {
@@ -15,31 +15,31 @@
         "value": 9.0
     },
     "target_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
                 "type": "shape-shifter-curse:explosion_damage_entity",
                 "power": 1,
                 "entity_condition": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "conditions": [
                         {
-                            "type": "origins:target_condition",
+                            "type": "apoli:target_condition",
                             "condition": {
-                                "type": "origins:in_tag",
+                                "type": "apoli:in_tag",
                                 "tag": "shape-shifter-curse:water_explode_immune"
                             },
                             "inverted": true
                         },
                         {
-                            "type": "origins:owner",
+                            "type": "apoli:owner",
                             "inverted": true
                         }
                     ]
                 }
             },
             {
-                "type": "origins:spawn_particles",
+                "type": "apoli:spawn_particles",
                 "particle": "minecraft:explosion",
                 "count": 2,
                 "speed": 0.0,
@@ -51,7 +51,7 @@
                 }
             },
             {
-                "type": "origins:spawn_particles",
+                "type": "apoli:spawn_particles",
                 "particle": "minecraft:soul_fire_flame",
                 "count": 8,
                 "speed": 0.0,
@@ -63,7 +63,7 @@
                 }
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.generic.explode"
             }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_craft_harming_potion.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_craft_harming_potion.json
@@ -1,30 +1,30 @@
 {
-    "type": "origins:item_on_item",
+    "type": "apoli:item_on_item",
     "using_item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:potion"
         }
     },
     "on_item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:fermented_spider_eye"
         }
     },
     "using_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "on_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "/give @p minecraft:splash_potion{Potion:\"minecraft:harming\"} 3"
             },
             {
@@ -34,7 +34,7 @@
         ]
     },
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:has_mana",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_craft_healing_potion.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_craft_healing_potion.json
@@ -1,30 +1,30 @@
 {
-    "type": "origins:item_on_item",
+    "type": "apoli:item_on_item",
     "using_item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:potion"
         }
     },
     "on_item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:glistering_melon_slice"
         }
     },
     "using_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "on_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "/give @p minecraft:splash_potion{Potion:\"minecraft:healing\"} 3"
             },
             {
@@ -34,7 +34,7 @@
         ]
     },
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:has_mana",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_craft_poison_potion.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_craft_poison_potion.json
@@ -1,30 +1,30 @@
 {
-    "type": "origins:item_on_item",
+    "type": "apoli:item_on_item",
     "using_item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:potion"
         }
     },
     "on_item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:spider_eye"
         }
     },
     "using_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "on_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "/give @p minecraft:splash_potion{Potion:\"minecraft:poison\"} 3"
             },
             {
@@ -34,7 +34,7 @@
         ]
     },
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:has_mana",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_health.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:attribute",
+    "type": "apoli:attribute",
     "modifier": {
         "name": "Form ocelot0 health reduction",
         "attribute": "minecraft:generic.max_health",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_stick_fireball.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_stick_fireball.json
@@ -1,18 +1,18 @@
 {
-    "type": "origins:action_on_item_use",
+    "type": "apoli:action_on_item_use",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:fire_projectile",
+                "type": "apoli:fire_projectile",
                 "entity_type": "minecraft:small_fireball",
                 "divergence": 1.0,
                 "count": 1,
                 "projectile_action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:spawn_particles",
+                            "type": "apoli:spawn_particles",
                             "particle": "minecraft:soul_fire_flame",
                             "count": 8,
                             "speed": 0.0,
@@ -27,7 +27,7 @@
                 }
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.blaze.shoot"
             },
             {
@@ -35,11 +35,11 @@
                 "mana": 2.5
             },
             {
-                "type": "origins:trigger_cooldown",
+                "type": "apoli:trigger_cooldown",
                 "power": "shape-shifter-curse:form_familiar_fox_fire_arrow_cooldown"
             },
             {
-                "type": "origins:modify_resource",
+                "type": "apoli:modify_resource",
                 "modifier": {
                     "operation": "set_total",
                     "value": 0
@@ -49,10 +49,10 @@
         ]
     },
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:resource",
+                "type": "apoli:resource",
                 "resource": "shape-shifter-curse:form_familiar_fox_fire_arrow_cooldown",
                 "comparison": "<",
                 "compare_to": 1
@@ -64,13 +64,13 @@
         ]
     },
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:stick"
         }
     },
     "item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "trigger": "instant"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_stick_fireball_damage.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_stick_fireball_damage.json
@@ -1,13 +1,13 @@
 {
-    "type": "origins:modify_projectile_damage",
+    "type": "apoli:modify_projectile_damage",
     "condition": {
-        "type": "origins:resource",
+        "type": "apoli:resource",
         "resource": "shape-shifter-curse:form_familiar_fox_fireball_kind_boolean_resource",
         "comparison": "==",
         "compare_to": 0
     },
     "damage_condition": {
-        "type": "origins:projectile",
+        "type": "apoli:projectile",
         "projectile": "minecraft:small_fireball"
     },
     "modifier": {

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_use_illager_creature.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_use_illager_creature.json
@@ -1,36 +1,36 @@
 {
-    "type": "origins:action_on_entity_use",
+    "type": "apoli:action_on_entity_use",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "particle soul_fire_flame ~ ~0.5 ~ 0.3 0.3 0.3 0.009 10 normal @a"
                         },
                         {
-                            "type": "origins:play_sound",
+                            "type": "apoli:play_sound",
                             "sound": "minecraft:entity.evoker.cast_spell"
                         }
                     ]
                 }
             },
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:feed",
+                            "type": "apoli:feed",
                             "food": 9,
                             "saturation": 0.4
                         },
                         {
-                            "type": "origins:trigger_cooldown",
+                            "type": "apoli:trigger_cooldown",
                             "power": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown"
                         },
                         {
@@ -43,31 +43,31 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:or",
+                "type": "apoli:or",
                 "conditions": [
                     {
-                        "type": "origins:target_condition",
+                        "type": "apoli:target_condition",
                         "condition": {
-                            "type": "origins:in_tag",
+                            "type": "apoli:in_tag",
                             "tag": "shape-shifter-curse:familiar_illager_target"
                         }
                     },
                     {
-                        "type": "origins:target_condition",
+                        "type": "apoli:target_condition",
                         "condition": {
-                            "type": "origins:in_tag",
+                            "type": "apoli:in_tag",
                             "tag": "shape-shifter-curse:familiar_sorcery_target"
                         }
                     }
                 ]
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
-                    "type": "origins:resource",
+                    "type": "apoli:resource",
                     "resource": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown",
                     "comparison": "<",
                     "compare_to": 1
@@ -76,7 +76,7 @@
         ]
     },
     "item_condition": {
-        "type": "origins:empty"
+        "type": "apoli:empty"
     },
     "hands": [
         "main_hand"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_use_illager_creature_bottle.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_2_use_illager_creature_bottle.json
@@ -1,35 +1,35 @@
 {
-    "type": "origins:action_on_entity_use",
+    "type": "apoli:action_on_entity_use",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "particle soul_fire_flame ~ ~0.5 ~ 0.3 0.3 0.3 0.009 10 normal @a"
                         },
                         {
-                            "type": "origins:play_sound",
+                            "type": "apoli:play_sound",
                             "sound": "minecraft:entity.evoker.cast_spell"
                         }
                     ]
                 }
             },
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "/give @p minecraft:splash_potion{Potion:\"shape-shifter-curse:feed_potion\"}"
                         },
                         {
-                            "type": "origins:trigger_cooldown",
+                            "type": "apoli:trigger_cooldown",
                             "power": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown"
                         }
                     ]
@@ -38,31 +38,31 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:or",
+                "type": "apoli:or",
                 "conditions": [
                     {
-                        "type": "origins:target_condition",
+                        "type": "apoli:target_condition",
                         "condition": {
-                            "type": "origins:in_tag",
+                            "type": "apoli:in_tag",
                             "tag": "shape-shifter-curse:familiar_illager_target"
                         }
                     },
                     {
-                        "type": "origins:target_condition",
+                        "type": "apoli:target_condition",
                         "condition": {
-                            "type": "origins:in_tag",
+                            "type": "apoli:in_tag",
                             "tag": "shape-shifter-curse:familiar_sorcery_target"
                         }
                     }
                 ]
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
-                    "type": "origins:resource",
+                    "type": "apoli:resource",
                     "resource": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown",
                     "comparison": "<",
                     "compare_to": 1
@@ -71,13 +71,13 @@
         ]
     },
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:glass_bottle"
         }
     },
     "held_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "hands": [

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_attract_to_witch2.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_attract_to_witch2.json
@@ -1,20 +1,20 @@
 {
     "type": "shape-shifter-curse:attract_by_entity",
     "entity_condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:witch"
             },
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:evoker"
             }
         ]
     },
     "self_action": {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
             "effect": "minecraft:nausea",
             "amplifier": 1,
@@ -22,7 +22,7 @@
         }
     },
     "entity_action": {
-        "type": "origins:spawn_particles",
+        "type": "apoli:spawn_particles",
         "particle": "minecraft:soul_fire_flame",
         "count": 1,
         "speed": 0.0,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_craft_harming_potion.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_craft_harming_potion.json
@@ -1,30 +1,30 @@
 {
-    "type": "origins:item_on_item",
+    "type": "apoli:item_on_item",
     "using_item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:potion"
         }
     },
     "on_item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:fermented_spider_eye"
         }
     },
     "using_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "on_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "/give @p minecraft:splash_potion{Potion:\"minecraft:strong_harming\"} 3"
             },
             {
@@ -34,7 +34,7 @@
         ]
     },
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:has_mana",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_craft_healing_potion.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_craft_healing_potion.json
@@ -1,30 +1,30 @@
 {
-    "type": "origins:item_on_item",
+    "type": "apoli:item_on_item",
     "using_item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:potion"
         }
     },
     "on_item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:glistering_melon_slice"
         }
     },
     "using_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "on_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "/give @p minecraft:splash_potion{Potion:\"minecraft:strong_healing\"} 3"
             },
             {
@@ -34,7 +34,7 @@
         ]
     },
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:has_mana",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_craft_poison_potion.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_craft_poison_potion.json
@@ -1,30 +1,30 @@
 {
-    "type": "origins:item_on_item",
+    "type": "apoli:item_on_item",
     "using_item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:potion"
         }
     },
     "on_item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:spider_eye"
         }
     },
     "using_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "on_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "/give @p minecraft:splash_potion{Potion:\"minecraft:strong_poison\"} 3"
             },
             {
@@ -34,7 +34,7 @@
         ]
     },
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:has_mana",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_digging_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_digging_speed_down.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:modify_break_speed",
+    "type": "apoli:modify_break_speed",
     "block_condition": {
-        "type": "origins:hardness",
+        "type": "apoli:hardness",
         "comparison": ">=",
         "compare_to": 1
     },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_fire_ring.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_fire_ring.json
@@ -1,24 +1,24 @@
 {
-    "type": "origins:active_self",
+    "type": "apoli:active_self",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
                 "type": "shape-shifter-curse:consume_mana",
                 "mana": 11
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:item.firecharge.use",
                 "volume": 0.5
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:block.fire.ambient",
                 "volume": 0.5
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "entity.evoker.prepare_summon",
                 "volume": 0.5
             },
@@ -26,22 +26,22 @@
                 "type": "shape-shifter-curse:explosion_damage_entity",
                 "power": 3,
                 "entity_condition": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "conditions": [
                         {
-                            "type": "origins:and",
+                            "type": "apoli:and",
                             "conditions": [
                                 {
-                                    "type": "origins:actor_condition",
+                                    "type": "apoli:actor_condition",
                                     "condition": {
-                                        "type": "origins:power_active",
+                                        "type": "apoli:power_active",
                                         "power": "shape-shifter-curse:pillager_friendly"
                                     }
                                 },
                                 {
-                                    "type": "origins:target_condition",
+                                    "type": "apoli:target_condition",
                                     "condition": {
-                                        "type": "origins:in_tag",
+                                        "type": "apoli:in_tag",
                                         "tag": "shape-shifter-curse:illager"
                                     }
                                 }
@@ -49,18 +49,18 @@
                             "inverted": true
                         },
                         {
-                            "type": "origins:and",
+                            "type": "apoli:and",
                             "conditions": [
                                 {
-                                    "type": "origins:target_condition",
+                                    "type": "apoli:target_condition",
                                     "condition": {
-                                        "type": "origins:in_tag",
+                                        "type": "apoli:in_tag",
                                         "tag": "shape-shifter-curse:water_explode_immune"
                                     },
                                     "inverted": true
                                 },
                                 {
-                                    "type": "origins:owner",
+                                    "type": "apoli:owner",
                                     "inverted": true
                                 }
                             ]
@@ -69,14 +69,14 @@
                 },
                 "entity_action":
                 {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:set_on_fire",
+                            "type": "apoli:set_on_fire",
                             "duration": 10
                         },
                         {
-                            "type": "origins:damage",
+                            "type": "apoli:damage",
                             "amount": 8,
                             "damage_type": "minecraft:on_fire"
                         }
@@ -113,7 +113,7 @@
                 "sample_count": 8
             },
             {
-                "type": "origins:spawn_particles",
+                "type": "apoli:spawn_particles",
                 "particle": "minecraft:soul_fire_flame",
                 "count": 8,
                 "speed": 0.0,
@@ -125,20 +125,20 @@
                 }
             },
             {
-                "type": "origins:trigger_cooldown",
+                "type": "apoli:trigger_cooldown",
                 "power": "shape-shifter-curse:form_familiar_fox_fire_explode_cooldown"
             }
         ]
     },
     "entity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:has_mana",
                 "mana": 11
             },
             {
-                "type": "origins:resource",
+                "type": "apoli:resource",
                 "resource": "shape-shifter-curse:form_familiar_fox_fire_explode_cooldown",
                 "comparison": "<",
                 "compare_to": 1

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_health.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:attribute",
+    "type": "apoli:attribute",
     "modifier": {
         "name": "Form ocelot0 health reduction",
         "attribute": "minecraft:generic.max_health",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_hurt_when_attack_witch.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_hurt_when_attack_witch.json
@@ -1,14 +1,14 @@
 {
-    "type": "origins:self_action_on_hit",
+    "type": "apoli:self_action_on_hit",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:heal",
+                "type": "apoli:heal",
                 "amount": -1
             },
             {
-                "type": "origins:add_velocity",
+                "type": "apoli:add_velocity",
                 "z": -0.5,
                 "y": 0.5,
                 "space": "local_horizontal_normalized"
@@ -16,34 +16,34 @@
         ]
     },
     "target_condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:witch"
             },
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:vex"
             },
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:evoker"
             },
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:illusioner"
             },
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:pillager"
             },
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:vindicator"
             },
             {
-                "type": "origins:entity_type",
+                "type": "apoli:entity_type",
                 "entity_type": "minecraft:ravager"
             }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_in_fire_cost_mana.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_in_fire_cost_mana.json
@@ -1,25 +1,25 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
         "type": "shape-shifter-curse:consume_mana",
         "mana": 0.1
     },
     "interval": 5,
     "condition": {
-        "type": "origins:in_block",
+        "type": "apoli:in_block",
         "block_condition": {
-            "type": "origins:or",
+            "type": "apoli:or",
             "conditions": [
                 {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:fire"
                 },
                 {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:lava"
                 },
                 {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:soul_fire"
                 }
             ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_jump_high.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_jump_high.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_jump",
+    "type": "apoli:modify_jump",
     "modifier": {
         "name": "Bonus jump force",
         "operation": "multiply_base",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_low_mana_damage.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_low_mana_damage.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:damage",
+        "type": "apoli:damage",
         "amount": 1,
         "damage_type": "minecraft:starve"
     },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_mob_glow_in_range.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_mob_glow_in_range.json
@@ -1,15 +1,15 @@
 {
-    "type": "origins:entity_glow",
+    "type": "apoli:entity_glow",
     "bientity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:distance",
+                "type": "apoli:distance",
                 "comparison": "<=",
                 "compare_to": 15
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
                     "type": "shape-shifter-curse:can_render_gui"
                 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_no_attack_witch.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_no_attack_witch.json
@@ -1,25 +1,25 @@
 {
-    "type": "origins:action_on_hit",
+    "type": "apoli:action_on_hit",
     "bientity_action": {
-        "type": "origins:target_action",
+        "type": "apoli:target_action",
         "action": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "actions": [
                 {
-                    "type": "origins:heal",
+                    "type": "apoli:heal",
                     "amount": 20.0
                 },
                 {
-                    "type": "origins:play_sound",
+                    "type": "apoli:play_sound",
                     "sound": "minecraft:entity.ender_eye.death"
                 }
             ]
         }
     },
     "bientity_condition": {
-        "type": "origins:target_condition",
+        "type": "apoli:target_condition",
         "condition": {
-            "type": "origins:in_tag",
+            "type": "apoli:in_tag",
             "tag": "shape-shifter-curse:illager"
         }
     },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_no_buff_effect.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_no_buff_effect.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:effect_immunity",
+    "type": "apoli:effect_immunity",
     "effects": [
         "minecraft:poison",
         "minecraft:hunger",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_no_food.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_no_food.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifiers": [
         {
             "operation": "set_total",
@@ -13,15 +13,15 @@
         }
     ],
     "item_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:food"
+                "type": "apoli:food"
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:ignore_diet"
+                    "tag": "shape-shifter-curse:ignore_diet"
                 },
                 "inverted": true
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_particle.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_particle.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:particle",
+    "type": "apoli:particle",
     "particle": "minecraft:soul_fire_flame",
     "frequency": 10,
     "visible_while_invisible": true,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_enemy_creature.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_enemy_creature.json
@@ -1,36 +1,36 @@
 {
-    "type": "origins:action_on_entity_use",
+    "type": "apoli:action_on_entity_use",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "particle soul_fire_flame ~ ~0.5 ~ 0.3 0.3 0.3 0.009 10 normal @a"
                         },
                         {
-                            "type": "origins:play_sound",
+                            "type": "apoli:play_sound",
                             "sound": "minecraft:entity.evoker.cast_spell"
                         }
                     ]
                 }
             },
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:feed",
+                            "type": "apoli:feed",
                             "food": 4,
                             "saturation": 0.3
                         },
                         {
-                            "type": "origins:apply_effect",
+                            "type": "apoli:apply_effect",
                             "effect": {
                                 "effect": "minecraft:blindness",
                                 "amplifier": 1,
@@ -38,7 +38,7 @@
                             }
                         },
                         {
-                            "type": "origins:apply_effect",
+                            "type": "apoli:apply_effect",
                             "effect": {
                                 "effect": "minecraft:slowness",
                                 "amplifier": 3,
@@ -46,7 +46,7 @@
                             }
                         },
                         {
-                            "type": "origins:apply_effect",
+                            "type": "apoli:apply_effect",
                             "effect": {
                                 "effect": "minecraft:weakness",
                                 "amplifier": 1,
@@ -54,7 +54,7 @@
                             }
                         },
                         {
-                            "type": "origins:trigger_cooldown",
+                            "type": "apoli:trigger_cooldown",
                             "power": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown"
                         },
                         {
@@ -67,19 +67,19 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:target_condition",
+                "type": "apoli:target_condition",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "shape-shifter-curse:familiar_enemy_target"
                 }
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
-                    "type": "origins:resource",
+                    "type": "apoli:resource",
                     "resource": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown",
                     "comparison": "<",
                     "compare_to": 1
@@ -88,7 +88,7 @@
         ]
     },
     "item_condition": {
-        "type": "origins:empty"
+        "type": "apoli:empty"
     },
     "hands": [
         "main_hand"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_human_creature.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_human_creature.json
@@ -1,40 +1,40 @@
 {
-    "type": "origins:action_on_entity_use",
+    "type": "apoli:action_on_entity_use",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:heal",
+                            "type": "apoli:heal",
                             "amount": -6
                         },
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "particle soul_fire_flame ~ ~0.5 ~ 0.3 0.3 0.3 0.009 10 normal @a"
                         },
                         {
-                            "type": "origins:play_sound",
+                            "type": "apoli:play_sound",
                             "sound": "minecraft:entity.evoker.cast_spell"
                         }
                     ]
                 }
             },
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:feed",
+                            "type": "apoli:feed",
                             "food": 9,
                             "saturation": 0.4
                         },
                         {
-                            "type": "origins:trigger_cooldown",
+                            "type": "apoli:trigger_cooldown",
                             "power": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown"
                         },
                         {
@@ -47,43 +47,43 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:target_condition",
+                "type": "apoli:target_condition",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "shape-shifter-curse:familiar_human_target"
                 }
             },
             {
-                "type": "origins:target_condition",
+                "type": "apoli:target_condition",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "shape-shifter-curse:familiar_human_onlyhand_blacklist"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
-                    "type": "origins:resource",
+                    "type": "apoli:resource",
                     "resource": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown",
                     "comparison": "<",
                     "compare_to": 1
                 }
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
-                    "type": "origins:sneaking",
+                    "type": "apoli:sneaking",
                     "inverted": true
                 }
             }
         ]
     },
     "item_condition": {
-        "type": "origins:empty"
+        "type": "apoli:empty"
     },
     "hands": [
         "main_hand"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_human_creature_bottle.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_human_creature_bottle.json
@@ -1,39 +1,39 @@
 {
-    "type": "origins:action_on_entity_use",
+    "type": "apoli:action_on_entity_use",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:heal",
+                            "type": "apoli:heal",
                             "amount": -6
                         },
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "particle soul_fire_flame ~ ~0.5 ~ 0.3 0.3 0.3 0.009 10 normal @a"
                         },
                         {
-                            "type": "origins:play_sound",
+                            "type": "apoli:play_sound",
                             "sound": "minecraft:entity.evoker.cast_spell"
                         }
                     ]
                 }
             },
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "/give @p minecraft:splash_potion{Potion:\"shape-shifter-curse:feed_potion\"}"
                         },
                         {
-                            "type": "origins:trigger_cooldown",
+                            "type": "apoli:trigger_cooldown",
                             "power": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown"
                         }
                     ]
@@ -42,19 +42,19 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:target_condition",
+                "type": "apoli:target_condition",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "shape-shifter-curse:familiar_human_target"
                 }
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
-                    "type": "origins:resource",
+                    "type": "apoli:resource",
                     "resource": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown",
                     "comparison": "<",
                     "compare_to": 1
@@ -63,13 +63,13 @@
         ]
     },
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:glass_bottle"
         }
     },
     "held_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "hands": [

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_illager_creature.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_illager_creature.json
@@ -1,36 +1,36 @@
 {
-    "type": "origins:action_on_entity_use",
+    "type": "apoli:action_on_entity_use",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "particle soul_fire_flame ~ ~0.5 ~ 0.3 0.3 0.3 0.009 10 normal @a"
                         },
                         {
-                            "type": "origins:play_sound",
+                            "type": "apoli:play_sound",
                             "sound": "minecraft:entity.evoker.cast_spell"
                         }
                     ]
                 }
             },
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:feed",
+                            "type": "apoli:feed",
                             "food": 9,
                             "saturation": 0.4
                         },
                         {
-                            "type": "origins:trigger_cooldown",
+                            "type": "apoli:trigger_cooldown",
                             "power": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown"
                         },
                         {
@@ -43,19 +43,19 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:target_condition",
+                "type": "apoli:target_condition",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "shape-shifter-curse:familiar_illager_target"
                 }
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
-                    "type": "origins:resource",
+                    "type": "apoli:resource",
                     "resource": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown",
                     "comparison": "<",
                     "compare_to": 1
@@ -64,7 +64,7 @@
         ]
     },
     "item_condition": {
-        "type": "origins:empty"
+        "type": "apoli:empty"
     },
     "hands": [
         "main_hand"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_illager_creature_bottle.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_illager_creature_bottle.json
@@ -1,35 +1,35 @@
 {
-    "type": "origins:action_on_entity_use",
+    "type": "apoli:action_on_entity_use",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "particle soul_fire_flame ~ ~0.5 ~ 0.3 0.3 0.3 0.009 10 normal @a"
                         },
                         {
-                            "type": "origins:play_sound",
+                            "type": "apoli:play_sound",
                             "sound": "minecraft:entity.evoker.cast_spell"
                         }
                     ]
                 }
             },
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "/give @p minecraft:splash_potion{Potion:\"shape-shifter-curse:feed_potion\"}"
                         },
                         {
-                            "type": "origins:trigger_cooldown",
+                            "type": "apoli:trigger_cooldown",
                             "power": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown"
                         }
                     ]
@@ -38,19 +38,19 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:target_condition",
+                "type": "apoli:target_condition",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "shape-shifter-curse:familiar_illager_target"
                 }
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
-                    "type": "origins:resource",
+                    "type": "apoli:resource",
                     "resource": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown",
                     "comparison": "<",
                     "compare_to": 1
@@ -59,13 +59,13 @@
         ]
     },
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:glass_bottle"
         }
     },
     "held_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "hands": [

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_normal_creature.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_normal_creature.json
@@ -1,40 +1,40 @@
 {
-    "type": "origins:action_on_entity_use",
+    "type": "apoli:action_on_entity_use",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:heal",
+                            "type": "apoli:heal",
                             "amount": -4
                         },
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "particle soul_fire_flame ~ ~0.5 ~ 0.3 0.3 0.3 0.009 10 normal @a"
                         },
                         {
-                            "type": "origins:play_sound",
+                            "type": "apoli:play_sound",
                             "sound": "minecraft:entity.evoker.cast_spell"
                         }
                     ]
                 }
             },
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:feed",
+                            "type": "apoli:feed",
                             "food": 6,
                             "saturation": 0.3
                         },
                         {
-                            "type": "origins:trigger_cooldown",
+                            "type": "apoli:trigger_cooldown",
                             "power": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown"
                         },
                         {
@@ -47,19 +47,19 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:target_condition",
+                "type": "apoli:target_condition",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "shape-shifter-curse:familiar_normal_target"
                 }
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
-                    "type": "origins:resource",
+                    "type": "apoli:resource",
                     "resource": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown",
                     "comparison": "<",
                     "compare_to": 1
@@ -68,7 +68,7 @@
         ]
     },
     "item_condition": {
-        "type": "origins:empty"
+        "type": "apoli:empty"
     },
     "hands": [
         "main_hand"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_sorcery_creature.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_sorcery_creature.json
@@ -1,40 +1,40 @@
 {
-    "type": "origins:action_on_entity_use",
+    "type": "apoli:action_on_entity_use",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "particle soul_fire_flame ~ ~0.5 ~ 0.3 0.3 0.3 0.009 10 normal @a"
                         },
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "particle heart ~ ~0.5 ~ 0.3 0.3 0.3 0.009 3 normal @a"
                         },
                         {
-                            "type": "origins:play_sound",
+                            "type": "apoli:play_sound",
                             "sound": "minecraft:entity.evoker.cast_spell"
                         }
                     ]
                 }
             },
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:feed",
+                            "type": "apoli:feed",
                             "food": 15,
                             "saturation": 0.4
                         },
                         {
-                            "type": "origins:trigger_cooldown",
+                            "type": "apoli:trigger_cooldown",
                             "power": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown"
                         },
                         {
@@ -47,19 +47,19 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:target_condition",
+                "type": "apoli:target_condition",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "shape-shifter-curse:familiar_sorcery_target"
                 }
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
-                    "type": "origins:resource",
+                    "type": "apoli:resource",
                     "resource": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown",
                     "comparison": "<",
                     "compare_to": 1
@@ -68,7 +68,7 @@
         ]
     },
     "item_condition": {
-        "type": "origins:empty"
+        "type": "apoli:empty"
     },
     "hands": [
         "main_hand"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_sorcery_creature_bottle.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_3_use_sorcery_creature_bottle.json
@@ -1,39 +1,39 @@
 {
-    "type": "origins:action_on_entity_use",
+    "type": "apoli:action_on_entity_use",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "particle soul_fire_flame ~ ~0.5 ~ 0.3 0.3 0.3 0.009 10 normal @a"
                         },
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "particle heart ~ ~0.5 ~ 0.3 0.3 0.3 0.009 3 normal @a"
                         },
                         {
-                            "type": "origins:play_sound",
+                            "type": "apoli:play_sound",
                             "sound": "minecraft:entity.evoker.cast_spell"
                         }
                     ]
                 }
             },
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "/give @p minecraft:splash_potion{Potion:\"shape-shifter-curse:feed_potion\"}"
                         },
                         {
-                            "type": "origins:trigger_cooldown",
+                            "type": "apoli:trigger_cooldown",
                             "power": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown"
                         }
                     ]
@@ -42,19 +42,19 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:target_condition",
+                "type": "apoli:target_condition",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "shape-shifter-curse:familiar_sorcery_target"
                 }
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
-                    "type": "origins:resource",
+                    "type": "apoli:resource",
                     "resource": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown",
                     "comparison": "<",
                     "compare_to": 1
@@ -63,13 +63,13 @@
         ]
     },
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:glass_bottle"
         }
     },
     "held_item_action": {
-        "type": "origins:consume",
+        "type": "apoli:consume",
         "amount": 1
     },
     "hands": [

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_amulet_bracelet_trinket.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_amulet_bracelet_trinket.json
@@ -1,36 +1,36 @@
 {
-    "type": "origins:action_on_entity_use",
+    "type": "apoli:action_on_entity_use",
     "bientity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:target_action",
+                "type": "apoli:target_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:execute_command",
+                            "type": "apoli:execute_command",
                             "command": "particle soul_fire_flame ~ ~0.5 ~ 0.3 0.3 0.3 0.009 10 normal @a"
                         },
                         {
-                            "type": "origins:play_sound",
+                            "type": "apoli:play_sound",
                             "sound": "minecraft:entity.evoker.cast_spell"
                         }
                     ]
                 }
             },
             {
-                "type": "origins:actor_action",
+                "type": "apoli:actor_action",
                 "action": {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "actions": [
                         {
-                            "type": "origins:feed",
+                            "type": "apoli:feed",
                             "food": 4,
                             "saturation": 0.3
                         },
                         {
-                            "type": "origins:trigger_cooldown",
+                            "type": "apoli:trigger_cooldown",
                             "power": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown"
                         },
                         {
@@ -43,19 +43,19 @@
         ]
     },
     "bientity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:target_condition",
+                "type": "apoli:target_condition",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "shape-shifter-curse:familiar_enemy_target"
                 }
             },
             {
-                "type": "origins:actor_condition",
+                "type": "apoli:actor_condition",
                 "condition": {
-                    "type": "origins:resource",
+                    "type": "apoli:resource",
                     "resource": "shape-shifter-curse:form_familiar_fox_use_entity_cooldown",
                     "comparison": "<",
                     "compare_to": 1
@@ -64,7 +64,7 @@
         ]
     },
     "item_condition": {
-        "type": "origins:empty"
+        "type": "apoli:empty"
     },
     "hands": [
         "main_hand"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_fire_arrow_cooldown.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_fire_arrow_cooldown.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:cooldown",
+    "type": "apoli:cooldown",
     "cooldown": 20,
     "hud_render": {
         "should_render": false

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_fire_explode_cooldown.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_fire_explode_cooldown.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:cooldown",
+    "type": "apoli:cooldown",
     "cooldown": 60,
     "hud_render": {
         "should_render": false

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_fireball_kind_boolean_resource.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_fireball_kind_boolean_resource.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:resource",
+    "type": "apoli:resource",
     "min": 0,
     "max": 1,
     "hud_render": {

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_instinct_biome.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_instinct_biome.json
@@ -4,9 +4,9 @@
     "value": 0.002,
     "duration": 1,
     "condition": {
-        "type": "origins:biome",
+        "type": "apoli:biome",
         "condition": {
-            "type": "origins:in_tag",
+            "type": "apoli:in_tag",
             "tag": "minecraft:is_taiga"
         }
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_instinct_eat_berry.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_instinct_eat_berry.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:action_on_item_use",
+    "type": "apoli:action_on_item_use",
     "entity_action": {
         "type": "shape-shifter-curse:add_instinct",
         "instinct_effect_id": "shape-shifter-curse:form_familiar_fox_eat_berry",
@@ -7,7 +7,7 @@
         "duration": 20
     },
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:sweet_berries"
         }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_instinct_in_berry_bush.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_instinct_in_berry_bush.json
@@ -4,12 +4,12 @@
     "value": 0.008,
     "duration": 1,
     "condition": {
-        "type": "origins:block_in_radius",
+        "type": "apoli:block_in_radius",
         "block_condition": {
-            "type": "origins:or",
+            "type": "apoli:or",
             "conditions": [
                 {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:sweet_berry_bush"
                 }
             ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_instinct_looking_witch.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_instinct_looking_witch.json
@@ -4,23 +4,23 @@
     "value": 0.013,
     "duration": 1,
     "condition": {
-        "type": "origins:raycast",
+        "type": "apoli:raycast",
         "distance": 20,
         "block": false,
         "entity": true,
         "shape_type": "visual",
         "fluid_handling": "any",
         "hit_bientity_condition": {
-            "type": "origins:target_condition",
+            "type": "apoli:target_condition",
             "condition": {
-                "type": "origins:or",
+                "type": "apoli:or",
                 "conditions": [
                     {
-                        "type": "origins:entity_type",
+                        "type": "apoli:entity_type",
                         "entity_type": "minecraft:witch"
                     },
                     {
-                        "type": "origins:entity_type",
+                        "type": "apoli:entity_type",
                         "entity_type": "minecraft:evoker"
                     }
                 ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_instinct_moving_on_snow.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_instinct_moving_on_snow.json
@@ -4,22 +4,22 @@
     "value": 0.008,
     "duration": 1,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:or",
+                "type": "apoli:or",
                 "conditions": [
                     {
-                        "type": "origins:on_block",
+                        "type": "apoli:on_block",
                         "block_condition": {
-                            "type": "origins:block",
+                            "type": "apoli:block",
                             "block": "minecraft:snow_block"
                         }
                     },
                     {
-                        "type": "origins:on_block",
+                        "type": "apoli:on_block",
                         "block_condition": {
-                            "type": "origins:block_state",
+                            "type": "apoli:block_state",
                             "property": "snowy",
                             "value": true
                         }
@@ -27,7 +27,7 @@
                 ]
             },
             {
-                "type": "origins:moving"
+                "type": "apoli:moving"
             }
         ]
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_low_mana_exhaustion.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_low_mana_exhaustion.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_exhaustion",
+    "type": "apoli:modify_exhaustion",
     "modifier": {
         "name": "Increased exhaustion",
         "operation": "multiply_base",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_sound.json
@@ -1,12 +1,12 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.fox.ambient"
     },
     "interval": 200,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:enable_random_sound"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_sound_hurt.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_sound_hurt.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:self_action_when_hit",
+    "type": "apoli:self_action_when_hit",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.fox.hurt"
     },
     "condition": {

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_sound_key.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_sound_key.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:active_self",
+    "type": "apoli:active_self",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.fox.ambient"
     },
     "cooldown": 5,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_use_entity_cooldown.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_familiar_fox_use_entity_cooldown.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:cooldown",
+    "type": "apoli:cooldown",
     "cooldown": 60,
     "hud_render": {
         "should_render": false

--- a/src/main/resources/data/shape-shifter-curse/powers/form_force_disable_feet_armor.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_force_disable_feet_armor.json
@@ -1,10 +1,10 @@
 {
-    "type": "origins:restrict_armor",
+    "type": "apoli:restrict_armor",
     "feet": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:armor_value",
+          "type": "apoli:armor_value",
           "comparison": ">",
           "compare_to": -1
         }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_force_disable_leg_armor.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_force_disable_leg_armor.json
@@ -1,10 +1,10 @@
 {
-    "type": "origins:restrict_armor",
+    "type": "apoli:restrict_armor",
     "legs": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:armor_value",
+          "type": "apoli:armor_value",
           "comparison": ">",
           "compare_to": -1
         }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_instinct_use_catalyst.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_instinct_use_catalyst.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:action_on_item_use",
+    "type": "apoli:action_on_item_use",
     "entity_action": {
         "type": "shape-shifter-curse:add_instinct",
         "instinct_effect_id": "shape-shifter-curse:form_use_catalyst",
@@ -7,7 +7,7 @@
         "duration": 40
     },
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "shape-shifter-curse:catalyst"
         }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_instinct_use_golden_apple.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_instinct_use_golden_apple.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:action_on_item_use",
+    "type": "apoli:action_on_item_use",
     "entity_action": {
         "type": "shape-shifter-curse:add_instinct",
         "instinct_effect_id": "shape-shifter-curse:form_use_golden_apple",
@@ -7,16 +7,16 @@
         "duration": 40
     },
     "item_condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
                     "item": "minecraft:golden_apple"
                 }
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
                     "item": "minecraft:enchanted_golden_apple"
                 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_meat_food_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_meat_food_down.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifier": {
         "name": "Decreased food points",
         "operation": "multiply_base_multiplicative",
@@ -11,31 +11,31 @@
         "value": -0.5
     },
     "item_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:or",
+                "type": "apoli:or",
                 "conditions": [
                     {
-                        "type": "origins:ingredient",
+                        "type": "apoli:ingredient",
                         "ingredient": {
-                            "tag": "origins:meat"
+                            "tag": "shape-shifter-curse:meat"
                         }
                     },
                     {
-                        "type": "origins:meat"
+                        "type": "apoli:meat"
                     }
                 ]
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:ignore_diet"
+                    "tag": "shape-shifter-curse:ignore_diet"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
                     "tag": "shape-shifter-curse:ignore_vc_eat"
                 },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_meat_food_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_meat_food_up.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifiers": [
         {
             "name": "increase food points",
@@ -25,31 +25,31 @@
         }
     ],
     "item_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:or",
+                "type": "apoli:or",
                 "conditions": [
                     {
-                        "type": "origins:ingredient",
+                        "type": "apoli:ingredient",
                         "ingredient": {
-                            "tag": "origins:meat"
+                            "tag": "shape-shifter-curse:meat"
                         }
                     },
                     {
-                        "type": "origins:meat"
+                        "type": "apoli:meat"
                     }
                 ]
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:ignore_diet"
+                    "tag": "shape-shifter-curse:ignore_diet"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
                     "tag": "shape-shifter-curse:ignore_vc_eat"
                 },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_0_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_0_health.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:attribute",
+    "type": "apoli:attribute",
     "modifier": {
         "name": "Form ocelot0 health reduction",
         "attribute": "minecraft:generic.max_health",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_1_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_1_health.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:attribute",
+    "type": "apoli:attribute",
     "modifier": {
         "name": "Form ocelot0 health reduction",
         "attribute": "minecraft:generic.max_health",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_1_sneaking_jump_far.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_1_sneaking_jump_far.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:active_self",
+    "type": "apoli:active_self",
     "entity_action": {
-        "type": "origins:add_velocity",
+        "type": "apoli:add_velocity",
         "z": 0.25,
         "space": "local"
     },
@@ -14,13 +14,13 @@
         "continuous": false
     },
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:sneaking"
+                "type": "apoli:sneaking"
             },
             {
-                "type": "origins:food_level",
+                "type": "apoli:food_level",
                 "comparison": ">=",
                 "compare_to": 6
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_arrow_dodge.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_arrow_dodge.json
@@ -5,10 +5,10 @@
     "dodge_speed": 2,
     "cooldown": 20,
     "entity_condition": {
-        "type": "origins:on_block"
+        "type": "apoli:on_block"
     },
     "action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.goat.long_jump"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_barepaw_sweeping.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_barepaw_sweeping.json
@@ -1,13 +1,13 @@
 {
     "type": "shape-shifter-curse:always_sweeping",
     "condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:inventory",
+                "type": "apoli:inventory",
                 "process_mode": "items",
                 "item_condition": {
-                    "type": "origins:harvest_level",
+                    "type": "apoli:harvest_level",
                     "comparison": "<=",
                     "compare_to": 1
                 },
@@ -16,7 +16,7 @@
                 ]
             },
             {
-                "type": "origins:inventory",
+                "type": "apoli:inventory",
                 "process_mode": "items",
                 "comparison": "==",
                 "compare_to": 0,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_climb_wood.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_climb_wood.json
@@ -1,28 +1,28 @@
 {
-    "type": "origins:climbing",
+    "type": "apoli:climbing",
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:collided_horizontally"
+                "type": "apoli:collided_horizontally"
             },
             {
-                "type": "origins:or",
+                "type": "apoli:or",
                 "conditions": [
                     {
-                        "type": "origins:block_collision",
+                        "type": "apoli:block_collision",
                         "block_condition": {
-                            "type": "origins:in_tag",
-                            "tag": "origins:natural_wood"
+                            "type": "apoli:in_tag",
+                            "tag": "shape-shifter-curse:natural_wood"
                         },
                         "offset_x": 0.1,
                         "offset_z": 0.1
                     },
                     {
-                        "type": "origins:block_collision",
+                        "type": "apoli:block_collision",
                         "block_condition": {
-                            "type": "origins:in_tag",
-                            "tag": "origins:natural_wood"
+                            "type": "apoli:in_tag",
+                            "tag": "shape-shifter-curse:natural_wood"
                         },
                         "offset_x": -0.1,
                         "offset_z": -0.1

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_health.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:attribute",
+    "type": "apoli:attribute",
     "modifier": {
         "name": "Form ocelot0 health reduction",
         "attribute": "minecraft:generic.max_health",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_light_armor.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_light_armor.json
@@ -1,22 +1,22 @@
 {
-  "type": "origins:restrict_armor",
+  "type": "apoli:restrict_armor",
   "chest": {
-    "type": "origins:or",
+    "type": "apoli:or",
     "conditions": [
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "minecraft:leather_chestplate"
         }
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "minecraft:chainmail_chestplate"
         }
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "minecraft:elytra"
         }
@@ -25,25 +25,25 @@
         "type": "shape-shifter-curse:is_morph_scale_item"
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-          "tag": "origins:ignore_armor_restriction"
+          "tag": "shape-shifter-curse:ignore_armor_restriction"
         }
       }
     ],
     "inverted": true
   },
   "legs": {
-    "type": "origins:or",
+    "type": "apoli:or",
     "conditions": [
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "minecraft:leather_leggings"
         }
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "minecraft:chainmail_leggings"
         }
@@ -52,25 +52,25 @@
         "type": "shape-shifter-curse:is_morph_scale_item"
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-          "tag": "origins:ignore_armor_restriction"
+          "tag": "shape-shifter-curse:ignore_armor_restriction"
         }
       }
     ],
     "inverted": true
   },
   "feet": {
-    "type": "origins:or",
+    "type": "apoli:or",
     "conditions": [
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "minecraft:leather_boots"
         }
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "minecraft:chainmail_boots"
         }
@@ -79,7 +79,7 @@
         "type": "shape-shifter-curse:is_morph_scale_item"
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "tag": "shape-shifter-curse:ignore_armor_restriction"
         }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_raw_meat_only.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_raw_meat_only.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:modify_food",
+  "type": "apoli:modify_food",
   "food_modifiers": [
     {
       "operation": "set_total",
@@ -13,19 +13,19 @@
     }
   ],
   "item_condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
           {
-            "type": "origins:ingredient",
+            "type": "apoli:ingredient",
             "ingredient": {
-              "tag": "origins:raw_meat"
+              "tag": "shape-shifter-curse:raw_meat"
             }
           },
           {
-            "type": "origins:ingredient",
+            "type": "apoli:ingredient",
             "ingredient": {
               "item": "minecraft:rotten_flesh"
             }
@@ -34,17 +34,17 @@
         "inverted": true
       },
       {
-        "type": "origins:food"
+        "type": "apoli:food"
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-          "tag": "origins:ignore_diet"
+          "tag": "shape-shifter-curse:ignore_diet"
         },
         "inverted": true
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "tag": "shape-shifter-curse:ignore_vc_eat"
         },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_sneaking_hunger.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_sneaking_hunger.json
@@ -1,18 +1,18 @@
 {
-    "type": "origins:exhaust",
+    "type": "apoli:exhaust",
     "interval": 10,
     "exhaustion": 0.5,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:sneaking"
+                "type": "apoli:sneaking"
             },
             {
-                "type": "origins:moving"
+                "type": "apoli:moving"
             },
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_sneaking_jump_far.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_sneaking_jump_far.json
@@ -1,29 +1,29 @@
 {
     "type": "shape-shifter-curse:action_on_jump",
     "entity_action": {
-        "type": "origins:add_velocity",
+        "type": "apoli:add_velocity",
         "z": 0.8,
         "space": "local"
     },
     "entity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:sneaking"
+                "type": "apoli:sneaking"
             },
             {
-                "type": "origins:food_level",
+                "type": "apoli:food_level",
                 "comparison": ">=",
                 "compare_to": 6
             },
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0
             },
             {
-                "type": "origins:on_block"
+                "type": "apoli:on_block"
             }
         ]
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_sneaking_jump_high.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_sneaking_jump_high.json
@@ -1,18 +1,18 @@
 {
-    "type": "origins:modify_jump",
+    "type": "apoli:modify_jump",
     "modifier": {
         "name": "Bonus jump force while sneaking",
         "operation": "multiply_base",
         "value": 0.15
     },
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:sneaking"
+                "type": "apoli:sneaking"
             },
             {
-                "type": "origins:food_level",
+                "type": "apoli:food_level",
                 "comparison": ">=",
                 "compare_to": 6
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_sneaking_scale.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_sneaking_scale.json
@@ -5,10 +5,10 @@
     "original_scale": 0.65,
     "original_eye_scale": 1.0,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:sneaking"
+                "type": "apoli:sneaking"
             }
         ]
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_sneaking_speed_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_sneaking_speed_up.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "addition",
@@ -8,19 +8,19 @@
     },
     "tick_rate": 1,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0
             },
             {
-                "type": "origins:sneaking"
+                "type": "apoli:sneaking"
             },
             {
-                "type": "origins:food_level",
+                "type": "apoli:food_level",
                 "comparison": ">=",
                 "compare_to": 6
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_3_climb_all.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_3_climb_all.json
@@ -1,21 +1,21 @@
 {
-    "type": "origins:climbing",
+    "type": "apoli:climbing",
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:collided_horizontally"
+                "type": "apoli:collided_horizontally"
             },
             {
-                "type": "origins:or",
+                "type": "apoli:or",
                 "conditions": [
                     {
-                        "type": "origins:block_collision",
+                        "type": "apoli:block_collision",
                         "offset_x": 0.1,
                         "offset_z": 0.1
                     },
                     {
-                        "type": "origins:block_collision",
+                        "type": "apoli:block_collision",
                         "offset_x": -0.1,
                         "offset_z": -0.1
                     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_3_hunger.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_3_hunger.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:exhaust",
+    "type": "apoli:exhaust",
     "interval": 1,
     "exhaustion": 0.002
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_3_jump_far.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_3_jump_far.json
@@ -1,29 +1,29 @@
 {
     "type": "shape-shifter-curse:action_on_jump",
     "entity_action": {
-        "type": "origins:add_velocity",
+        "type": "apoli:add_velocity",
         "z": 0.8,
         "space": "local"
     },
     "entity_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:sneaking"
+                "type": "apoli:sneaking"
             },
             {
-                "type": "origins:food_level",
+                "type": "apoli:food_level",
                 "comparison": ">=",
                 "compare_to": 6
             },
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0
             },
             {
-                "type": "origins:on_block"
+                "type": "apoli:on_block"
             }
         ]
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_3_jump_high.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_3_jump_high.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:modify_jump",
+  "type": "apoli:modify_jump",
   "modifier": {
     "name": "Bonus jump force",
     "operation": "multiply_base",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_3_sneaking_jump_clash.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_3_sneaking_jump_clash.json
@@ -1,19 +1,19 @@
 {
   "type": "shape-shifter-curse:sneaking_jump_clash",
   "bientity_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:add_velocity",
+        "type": "apoli:add_velocity",
         "z": 2.0
       },
       {
-        "type": "origins:target_action",
+        "type": "apoli:target_action",
         "action": {
-          "type": "origins:and",
+          "type": "apoli:and",
           "actions": [
             {
-              "type": "origins:spawn_particles",
+              "type": "apoli:spawn_particles",
               "particle": "minecraft:crit",
               "count": 8,
               "speed": 0.0,
@@ -28,29 +28,29 @@
         }
       },
       {
-        "type": "origins:actor_action",
+        "type": "apoli:actor_action",
         "action": {
-          "type": "origins:and",
+          "type": "apoli:and",
           "actions": [
             {
-              "type": "origins:add_velocity",
+              "type": "apoli:add_velocity",
               "z": -0.3,
               "space": "local_horizontal_normalized"
             },
             {
-              "type": "origins:play_sound",
+              "type": "apoli:play_sound",
               "sound": "minecraft:entity.goat.ram_impact",
               "volume": 0.5,
               "pitch": 1.2
             },
             {
-              "type": "origins:play_sound",
+              "type": "apoli:play_sound",
               "sound": "minecraft:entity.player.attack.sweep",
               "volume": 0.5,
               "pitch": 1.0
             },
             {
-              "type": "origins:spawn_particles",
+              "type": "apoli:spawn_particles",
               "particle": "minecraft:sweep_attack",
               "count": 3,
               "speed": 0.0,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_3_sneaking_step_height.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_3_sneaking_step_height.json
@@ -3,6 +3,6 @@
     "step_height_scale": 2.0,
     "affect_sneak": false,
     "condition": {
-        "type": "origins:sneaking"
+        "type": "apoli:sneaking"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_collar_of_tension_trinket.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_collar_of_tension_trinket.json
@@ -1,13 +1,13 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
 
   "bare_paw_attack": {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "condition": {
-      "type": "origins:or",
+      "type": "apoli:or",
       "conditions": [
         {
-          "type": "origins:inventory",
+          "type": "apoli:inventory",
           "process_mode": "items",
           "item_condition": {
             "type": "shape-shifter-curse:is_weapon"
@@ -18,7 +18,7 @@
           "inverted": true
         },
         {
-          "type": "origins:inventory",
+          "type": "apoli:inventory",
           "process_mode": "items",
           "comparison": "==",
           "compare_to": 0,
@@ -40,19 +40,19 @@
   "sneaking_jump_clash": {
     "type": "shape-shifter-curse:sneaking_jump_clash",
     "bientity_action": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "actions": [
         {
-          "type": "origins:add_velocity",
+          "type": "apoli:add_velocity",
           "z": 2.0
         },
         {
-          "type": "origins:target_action",
+          "type": "apoli:target_action",
           "action": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "actions": [
               {
-                "type": "origins:spawn_particles",
+                "type": "apoli:spawn_particles",
                 "particle": "minecraft:crit",
                 "count": 8,
                 "speed": 0.0,
@@ -67,29 +67,29 @@
           }
         },
         {
-          "type": "origins:actor_action",
+          "type": "apoli:actor_action",
           "action": {
-            "type": "origins:and",
+            "type": "apoli:and",
             "actions": [
               {
-                "type": "origins:add_velocity",
+                "type": "apoli:add_velocity",
                 "z": -0.3,
                 "space": "local_horizontal_normalized"
               },
               {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.goat.ram_impact",
                 "volume": 0.5,
                 "pitch": 1.2
               },
               {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.player.attack.sweep",
                 "volume": 0.5,
                 "pitch": 1.0
               },
               {
-                "type": "origins:spawn_particles",
+                "type": "apoli:spawn_particles",
                 "particle": "minecraft:sweep_attack",
                 "count": 3,
                 "speed": 0.0,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_collar_of_whiskers_trinket.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_collar_of_whiskers_trinket.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
 
   "dodge_arrow_plus": {
     "type": "shape-shifter-curse:projectile_dodge",
@@ -8,17 +8,17 @@
     "dodge_speed": 2,
     "cooldown": 20,
     "entity_condition": {
-      "type": "origins:on_block"
+      "type": "apoli:on_block"
     },
     "action": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "actions": [
         {
-          "type": "origins:play_sound",
+          "type": "apoli:play_sound",
           "sound": "minecraft:entity.goat.long_jump"
         },
         {
-          "type": "origins:apply_effect",
+          "type": "apoli:apply_effect",
           "effect": {
             "effect": "minecraft:regeneration",
             "duration": 102,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_digestion_fiber_ball_trinket.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_digestion_fiber_ball_trinket.json
@@ -1,8 +1,8 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
 
   "can_eat_non_raw_meat_food": {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifier": {
       "operation": "multiply_base_multiplicative",
       "value": -0.3
@@ -12,19 +12,19 @@
       "value": -0.3
     },
     "item_condition": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:or",
+          "type": "apoli:or",
           "conditions": [
             {
-              "type": "origins:ingredient",
+              "type": "apoli:ingredient",
               "ingredient": {
-                "tag": "origins:raw_meat"
+                "tag": "shape-shifter-curse:raw_meat"
               }
             },
             {
-              "type": "origins:ingredient",
+              "type": "apoli:ingredient",
               "ingredient": {
                 "item": "minecraft:rotten_flesh"
               }
@@ -33,17 +33,17 @@
           "inverted": true
         },
         {
-          "type": "origins:food"
+          "type": "apoli:food"
         },
         {
-          "type": "origins:ingredient",
+          "type": "apoli:ingredient",
           "ingredient": {
-            "tag": "origins:ignore_diet"
+            "tag": "shape-shifter-curse:ignore_diet"
           },
           "inverted": true
         },
         {
-          "type": "origins:ingredient",
+          "type": "apoli:ingredient",
           "ingredient": {
             "tag": "shape-shifter-curse:ignore_vc_eat"
           },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_hiss_phantom.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_hiss_phantom.json
@@ -1,9 +1,9 @@
 {
     "type": "shape-shifter-curse:hiss_phantom_power",
     "on_hiss_phantom_action": {
-        "type": "origins:actor_action",
+        "type": "apoli:actor_action",
         "action": {
-            "type": "origins:play_sound",
+            "type": "apoli:play_sound",
             "sound": "minecraft:entity.cat.hiss"
         }
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_instinct_attack_barepaw.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_instinct_attack_barepaw.json
@@ -1,15 +1,15 @@
 {
-    "type": "origins:action_on_hit",
+    "type": "apoli:action_on_hit",
     "bientity_condition": {
-        "type": "origins:actor_condition",
+        "type": "apoli:actor_condition",
         "condition": {
-            "type": "origins:or",
+            "type": "apoli:or",
             "conditions": [
                 {
-                    "type": "origins:inventory",
+                    "type": "apoli:inventory",
                     "process_mode": "items",
                     "item_condition": {
-                        "type": "origins:harvest_level",
+                        "type": "apoli:harvest_level",
                         "comparison": "<=",
                         "compare_to": 1
                     },
@@ -18,7 +18,7 @@
                     ]
                 },
                 {
-                    "type": "origins:inventory",
+                    "type": "apoli:inventory",
                     "process_mode": "items",
                     "comparison": "==",
                     "compare_to": 0,
@@ -30,7 +30,7 @@
         }
     },
     "bientity_action": {
-        "type": "origins:actor_action",
+        "type": "apoli:actor_action",
         "action": {
             "type": "shape-shifter-curse:add_instinct",
             "instinct_effect_id": "shape-shifter-curse:form_ocelot_attack_livestock",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_instinct_attack_livestock.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_instinct_attack_livestock.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:self_action_on_hit",
+    "type": "apoli:self_action_on_hit",
     "entity_action": {
         "type": "shape-shifter-curse:add_instinct",
         "instinct_effect_id": "shape-shifter-curse:form_ocelot_attack_livestock",
@@ -7,7 +7,7 @@
         "duration": 0
     },
     "target_condition": {
-        "type": "origins:in_tag",
-        "tag": "origins:livestock"
+        "type": "apoli:in_tag",
+        "tag": "shape-shifter-curse:livestock"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_instinct_biome.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_instinct_biome.json
@@ -4,9 +4,9 @@
     "value": 0.003,
     "duration": 1,
     "condition": {
-        "type": "origins:biome",
+        "type": "apoli:biome",
         "condition": {
-            "type": "origins:in_tag",
+            "type": "apoli:in_tag",
             "tag": "minecraft:is_jungle"
         }
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_instinct_eat_raw_meat.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_instinct_eat_raw_meat.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:action_on_item_use",
+    "type": "apoli:action_on_item_use",
     "entity_action": {
         "type": "shape-shifter-curse:add_instinct",
         "instinct_effect_id": "shape-shifter-curse:form_ocelot_eat_raw_meat",
@@ -7,9 +7,9 @@
         "duration": 20
     },
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-            "tag": "origins:raw_meat"
+            "tag": "shape-shifter-curse:raw_meat"
         }
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_instinct_on_leaf.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_instinct_on_leaf.json
@@ -4,10 +4,10 @@
     "value": 0.008,
     "duration": 1,
     "condition": {
-        "type": "origins:on_block",
+        "type": "apoli:on_block",
         "block_condition": {
-            "type": "origins:in_tag",
-            "tag": "origins:leaves"
+            "type": "apoli:in_tag",
+            "tag": "shape-shifter-curse:leaves"
         }
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_sound.json
@@ -1,14 +1,14 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.cat.ambient",
         "pitch": 0.5,
         "volume": 0.7
     },
     "interval": 200,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:enable_random_sound"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_sound_hurt.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_sound_hurt.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:self_action_when_hit",
+    "type": "apoli:self_action_when_hit",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.cat.hurt",
         "pitch": 0.5,
         "volume": 0.7

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_sound_key.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_sound_key.json
@@ -1,9 +1,9 @@
 {
-    "type": "origins:multiple",
+    "type": "apoli:multiple",
     "form_ocelot_sound_key_normal": {
-        "type": "origins:active_self",
+        "type": "apoli:active_self",
         "entity_action": {
-            "type": "origins:play_sound",
+            "type": "apoli:play_sound",
             "sound": "minecraft:entity.cat.ambient",
             "pitch": 0.5,
             "volume": 0.7
@@ -17,14 +17,14 @@
             "continuous": false
         },
         "condition": {
-            "type": "origins:sneaking",
+            "type": "apoli:sneaking",
             "inverted": true
         }
     },
     "form_ocelot_sound_key_hiss": {
-        "type": "origins:active_self",
+        "type": "apoli:active_self",
         "entity_action": {
-            "type": "origins:play_sound",
+            "type": "apoli:play_sound",
             "sound": "minecraft:entity.cat.hiss"
         },
         "cooldown": 5,
@@ -36,7 +36,7 @@
             "continuous": false
         },
         "condition": {
-            "type": "origins:sneaking"
+            "type": "apoli:sneaking"
         }
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_raw_fish_food_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_raw_fish_food_up.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifiers": [
         {
             "name": "increase food points",
@@ -25,9 +25,9 @@
         }
     ],
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-            "tag": "origins:raw_fish"
+            "tag": "shape-shifter-curse:raw_fish"
         }
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_raw_meat_food_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_raw_meat_food_up.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifiers": [
         {
             "name": "increase food points",
@@ -25,9 +25,9 @@
         }
     ],
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-            "tag": "origins:raw_meat"
+            "tag": "shape-shifter-curse:raw_meat"
         }
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_0_desert_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_0_desert_health.json
@@ -9,29 +9,29 @@
     "updateHealth": true,
     "delay": 5,
     "condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:and",
+                "type": "apoli:and",
                 "conditions": [
                     {
-                        "type": "origins:biome",
+                        "type": "apoli:biome",
                         "condition": {
-                            "type": "origins:temperature",
+                            "type": "apoli:temperature",
                             "comparison": ">=",
                             "compare_to": 1
                         }
                     },
                     {
-                        "type": "origins:and",
+                        "type": "apoli:and",
                         "conditions": [
                             {
-                                "type": "origins:time_of_day",
+                                "type": "apoli:time_of_day",
                                 "comparison": ">=",
                                 "compare_to": 1000
                             },
                             {
-                                "type": "origins:time_of_day",
+                                "type": "apoli:time_of_day",
                                 "comparison": "<=",
                                 "compare_to": 12000
                             }
@@ -40,9 +40,9 @@
                 ]
             },
             {
-                "type": "origins:biome",
+                "type": "apoli:biome",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "minecraft:is_nether"
                 }
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_0_triple_jump.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_0_triple_jump.json
@@ -4,28 +4,28 @@
     "second_jump_multiplier": 1.25,
     "third_jump_multiplier": 1.25,
     "first_jump_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 5"
             }
         ]
     },
     "second_jump_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 5"
             }
         ]
     },
     "third_jump_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 5"
             }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_1_charm_of_reverse_thermometer_trinket.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_1_charm_of_reverse_thermometer_trinket.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
   "reverse_hot_cold": {
     "type": "shape-shifter-curse:delay_attribute",
     "modifier": {
@@ -11,9 +11,9 @@
     "updateHealth": true,
     "delay": 5,
     "condition": {
-      "type": "origins:biome",
+      "type": "apoli:biome",
       "condition": {
-        "type": "origins:temperature",
+        "type": "apoli:temperature",
         "comparison": "<=",
         "compare_to": 0
       }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_1_desert_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_1_desert_health.json
@@ -9,29 +9,29 @@
     "updateHealth": true,
     "delay": 5,
     "condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:and",
+                "type": "apoli:and",
                 "conditions": [
                     {
-                        "type": "origins:biome",
+                        "type": "apoli:biome",
                         "condition": {
-                            "type": "origins:temperature",
+                            "type": "apoli:temperature",
                             "comparison": ">=",
                             "compare_to": 1
                         }
                     },
                     {
-                        "type": "origins:and",
+                        "type": "apoli:and",
                         "conditions": [
                             {
-                                "type": "origins:time_of_day",
+                                "type": "apoli:time_of_day",
                                 "comparison": ">=",
                                 "compare_to": 1000
                             },
                             {
-                                "type": "origins:time_of_day",
+                                "type": "apoli:time_of_day",
                                 "comparison": "<=",
                                 "compare_to": 12000
                             }
@@ -40,9 +40,9 @@
                 ]
             },
             {
-                "type": "origins:biome",
+                "type": "apoli:biome",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "minecraft:is_nether"
                 }
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_1_triple_jump.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_1_triple_jump.json
@@ -4,40 +4,40 @@
     "second_jump_multiplier": 1.4,
     "third_jump_multiplier": 1.4,
     "first_jump_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 5"
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.goat.long_jump"
             }
         ]
     },
     "second_jump_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 5"
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.goat.long_jump"
             }
         ]
     },
     "third_jump_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 5"
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.goat.long_jump"
             }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_2_charm_of_reverse_thermometer_trinket.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_2_charm_of_reverse_thermometer_trinket.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
   "reverse_hot_cold": {
     "type": "shape-shifter-curse:delay_attribute",
     "modifier": {
@@ -11,9 +11,9 @@
     "updateHealth": true,
     "delay": 5,
     "condition": {
-      "type": "origins:biome",
+      "type": "apoli:biome",
       "condition": {
-        "type": "origins:temperature",
+        "type": "apoli:temperature",
         "comparison": "<=",
         "compare_to": 0
       }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_2_desert_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_2_desert_health.json
@@ -9,29 +9,29 @@
     "updateHealth": true,
     "delay": 5,
     "condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:and",
+                "type": "apoli:and",
                 "conditions": [
                     {
-                        "type": "origins:biome",
+                        "type": "apoli:biome",
                         "condition": {
-                            "type": "origins:temperature",
+                            "type": "apoli:temperature",
                             "comparison": ">=",
                             "compare_to": 1
                         }
                     },
                     {
-                        "type": "origins:and",
+                        "type": "apoli:and",
                         "conditions": [
                             {
-                                "type": "origins:time_of_day",
+                                "type": "apoli:time_of_day",
                                 "comparison": ">=",
                                 "compare_to": 1000
                             },
                             {
-                                "type": "origins:time_of_day",
+                                "type": "apoli:time_of_day",
                                 "comparison": "<=",
                                 "compare_to": 12000
                             }
@@ -40,9 +40,9 @@
                 ]
             },
             {
-                "type": "origins:biome",
+                "type": "apoli:biome",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "minecraft:is_nether"
                 }
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_2_plain_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_2_plain_health.json
@@ -9,23 +9,23 @@
     "updateHealth": true,
     "delay": 5,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:and",
+                "type": "apoli:and",
                 "conditions": [
                     {
-                        "type": "origins:biome",
+                        "type": "apoli:biome",
                         "condition": {
-                            "type": "origins:temperature",
+                            "type": "apoli:temperature",
                             "comparison": "<",
                             "compare_to": 1
                         }
                     },
                     {
-                        "type": "origins:biome",
+                        "type": "apoli:biome",
                         "condition": {
-                            "type": "origins:temperature",
+                            "type": "apoli:temperature",
                             "comparison": ">",
                             "compare_to": 0.7
                         }
@@ -33,15 +33,15 @@
                 ]
             },
             {
-                "type": "origins:and",
+                "type": "apoli:and",
                 "conditions": [
                     {
-                        "type": "origins:time_of_day",
+                        "type": "apoli:time_of_day",
                         "comparison": ">=",
                         "compare_to": 1000
                     },
                     {
-                        "type": "origins:time_of_day",
+                        "type": "apoli:time_of_day",
                         "comparison": "<=",
                         "compare_to": 12000
                     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_2_snowball_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_2_snowball_up.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:modify_projectile_damage",
+  "type": "apoli:modify_projectile_damage",
   "damage_condition": {
-    "type": "origins:projectile",
+    "type": "apoli:projectile",
     "projectile": "minecraft:snowball"
   },
   "modifier": {
@@ -9,11 +9,11 @@
     "value": 5
   },
   "target_action": {
-    "type": "origins:execute_command",
+    "type": "apoli:execute_command",
     "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 10"
   },
   "self_action": {
-    "type": "origins:play_sound",
+    "type": "apoli:play_sound",
     "sound": "minecraft:entity.firework_rocket.blast_far"
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_2_triple_jump.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_2_triple_jump.json
@@ -4,65 +4,65 @@
   "second_jump_multiplier": 1.5,
   "third_jump_multiplier": 1.65,
   "first_jump_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 5"
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.bass",
         "pitch": 1
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.goat.long_jump"
       }
     ]
   },
   "second_jump_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:add_velocity",
+        "type": "apoli:add_velocity",
         "y": 1.3,
         "space": "world"
       },
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 5"
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.bass",
         "pitch": 1.19
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.goat.long_jump"
       }
     ]
   },
   "third_jump_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:add_velocity",
+        "type": "apoli:add_velocity",
         "y": 1.3,
         "space": "world"
       },
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 5"
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.bass",
         "pitch": 1.414
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.goat.long_jump"
       }
     ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_air_speed.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_air_speed.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_air_speed",
+    "type": "apoli:modify_air_speed",
     "modifier": {
         "operation": "multiply_total",
         "value": 1.25

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_charm_of_reverse_thermometer_trinket.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_charm_of_reverse_thermometer_trinket.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
   "reverse_hot_cold": {
     "type": "shape-shifter-curse:delay_attribute",
     "modifier": {
@@ -11,9 +11,9 @@
     "updateHealth": true,
     "delay": 5,
     "condition": {
-      "type": "origins:biome",
+      "type": "apoli:biome",
       "condition": {
-        "type": "origins:temperature",
+        "type": "apoli:temperature",
         "comparison": "<=",
         "compare_to": 0
       }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_desert_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_desert_health.json
@@ -9,29 +9,29 @@
     "updateHealth": true,
     "delay": 5,
     "condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:and",
+                "type": "apoli:and",
                 "conditions": [
                     {
-                        "type": "origins:biome",
+                        "type": "apoli:biome",
                         "condition": {
-                            "type": "origins:temperature",
+                            "type": "apoli:temperature",
                             "comparison": ">=",
                             "compare_to": 1
                         }
                     },
                     {
-                        "type": "origins:and",
+                        "type": "apoli:and",
                         "conditions": [
                             {
-                                "type": "origins:time_of_day",
+                                "type": "apoli:time_of_day",
                                 "comparison": ">=",
                                 "compare_to": 1000
                             },
                             {
-                                "type": "origins:time_of_day",
+                                "type": "apoli:time_of_day",
                                 "comparison": "<=",
                                 "compare_to": 12000
                             }
@@ -40,9 +40,9 @@
                 ]
             },
             {
-                "type": "origins:biome",
+                "type": "apoli:biome",
                 "condition": {
-                    "type": "origins:in_tag",
+                    "type": "apoli:in_tag",
                     "tag": "minecraft:is_nether"
                 }
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_fall_speed.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_fall_speed.json
@@ -1,4 +1,4 @@
 {
-    "type": "origins:modify_falling",
+    "type": "apoli:modify_falling",
     "velocity": 0.06
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_falling_bouncing.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_falling_bouncing.json
@@ -1,47 +1,47 @@
 {
-    "type": "origins:action_on_block_use",
+    "type": "apoli:action_on_block_use",
     "directions": [
         "up"
     ],
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:resource",
+                "type": "apoli:resource",
                 "resource": "shape-shifter-curse:form_snow_fox_bounce_cooldown",
                 "comparison": "<",
                 "compare_to": 1
             },
             {
-                "type": "origins:fall_distance",
+                "type": "apoli:fall_distance",
                 "comparison": ">=",
                 "compare_to": 0.5
             },
             {
-                "type": "origins:fall_flying",
+                "type": "apoli:fall_flying",
                 "inverted": true
             }
         ]
     },
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:add_velocity",
+                "type": "apoli:add_velocity",
                 "y": 0.65,
                 "space": "world",
                 "set": true
             },
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "particle cloud ~ ~ ~ 0.3 0.3 0.3 0.01 16 normal @a"
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.goat.long_jump"
             },
             {
-                "type": "origins:trigger_cooldown",
+                "type": "apoli:trigger_cooldown",
                 "power": "shape-shifter-curse:form_snow_fox_bounce_cooldown"
             }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_keep_burn.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_keep_burn.json
@@ -1,11 +1,11 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:set_on_fire",
+        "type": "apoli:set_on_fire",
         "duration": 4
     },
     "interval": 20,
     "condition": {
-        "type": "origins:on_fire"
+        "type": "apoli:on_fire"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_near_fire_damage.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_near_fire_damage.json
@@ -1,28 +1,28 @@
 {
-    "type": "origins:damage_over_time",
+    "type": "apoli:damage_over_time",
     "interval": 60,
     "onset_delay": 60,
     "damage": 1,
     "damage_easy": 1,
     "damage_type": "minecraft:on_fire",
     "condition": {
-        "type": "origins:block_in_radius",
+        "type": "apoli:block_in_radius",
         "block_condition": {
-            "type": "origins:or",
+            "type": "apoli:or",
             "conditions": [
                 {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:fire"
                 },
                 {
-                    "type": "origins:and",
+                    "type": "apoli:and",
                     "conditions": [
                         {
-                            "type": "origins:block",
+                            "type": "apoli:block",
                             "block": "minecraft:campfire"
                         },
                         {
-                            "type": "origins:block_state",
+                            "type": "apoli:block_state",
                             "property": "lit",
                             "value": "true"
                         }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_near_lava_damage.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_near_lava_damage.json
@@ -1,17 +1,17 @@
 {
-    "type": "origins:damage_over_time",
+    "type": "apoli:damage_over_time",
     "interval": 60,
     "onset_delay": 60,
     "damage": 1,
     "damage_easy": 1,
     "damage_type": "minecraft:on_fire",
     "condition": {
-        "type": "origins:block_in_radius",
+        "type": "apoli:block_in_radius",
         "block_condition": {
-            "type": "origins:or",
+            "type": "apoli:or",
             "conditions": [
                 {
-                    "type": "origins:block",
+                    "type": "apoli:block",
                     "block": "minecraft:lava"
                 }
             ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_particle.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_particle.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:particle",
+    "type": "apoli:particle",
     "particle": "minecraft:white_ash",
     "frequency": 10,
     "visible_while_invisible": true,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_plain_health.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_plain_health.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.max_health",
         "value": -4.0,
@@ -7,23 +7,23 @@
     },
     "tick_rate": 20,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:and",
+                "type": "apoli:and",
                 "conditions": [
                     {
-                        "type": "origins:biome",
+                        "type": "apoli:biome",
                         "condition": {
-                            "type": "origins:temperature",
+                            "type": "apoli:temperature",
                             "comparison": "<",
                             "compare_to": 1
                         }
                     },
                     {
-                        "type": "origins:biome",
+                        "type": "apoli:biome",
                         "condition": {
-                            "type": "origins:temperature",
+                            "type": "apoli:temperature",
                             "comparison": ">",
                             "compare_to": 0.7
                         }
@@ -31,15 +31,15 @@
                 ]
             },
             {
-                "type": "origins:and",
+                "type": "apoli:and",
                 "conditions": [
                     {
-                        "type": "origins:time_of_day",
+                        "type": "apoli:time_of_day",
                         "comparison": ">=",
                         "compare_to": 1000
                     },
                     {
-                        "type": "origins:time_of_day",
+                        "type": "apoli:time_of_day",
                         "comparison": "<=",
                         "compare_to": 12000
                     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_snowball_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_snowball_up.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:modify_projectile_damage",
+    "type": "apoli:modify_projectile_damage",
     "damage_condition": {
-        "type": "origins:projectile",
+        "type": "apoli:projectile",
         "projectile": "minecraft:snowball"
     },
     "modifier": {
@@ -9,11 +9,11 @@
         "value": 7.5
     },
     "target_action": {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 10"
     },
     "self_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.firework_rocket.blast_far"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_sweet_berry_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_sweet_berry_up.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifier": {
         "name": "increase food points",
         "operation": "addition",
@@ -11,7 +11,7 @@
         "value": 0.5
     },
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:sweet_berries"
         }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_triple_jump.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_triple_jump.json
@@ -4,65 +4,65 @@
     "second_jump_multiplier": 1.6,
     "third_jump_multiplier": 2.0,
     "first_jump_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 5"
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:block.note_block.bass",
                 "pitch": 1.0
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.goat.long_jump"
             }
         ]
     },
     "second_jump_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:add_velocity",
+                "type": "apoli:add_velocity",
                 "y": 1.3,
                 "space": "world"
             },
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 5"
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:block.note_block.bass",
                 "pitch": 1.19
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.goat.long_jump"
             }
         ]
     },
     "third_jump_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:add_velocity",
+                "type": "apoli:add_velocity",
                 "y": 1.3,
                 "space": "world"
             },
             {
-                "type": "origins:execute_command",
+                "type": "apoli:execute_command",
                 "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 5"
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:block.note_block.bass",
                 "pitch": 1.414
             },
             {
-                "type": "origins:play_sound",
+                "type": "apoli:play_sound",
                 "sound": "minecraft:entity.goat.long_jump"
             }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_water_bottle_put_out_fire.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_3_water_bottle_put_out_fire.json
@@ -1,13 +1,13 @@
 {
-    "type": "origins:action_on_item_use",
+    "type": "apoli:action_on_item_use",
     "hidden": true,
     "item_condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
             "item": "minecraft:potion"
         }
     },
     "entity_action": {
-        "type": "origins:extinguish"
+        "type": "apoli:extinguish"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_bottled_snowfall_cooldown.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_bottled_snowfall_cooldown.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:cooldown",
+    "type": "apoli:cooldown",
     "cooldown": 8,
     "hud_render": {
         "should_render": false

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_bottled_snowfall_tool.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_bottled_snowfall_tool.json
@@ -1,18 +1,18 @@
 {
-  "type": "origins:action_on_item_use",
+  "type": "apoli:action_on_item_use",
   "entity_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:fire_projectile",
+        "type": "apoli:fire_projectile",
         "entity_type": "minecraft:snowball",
         "divergence": 0,
         "count": 1,
         "projectile_action": {
-          "type": "origins:and",
+          "type": "apoli:and",
           "actions": [
             {
-              "type": "origins:spawn_particles",
+              "type": "apoli:spawn_particles",
               "particle": {
                 "type": "minecraft:cloud"
               },
@@ -29,47 +29,47 @@
         }
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.snowball.throw"
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.amethyst_block.fall"
       },
       {
-        "type": "origins:exhaust",
+        "type": "apoli:exhaust",
         "amount": 2
       },
       {
-        "type": "origins:trigger_cooldown",
+        "type": "apoli:trigger_cooldown",
         "power": "shape-shifter-curse:form_snow_fox_bottled_snowfall_cooldown"
       }
     ]
   },
   "condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:resource",
+        "type": "apoli:resource",
         "resource": "shape-shifter-curse:form_snow_fox_bottled_snowfall_cooldown",
         "comparison": "<",
         "compare_to": 1
       },
       {
-        "type": "origins:food_level",
+        "type": "apoli:food_level",
         "comparison": ">",
         "compare_to": 0
       }
     ]
   },
   "item_condition": {
-    "type": "origins:ingredient",
+    "type": "apoli:ingredient",
     "ingredient": {
       "item": "shape-shifter-curse:bottled_snowfall"
     }
   },
   "item_action": {
-    "type": "origins:damage",
+    "type": "apoli:damage",
     "amount": 1,
     "ignore_unbreaking": false
   },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_bounce_cooldown.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_bounce_cooldown.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:cooldown",
+    "type": "apoli:cooldown",
     "cooldown": 10,
     "hud_render": {
         "should_render": false

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_frost_pawglove_trinket.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_frost_pawglove_trinket.json
@@ -1,10 +1,10 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
 
   "snow_ball_damage_down": {
-    "type": "origins:modify_projectile_damage",
+    "type": "apoli:modify_projectile_damage",
     "damage_condition": {
-      "type": "origins:projectile",
+      "type": "apoli:projectile",
       "projectile": "minecraft:snowball"
     },
     "modifier": {
@@ -12,37 +12,37 @@
       "value": 3.0
     },
     "target_action": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "actions": [
         {
-          "type": "origins:execute_command",
+          "type": "apoli:execute_command",
           "command": "particle minecraft:crit ~ ~0.5 ~ 0.2 0.2 0.2 0 10"
         }
       ]
     },
     "self_action": {
-      "type": "origins:play_sound",
+      "type": "apoli:play_sound",
       "sound": "minecraft:entity.firework_rocket.blast_far"
     }
   },
 
   "snow_ball_effect": {
-    "type": "origins:modify_projectile_damage",
+    "type": "apoli:modify_projectile_damage",
     "damage_condition": {
-      "type": "origins:projectile",
+      "type": "apoli:projectile",
       "projectile": "minecraft:snowball"
     },
     "condition": {
-      "type": "origins:resource",
+      "type": "apoli:resource",
       "resource": "shape-shifter-curse:form_snow_fox_snowball_effect_cooldown",
       "comparison": "<",
       "compare_to": 1
     },
     "target_action": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "actions": [
         {
-          "type": "origins:spawn_effect_cloud",
+          "type": "apoli:spawn_effect_cloud",
           "radius": 3.0,
           "radius_on_use": -1.0,
           "wait_time": 10,
@@ -55,13 +55,13 @@
       ]
     },
     "self_action": {
-      "type": "origins:trigger_cooldown",
+      "type": "apoli:trigger_cooldown",
       "power": "shape-shifter-curse:form_snow_fox_snowball_effect_cooldown"
     }
   },
 
   "no_slowness": {
-    "type": "origins:effect_immunity",
+    "type": "apoli:effect_immunity",
     "effects": [
       "minecraft:slowness"
     ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_instinct_sprint_jump.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_instinct_sprint_jump.json
@@ -4,20 +4,20 @@
     "value": 0.008,
     "duration": 1,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0
             },
             {
-                "type": "origins:on_block",
+                "type": "apoli:on_block",
                 "inverted": true
             },
             {
-                "type": "origins:sprinting"
+                "type": "apoli:sprinting"
             }
         ]
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_snowball_effect_cooldown.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_snow_fox_snowball_effect_cooldown.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:cooldown",
+    "type": "apoli:cooldown",
     "cooldown": 10,
     "hud_render": {
         "should_render": false

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_0_dew_covered_cobweb_instinct.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_0_dew_covered_cobweb_instinct.json
@@ -4,9 +4,9 @@
     "value": 0.16,
     "duration": 1,
     "condition": {
-      "type": "origins:block_in_radius",
+      "type": "apoli:block_in_radius",
       "block_condition": {
-        "type": "origins:block",
+        "type": "apoli:block",
         "block": "shape-shifter-curse:dew_covered_cobweb"
       },
       "radius": 1,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_0_dew_covered_cobweb_particle.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_0_dew_covered_cobweb_particle.json
@@ -1,10 +1,10 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:spawn_particles",
+                "type": "apoli:spawn_particles",
                 "particle": "minecraft:poof",
                 "count": 1,
                 "speed": 0.0,
@@ -20,9 +20,9 @@
     },
     "interval": 4,
   "condition": {
-    "type": "origins:block_in_radius",
+    "type": "apoli:block_in_radius",
     "block_condition": {
-      "type": "origins:block",
+      "type": "apoli:block",
       "block": "shape-shifter-curse:dew_covered_cobweb"
     },
     "radius": 1,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_0_instinct_max_particle.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_0_instinct_max_particle.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
               "type": "shape-shifter-curse:spawn_particles_in_circle",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_0_vegetarian_saturation_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_0_vegetarian_saturation_down.json
@@ -1,33 +1,33 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "saturation_modifier": {
         "name": "Decreased saturation points",
         "operation": "multiply_base_multiplicative",
         "value": -0.2
     },
     "item_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:meat"
+                    "tag": "shape-shifter-curse:meat"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:meat",
+                "type": "apoli:meat",
                 "inverted": true
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:ignore_diet"
+                    "tag": "shape-shifter-curse:ignore_diet"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
                     "tag": "shape-shifter-curse:ignore_vc_eat"
                 },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_0_web_projectile.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_0_web_projectile.json
@@ -8,10 +8,10 @@
   "tier0_enable": true,
   "tier0_charge_time": 0,
   "tier0_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -30,7 +30,7 @@
     "mana": 6
   },
   "tier1_use_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
         "type": "shape-shifter-curse:fire_web_bullet",
@@ -43,10 +43,10 @@
     ]
   },
   "tier1_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -62,20 +62,20 @@
     "mana": 0.25
   },
   "tier1_charge_complete_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.hat",
         "pitch": 1.0
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.snare",
         "pitch": 1.0
       },
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:cloud ~ ~1.0 ~ 0.8 0.8 0.8 0 10"
       }
     ]
@@ -89,7 +89,7 @@
   },
 
   "tier2_use_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
         "type": "shape-shifter-curse:fire_web_bullet",
@@ -102,10 +102,10 @@
     ]
   },
   "tier2_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -121,20 +121,20 @@
     "mana": 0.25
   },
   "tier2_charge_complete_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.hat",
         "pitch": 1.19
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.snare",
         "pitch": 1.19
       },
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:cloud ~ ~1.0 ~ 0.8 0.8 0.8 0 10"
       }
     ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_1_cocoon_instinct.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_1_cocoon_instinct.json
@@ -4,12 +4,12 @@
     "value": 0.08,
     "duration": 1,
     "condition": {
-      "type": "origins:block_in_radius",
+      "type": "apoli:block_in_radius",
       "block_condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
           {
-            "type": "origins:block",
+            "type": "apoli:block",
             "block": "shape-shifter-curse:dew_covered_cobweb"
           }
         ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_1_darkness.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_1_darkness.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:action_over_time",
+  "type": "apoli:action_over_time",
   "entity_action": {
-    "type": "origins:apply_effect",
+    "type": "apoli:apply_effect",
     "effect": {
       "effect": "minecraft:darkness",
       "duration": 100,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_1_in_cocoon_features.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_1_in_cocoon_features.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
   "health_down": {
-    "type": "origins:attribute",
+    "type": "apoli:attribute",
     "modifier": {
       "attribute": "minecraft:generic.max_health",
       "value": -12.0,
@@ -10,7 +10,7 @@
   },
 
   "armor_value_up": {
-    "type": "origins:attribute",
+    "type": "apoli:attribute",
     "modifier": {
       "attribute": "minecraft:generic.armor",
       "value": 20.0,
@@ -19,24 +19,24 @@
   },
 
   "no_armors": {
-    "type": "origins:restrict_armor",
+    "type": "apoli:restrict_armor",
     "head": {
-      "type": "origins:armor_value",
+      "type": "apoli:armor_value",
       "comparison": ">",
       "compare_to": -1
     },
     "chest": {
-      "type": "origins:armor_value",
+      "type": "apoli:armor_value",
       "comparison": ">",
       "compare_to": -1
     },
     "legs": {
-      "type": "origins:armor_value",
+      "type": "apoli:armor_value",
       "comparison": ">",
       "compare_to": -1
     },
     "feet": {
-      "type": "origins:armor_value",
+      "type": "apoli:armor_value",
       "comparison": ">",
       "compare_to": -1
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_1_instinct_max_particle.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_1_instinct_max_particle.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
               "type": "shape-shifter-curse:spawn_particles_in_circle",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_1_jump_height.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_1_jump_height.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:modify_jump",
+  "type": "apoli:modify_jump",
   "modifier": {
     "operation": "multiply_base_multiplicative",
     "value": -0.75

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_1_particle.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_1_particle.json
@@ -1,10 +1,10 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "actions": [
             {
-                "type": "origins:spawn_particles",
+                "type": "apoli:spawn_particles",
                 "particle": "minecraft:enchant",
                 "count": 1,
                 "speed": 0.0,

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_1_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_1_speed_down.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:attribute",
+  "type": "apoli:attribute",
   "modifier": {
     "attribute": "minecraft:generic.movement_speed",
     "operation": "multiply_total",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_2_meat_and_fluid_cocoon_only.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_2_meat_and_fluid_cocoon_only.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
   "restrict_food_type": {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifiers": [
       {
         "operation": "set_total",
@@ -15,25 +15,25 @@
       }
     ],
     "item_condition": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:or",
+          "type": "apoli:or",
           "conditions": [
             {
-              "type": "origins:ingredient",
+              "type": "apoli:ingredient",
               "ingredient": {
-                "tag": "origins:meat"
+                "tag": "shape-shifter-curse:meat"
               }
             },
             {
-              "type": "origins:ingredient",
+              "type": "apoli:ingredient",
               "ingredient": {
                 "item": "minecraft:rotten_flesh"
               }
             },
             {
-              "type": "origins:ingredient",
+              "type": "apoli:ingredient",
               "ingredient": {
                 "item": "shape-shifter-curse:spider_fluid_cocoon"
               }
@@ -42,17 +42,17 @@
           "inverted": true
         },
         {
-          "type": "origins:food"
+          "type": "apoli:food"
         },
         {
-          "type": "origins:ingredient",
+          "type": "apoli:ingredient",
           "ingredient": {
-            "tag": "origins:ignore_diet"
+            "tag": "shape-shifter-curse:ignore_diet"
           },
           "inverted": true
         },
         {
-          "type": "origins:ingredient",
+          "type": "apoli:ingredient",
           "ingredient": {
             "tag": "shape-shifter-curse:ignore_vc_eat"
           },
@@ -67,7 +67,7 @@
   },
 
   "meat_down": {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifiers": [
       {
         "operation": "multiply_base_multiplicative",
@@ -81,12 +81,12 @@
       }
     ],
     "item_condition": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:ingredient",
+          "type": "apoli:ingredient",
           "ingredient": {
-            "tag": "origins:meat"
+            "tag": "shape-shifter-curse:meat"
           }
         }
       ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_2_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_2_speed_down.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:conditioned_attribute",
+  "type": "apoli:conditioned_attribute",
   "modifier": {
     "attribute": "minecraft:generic.movement_speed",
     "operation": "multiply_base",
@@ -7,15 +7,15 @@
   },
   "tick_rate": 2,
   "condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:on_block"
+        "type": "apoli:on_block"
       },
       {
-        "type": "origins:in_block",
+        "type": "apoli:in_block",
         "block_condition": {
-          "type": "origins:block",
+          "type": "apoli:block",
           "block": "minecraft:water"
         },
         "inverted": true

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_2_web_projectile.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_2_web_projectile.json
@@ -8,10 +8,10 @@
   "tier0_enable": true,
   "tier0_charge_time": 0,
   "tier0_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -30,7 +30,7 @@
     "mana": 6
   },
   "tier1_use_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
         "type": "shape-shifter-curse:fire_web_bullet",
@@ -42,10 +42,10 @@
     ]
   },
   "tier1_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -61,20 +61,20 @@
     "mana": 0.25
   },
   "tier1_charge_complete_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.hat",
         "pitch": 1.0
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.snare",
         "pitch": 1.0
       },
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:cloud ~ ~1.0 ~ 0.8 0.8 0.8 0 10"
       }
     ]
@@ -88,7 +88,7 @@
   },
 
   "tier2_use_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
         "type": "shape-shifter-curse:fire_web_bullet",
@@ -100,10 +100,10 @@
     ]
   },
   "tier2_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -119,20 +119,20 @@
     "mana": 0.25
   },
   "tier2_charge_complete_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.hat",
         "pitch": 1.19
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.snare",
         "pitch": 1.19
       },
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:cloud ~ ~1.0 ~ 0.8 0.8 0.8 0 10"
       }
     ]
@@ -146,7 +146,7 @@
     "mana": 6
   },
   "tier3_use_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
         "type": "shape-shifter-curse:fire_web_bullet",
@@ -158,10 +158,10 @@
     ]
   },
   "tier3_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -177,20 +177,20 @@
     "mana": 0.25
   },
   "tier3_charge_complete_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.hat",
         "pitch": 1.414
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.snare",
         "pitch": 1.414
       },
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:cloud ~ ~1.0 ~ 0.8 0.8 0.8 0 10"
       }
     ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_auto_feed.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_auto_feed.json
@@ -1,15 +1,15 @@
 {
-  "type": "origins:action_over_time",
+  "type": "apoli:action_over_time",
   "entity_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:feed",
+        "type": "apoli:feed",
         "food": 7,
         "saturation": 0.8
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.generic.eat"
       },
       {
@@ -18,7 +18,7 @@
         "slot": "extra_hand",
         "slot_index": 0,
         "action": {
-          "type": "origins:consume",
+          "type": "apoli:consume",
           "amount": 1
         }
       }
@@ -26,10 +26,10 @@
   },
   "interval": 20,
   "condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:food_level",
+        "type": "apoli:food_level",
         "comparison": "<=",
         "compare_to": 13
       },
@@ -39,7 +39,7 @@
         "slot": "extra_hand",
         "slot_index": 0,
         "condition": {
-          "type": "origins:ingredient",
+          "type": "apoli:ingredient",
           "ingredient": {
             "item": "shape-shifter-curse:spider_fluid_cocoon"
           }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_climb.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_climb.json
@@ -1,21 +1,21 @@
 {
-    "type": "origins:climbing",
+    "type": "apoli:climbing",
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:collided_horizontally"
+                "type": "apoli:collided_horizontally"
             },
             {
-                "type": "origins:or",
+                "type": "apoli:or",
                 "conditions": [
                     {
-                        "type": "origins:block_collision",
+                        "type": "apoli:block_collision",
                         "offset_x": 0.1,
                         "offset_z": 0.1
                     },
                     {
-                        "type": "origins:block_collision",
+                        "type": "apoli:block_collision",
                         "offset_x": -0.1,
                         "offset_z": -0.1
                     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_extra_hand_auxiliary_tools.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_extra_hand_auxiliary_tools.json
@@ -1,8 +1,8 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
 
   "auxiliary_sword_attack_speed":{
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
       "attribute": "minecraft:generic.attack_speed",
       "operation": "addition",
@@ -16,7 +16,7 @@
       "slot": "extra_hand",
       "slot_index": 0,
       "condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "shape-shifter-curse:auxiliary_sword"
         }
@@ -25,15 +25,15 @@
   },
 
   "auxiliary_sword_tool_damage":{
-    "type": "origins:self_action_on_hit",
+    "type": "apoli:self_action_on_hit",
     "entity_action": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "actions": [
         {
-          "type": "origins:equipped_item_action",
+          "type": "apoli:equipped_item_action",
           "equipment_slot": "mainhand",
           "action": {
-            "type": "origins:damage",
+            "type": "apoli:damage",
             "amount": 2,
             "ignore_unbreaking": true
           }
@@ -44,7 +44,7 @@
           "slot": "extra_hand",
           "slot_index": 0,
           "action": {
-            "type": "origins:damage",
+            "type": "apoli:damage",
             "amount": 1,
             "ignore_unbreaking": true
           }
@@ -57,7 +57,7 @@
       "slot": "extra_hand",
       "slot_index": 0,
       "condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "shape-shifter-curse:auxiliary_sword"
         }
@@ -66,14 +66,14 @@
   },
 
   "auxiliary_axe_attack_damage":{
-    "type": "origins:modify_damage_dealt",
+    "type": "apoli:modify_damage_dealt",
     "modifier": {
       "name": "Increased attack damage",
       "operation": "addition",
       "value": 5.0
     },
     "damage_condition": {
-      "type": "origins:amount",
+      "type": "apoli:amount",
       "comparison": ">=",
       "compare_to": 4
     },
@@ -83,7 +83,7 @@
       "slot": "extra_hand",
       "slot_index": 0,
       "condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "shape-shifter-curse:auxiliary_axe"
         }
@@ -92,7 +92,7 @@
   },
 
   "auxiliary_axe_attack_speed":{
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
       "attribute": "minecraft:generic.attack_speed",
       "operation": "multiply_base",
@@ -106,7 +106,7 @@
       "slot": "extra_hand",
       "slot_index": 0,
       "condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "shape-shifter-curse:auxiliary_axe"
         }
@@ -115,9 +115,9 @@
   },
 
   "auxiliary_axe_tool_damage":{
-    "type": "origins:self_action_on_hit",
+    "type": "apoli:self_action_on_hit",
     "entity_action": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "actions": [
         {
           "type": "shape-shifter-curse:invoke_accessory",
@@ -125,7 +125,7 @@
           "slot": "extra_hand",
           "slot_index": 0,
           "action": {
-            "type": "origins:damage",
+            "type": "apoli:damage",
             "amount": 1,
             "ignore_unbreaking": true
           }
@@ -138,7 +138,7 @@
       "slot": "extra_hand",
       "slot_index": 0,
       "condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "shape-shifter-curse:auxiliary_axe"
         }
@@ -147,7 +147,7 @@
   },
 
   "auxiliary_pickaxe_attack_damage":{
-    "type": "origins:modify_damage_dealt",
+    "type": "apoli:modify_damage_dealt",
     "modifier": {
       "name": "Decreased attack damage",
       "operation": "addition",
@@ -159,7 +159,7 @@
       "slot": "extra_hand",
       "slot_index": 0,
       "condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "shape-shifter-curse:auxiliary_pickaxe"
         }
@@ -168,7 +168,7 @@
   },
 
   "auxiliary_pickaxe_mining_speed":{
-    "type": "origins:modify_break_speed",
+    "type": "apoli:modify_break_speed",
     "modifier": {
       "operation": "multiply_base",
       "value": 0.8
@@ -179,7 +179,7 @@
       "slot": "extra_hand",
       "slot_index": 0,
       "condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "shape-shifter-curse:auxiliary_pickaxe"
         }
@@ -188,9 +188,9 @@
   },
 
   "auxiliary_pickaxe_tool_damage":{
-    "type": "origins:self_action_on_hit",
+    "type": "apoli:self_action_on_hit",
     "entity_action": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "actions": [
         {
           "type": "shape-shifter-curse:invoke_accessory",
@@ -198,7 +198,7 @@
           "slot": "extra_hand",
           "slot_index": 0,
           "action": {
-            "type": "origins:damage",
+            "type": "apoli:damage",
             "amount": 1,
             "ignore_unbreaking": true
           }
@@ -211,7 +211,7 @@
       "slot": "extra_hand",
       "slot_index": 0,
       "condition": {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "shape-shifter-curse:auxiliary_pickaxe"
         }
@@ -222,7 +222,7 @@
   "extra_shield_blocking":{
     "type": "shape-shifter-curse:virtual_shield",
     "active_shield_condition": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
           "type": "shape-shifter-curse:is_item_in_cooldown",
@@ -235,7 +235,7 @@
           "slot": "extra_hand",
           "slot_index": 0,
           "condition": {
-            "type": "origins:ingredient",
+            "type": "apoli:ingredient",
             "ingredient": {
               "item": "minecraft:shield"
             }
@@ -244,7 +244,7 @@
       ]
     },
     "normal_damage_action": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "actions": [
         {
           "type": "shape-shifter-curse:set_item_cooldown",
@@ -257,7 +257,7 @@
           "slot": "extra_hand",
           "slot_index": 0,
           "action": {
-            "type": "origins:damage",
+            "type": "apoli:damage",
             "amount": 1,
             "ignore_unbreaking": true
           }
@@ -265,7 +265,7 @@
       ]
     },
     "shield_break_action": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "actions": [
         {
           "type": "shape-shifter-curse:set_item_cooldown",
@@ -278,7 +278,7 @@
           "slot": "extra_hand",
           "slot_index": 0,
           "action": {
-            "type": "origins:damage",
+            "type": "apoli:damage",
             "amount": 2,
             "ignore_unbreaking": true
           }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_jump_lower_and_far.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_jump_lower_and_far.json
@@ -1,61 +1,61 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
   "jump_far": {
     "type": "shape-shifter-curse:action_on_jump",
     "entity_action": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "actions": [
         {
-          "type": "origins:add_velocity",
+          "type": "apoli:add_velocity",
           "z": 0.22,
           "space": "local"
         },
         {
-          "type": "origins:exhaust",
+          "type": "apoli:exhaust",
           "amount": 0.2
         },
         {
-          "type": "origins:play_sound",
+          "type": "apoli:play_sound",
           "sound": "minecraft:entity.frog.long_jump",
           "pitch": 0.8
         },
         {
-          "type": "origins:play_sound",
+          "type": "apoli:play_sound",
           "sound": "minecraft:entity.goat.long_jump",
           "pitch": 1.0
         },
         {
-          "type": "origins:execute_command",
+          "type": "apoli:execute_command",
           "command": "particle cloud ~ ~ ~ 0.3 0.3 0.3 0.01 16 normal @a"
         }
       ]
 
     },
     "entity_condition": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:food_level",
+          "type": "apoli:food_level",
           "comparison": ">=",
           "compare_to": 6
         },
         {
-          "type": "origins:fluid_height",
+          "type": "apoli:fluid_height",
           "fluid": "minecraft:water",
           "comparison": "<=",
           "compare_to": 0
         },
         {
-          "type": "origins:on_block"
+          "type": "apoli:on_block"
         },
         {
-          "type": "origins:sprinting"
+          "type": "apoli:sprinting"
         }
       ]
     }
   },
   "jump_lower": {
-    "type": "origins:modify_jump",
+    "type": "apoli:modify_jump",
     "modifier": {
       "operation": "multiply_base_multiplicative",
       "value": -0.25

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_make_cobweb.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_make_cobweb.json
@@ -1,23 +1,23 @@
 {
-  "type": "origins:item_on_item",
+  "type": "apoli:item_on_item",
   "using_item_condition": {
-    "type": "origins:ingredient",
+    "type": "apoli:ingredient",
     "ingredient": {
       "item": "minecraft:string"
     }
   },
   "on_item_condition": {
-    "type": "origins:ingredient",
+    "type": "apoli:ingredient",
     "ingredient": {
       "item": "minecraft:string"
     }
   },
   "using_item_action": {
-    "type": "origins:consume",
+    "type": "apoli:consume",
     "amount": 1
   },
   "on_item_action": {
-    "type": "origins:consume",
+    "type": "apoli:consume",
     "amount": 1
   },
   "result": {
@@ -25,10 +25,10 @@
     "amount": 1
   },
   "entity_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.shulker.hurt_closed",
         "volume": 0.45
       },
@@ -39,7 +39,7 @@
     ]
   },
   "condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
         "type": "shape-shifter-curse:has_mana",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_make_web_composter.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_make_web_composter.json
@@ -1,23 +1,23 @@
 {
-  "type": "origins:item_on_item",
+  "type": "apoli:item_on_item",
   "using_item_condition": {
-    "type": "origins:ingredient",
+    "type": "apoli:ingredient",
     "ingredient": {
       "item": "minecraft:cobweb"
     }
   },
   "on_item_condition": {
-    "type": "origins:ingredient",
+    "type": "apoli:ingredient",
     "ingredient": {
       "item": "minecraft:composter"
     }
   },
   "using_item_action": {
-    "type": "origins:consume",
+    "type": "apoli:consume",
     "amount": 1
   },
   "on_item_action": {
-    "type": "origins:consume",
+    "type": "apoli:consume",
     "amount": 1
   },
   "result": {
@@ -25,10 +25,10 @@
     "amount": 1
   },
   "entity_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.shulker.hurt_closed",
         "volume": 0.45
       },
@@ -39,7 +39,7 @@
     ]
   },
   "condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
         "type": "shape-shifter-curse:has_mana",

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_mana_attack_cocooned_enemy.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_mana_attack_cocooned_enemy.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:self_action_on_hit",
+  "type": "apoli:self_action_on_hit",
   "entity_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
         "type": "shape-shifter-curse:gain_mana",
@@ -10,11 +10,11 @@
     ]
   },
   "damage_condition": {
-    "type": "origins:projectile",
+    "type": "apoli:projectile",
     "inverted" : true
   },
   "target_condition": {
-    "type": "origins:status_effect",
+    "type": "apoli:status_effect",
     "effect": "shape-shifter-curse:entangled_full_effect"
   },
   "cooldown": 20

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_mana_eat_string.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_mana_eat_string.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:action_on_item_use",
+  "type": "apoli:action_on_item_use",
   "entity_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
         "type": "shape-shifter-curse:gain_mana",
@@ -10,7 +10,7 @@
     ]
   },
   "item_condition": {
-    "type": "origins:ingredient",
+    "type": "apoli:ingredient",
     "ingredient": {
       "item": "minecraft:string"
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_mana_recover.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_mana_recover.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:action_over_time",
+  "type": "apoli:action_over_time",
   "entity_action": {
     "type": "shape-shifter-curse:gain_mana",
     "mana": 0.1

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_night_vision.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_night_vision.json
@@ -1,8 +1,8 @@
 {
-    "type": "origins:night_vision",
+    "type": "apoli:night_vision",
     "strength": 0.4,
     "condition": {
-        "type": "origins:submerged_in",
+        "type": "apoli:submerged_in",
         "fluid": "minecraft:water",
         "inverted": true
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_poison_immunity.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_poison_immunity.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:effect_immunity",
+  "type": "apoli:effect_immunity",
   "effects": [
     "minecraft:poison"
   ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_speed_down.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:conditioned_attribute",
+  "type": "apoli:conditioned_attribute",
   "modifier": {
     "attribute": "minecraft:generic.movement_speed",
     "operation": "multiply_base",
@@ -7,15 +7,15 @@
   },
   "tick_rate": 2,
   "condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:on_block"
+        "type": "apoli:on_block"
       },
       {
-        "type": "origins:in_block",
+        "type": "apoli:in_block",
         "block_condition": {
-          "type": "origins:block",
+          "type": "apoli:block",
           "block": "minecraft:water"
         },
         "inverted": true

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_spider_fluid_cocoon_only.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_spider_fluid_cocoon_only.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:modify_food",
+  "type": "apoli:modify_food",
   "food_modifiers": [
     {
       "operation": "set_total",
@@ -13,27 +13,27 @@
     }
   ],
   "item_condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:food"
+        "type": "apoli:food"
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-          "tag": "origins:ignore_diet"
+          "tag": "shape-shifter-curse:ignore_diet"
         },
         "inverted": true
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "tag": "shape-shifter-curse:ignore_vc_eat"
         },
         "inverted": true
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "item": "shape-shifter-curse:spider_fluid_cocoon"
         },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_totem_of_undying_extra_slot.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_totem_of_undying_extra_slot.json
@@ -20,7 +20,7 @@
     "slot": "extra_hand",
     "slot_index": 0,
     "condition": {
-      "type": "origins:ingredient",
+      "type": "apoli:ingredient",
       "ingredient": {
         "item": "minecraft:totem_of_undying"
       }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_web_bridge.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_web_bridge.json
@@ -8,10 +8,10 @@
   "tier0_enable": true,
   "tier0_charge_time": 0,
   "tier0_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -30,7 +30,7 @@
     "mana": 6
   },
   "tier1_use_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
         "type": "shape-shifter-curse:web_bridge",
@@ -38,7 +38,7 @@
         "web_bridge_width": 0
       },
       {
-        "type": "origins:spawn_particles",
+        "type": "apoli:spawn_particles",
         "particle": {
           "type": "minecraft:cloud"
         },
@@ -52,13 +52,13 @@
         }
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.shulker_bullet.hit",
         "volume": 0.5,
         "pitch": 0.8
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.grass.place",
         "volume": 0.5,
         "pitch": 0.8
@@ -66,10 +66,10 @@
     ]
   },
   "tier1_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -85,20 +85,20 @@
     "mana": 0.25
   },
   "tier1_charge_complete_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.hat",
         "pitch": 1.0
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.snare",
         "pitch": 1.0
       },
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:cloud ~ ~1.0 ~ 0.8 0.8 0.8 0 10"
       }
     ]
@@ -112,7 +112,7 @@
     "mana": 6
   },
   "tier2_use_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
         "type": "shape-shifter-curse:web_bridge",
@@ -120,7 +120,7 @@
         "web_bridge_width": 0
       },
       {
-        "type": "origins:spawn_particles",
+        "type": "apoli:spawn_particles",
         "particle": {
           "type": "minecraft:cloud"
         },
@@ -134,13 +134,13 @@
         }
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.shulker_bullet.hit",
         "volume": 0.5,
         "pitch": 0.8
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.grass.place",
         "volume": 0.5,
         "pitch": 0.8
@@ -148,10 +148,10 @@
     ]
   },
   "tier2_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -167,20 +167,20 @@
     "mana": 0.25
   },
   "tier2_charge_complete_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.hat",
         "pitch": 1.19
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.snare",
         "pitch": 1.19
       },
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:cloud ~ ~1.0 ~ 0.8 0.8 0.8 0 10"
       }
     ]
@@ -194,7 +194,7 @@
     "mana": 6
   },
   "tier3_use_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
         "type": "shape-shifter-curse:web_bridge",
@@ -202,7 +202,7 @@
         "web_bridge_width": 1
       },
       {
-        "type": "origins:spawn_particles",
+        "type": "apoli:spawn_particles",
         "particle": {
           "type": "minecraft:cloud"
         },
@@ -216,13 +216,13 @@
         }
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.shulker_bullet.hit",
         "volume": 0.5,
         "pitch": 0.8
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.grass.place",
         "volume": 0.5,
         "pitch": 0.8
@@ -230,10 +230,10 @@
     ]
   },
   "tier3_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -249,20 +249,20 @@
     "mana": 0.25
   },
   "tier3_charge_complete_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.hat",
         "pitch": 1.414
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.snare",
         "pitch": 1.414
       },
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:cloud ~ ~1.0 ~ 0.8 0.8 0.8 0 10"
       }
     ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_web_projectile.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_web_projectile.json
@@ -8,10 +8,10 @@
   "tier0_enable": true,
   "tier0_charge_time": 0,
   "tier0_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -30,7 +30,7 @@
     "mana": 6
   },
   "tier1_use_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
         "type": "shape-shifter-curse:fire_web_bullet",
@@ -41,10 +41,10 @@
     ]
   },
   "tier1_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -60,20 +60,20 @@
     "mana": 0.25
   },
   "tier1_charge_complete_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.hat",
         "pitch": 1.0
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.snare",
         "pitch": 1.0
       },
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:cloud ~ ~1.0 ~ 0.8 0.8 0.8 0 10"
       }
     ]
@@ -87,7 +87,7 @@
   },
 
   "tier2_use_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
         "type": "shape-shifter-curse:fire_web_bullet",
@@ -98,10 +98,10 @@
     ]
   },
   "tier2_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -117,20 +117,20 @@
     "mana": 0.25
   },
   "tier2_charge_complete_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.hat",
         "pitch": 1.19
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.snare",
         "pitch": 1.19
       },
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:cloud ~ ~1.0 ~ 0.8 0.8 0.8 0 10"
       }
     ]
@@ -144,7 +144,7 @@
     "mana": 6
   },
   "tier3_use_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
         "type": "shape-shifter-curse:fire_web_bullet",
@@ -155,10 +155,10 @@
     ]
   },
   "tier3_tick_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:apply_effect",
+        "type": "apoli:apply_effect",
         "effect": {
           "effect": "minecraft:slowness",
           "duration": 10,
@@ -174,20 +174,20 @@
     "mana": 0.25
   },
   "tier3_charge_complete_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.hat",
         "pitch": 1.414
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.note_block.snare",
         "pitch": 1.414
       },
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:cloud ~ ~1.0 ~ 0.8 0.8 0.8 0 10"
       }
     ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_climb_web.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_climb_web.json
@@ -1,49 +1,49 @@
 {
-  "type": "origins:multiple",
+  "type": "apoli:multiple",
   "climbing": {
-    "type": "origins:climbing",
+    "type": "apoli:climbing",
     "condition": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:in_block_anywhere",
+          "type": "apoli:in_block_anywhere",
           "block_condition": {
-            "type": "origins:in_tag",
-            "tag": "origins:cobwebs"
+            "type": "apoli:in_tag",
+            "tag": "shape-shifter-curse:cobwebs"
           }
         }
       ]
     },
     "hold_condition": {
-      "type": "origins:sneaking",
+      "type": "apoli:sneaking",
       "inverted": true
     }
   },
   "punch_through": {
-    "type": "origins:prevent_block_selection",
+    "type": "apoli:prevent_block_selection",
     "block_condition": {
-      "type": "origins:in_tag",
-      "tag": "origins:cobwebs"
+      "type": "apoli:in_tag",
+      "tag": "shape-shifter-curse:cobwebs"
     },
     "condition": {
-      "type": "origins:sneaking",
+      "type": "apoli:sneaking",
       "inverted": true
     }
   },
   "sense": {
-    "type": "origins:entity_glow",
+    "type": "apoli:entity_glow",
     "entity_condition": {
-      "type": "origins:and",
+      "type": "apoli:and",
       "conditions": [
         {
-          "type": "origins:in_block_anywhere",
+          "type": "apoli:in_block_anywhere",
           "block_condition": {
-            "type": "origins:in_tag",
-            "tag": "origins:cobwebs"
+            "type": "apoli:in_tag",
+            "tag": "shape-shifter-curse:cobwebs"
           }
         },
         {
-          "type": "origins:entity_group",
+          "type": "apoli:entity_group",
           "group": "arthropod",
           "inverted": true
         }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_entity_group.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_entity_group.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:entity_group",
+  "type": "apoli:entity_group",
   "group": "arthropod",
   "hidden": true
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_on_web_projectile_hit.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_on_web_projectile_hit.json
@@ -1,29 +1,29 @@
 {
-  "type": "origins:modify_projectile_damage",
+  "type": "apoli:modify_projectile_damage",
   "damage_condition": {
-    "type": "origins:projectile"
+    "type": "apoli:projectile"
   },
   "modifier": {
     "operation": "addition",
     "value": 0
   },
   "target_action": {
-    "type": "origins:execute_command",
+    "type": "apoli:execute_command",
     "command": "particle minecraft:cloud ~ ~0.5 ~ 0.2 0.2 0.2 0 10"
   },
   "self_action": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "actions": [
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.firework_rocket.blast_far"
       },
       {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:block.grass.break"
       },
       {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle minecraft:white_smoke ~ ~0.5 ~ 0.2 0.2 0.2 0 10"
       }
     ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound.json
@@ -1,13 +1,13 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.spider.ambient",
         "volume": 0.15
     },
     "interval": 200,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
                 "type": "shape-shifter-curse:enable_random_sound"

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound_hurt.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound_hurt.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:self_action_when_hit",
+    "type": "apoli:self_action_when_hit",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.spider.hurt",
         "volume": 0.2
     },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound_key.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound_key.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:active_self",
+    "type": "apoli:active_self",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.spider.ambient",
         "volume": 0.15
     },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound_walk.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_sound_walk.json
@@ -1,32 +1,32 @@
 {
-    "type": "origins:action_over_time",
+    "type": "apoli:action_over_time",
     "entity_action": {
-        "type": "origins:play_sound",
+        "type": "apoli:play_sound",
         "sound": "minecraft:entity.spider.step",
         "volume": 0.075
     },
     "interval": 10,
     "condition": {
-        "type": "origins:or",
+        "type": "apoli:or",
         "conditions": [
             {
-                "type": "origins:and",
+                "type": "apoli:and",
                 "conditions": [
                     {
-                        "type": "origins:moving",
+                        "type": "apoli:moving",
                         "horizontally": false,
                         "vertically": true
                     },
                     {
-                        "type": "origins:or",
+                        "type": "apoli:or",
                         "conditions": [
                             {
-                                "type": "origins:block_collision",
+                                "type": "apoli:block_collision",
                                 "offset_x": 0.1,
                                 "offset_z": 0.1
                             },
                             {
-                                "type": "origins:block_collision",
+                                "type": "apoli:block_collision",
                                 "offset_x": -0.1,
                                 "offset_z": -0.1
                             }
@@ -35,15 +35,15 @@
                 ]
             },
             {
-                "type": "origins:and",
+                "type": "apoli:and",
                 "conditions": [
                     {
-                        "type": "origins:moving",
+                        "type": "apoli:moving",
                         "horizontally": true,
                         "vertically": false
                     },
                     {
-                        "type": "origins:block_collision",
+                        "type": "apoli:block_collision",
                         "offset_y": -0.1
                     }
                 ]

--- a/src/main/resources/data/shape-shifter-curse/powers/form_sprint_speed_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_sprint_speed_up.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "multiply_total",
@@ -8,6 +8,6 @@
     },
     "tick_rate": 4,
     "condition": {
-        "type": "origins:sprinting"
+        "type": "apoli:sprinting"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_tan_axolotl_thirst_in_water.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_tan_axolotl_thirst_in_water.json
@@ -1,12 +1,12 @@
 {
-  "type": "origins:action_over_time",
+  "type": "apoli:action_over_time",
   "entity_action": {
     "type": "shape-shifter-curse:tan_add_thirst",
     "amount": 1
   },
   "interval": 10,
   "condition": {
-    "type": "origins:submerged_in",
+    "type": "apoli:submerged_in",
     "fluid": "water"
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_vegetarian.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_vegetarian.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:modify_food",
+  "type": "apoli:modify_food",
   "food_modifiers": [
     {
       "operation": "set_total",
@@ -13,22 +13,22 @@
     }
   ],
   "item_condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
           {
-            "type": "origins:or",
+            "type": "apoli:or",
             "conditions": [
               {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                  "tag": "origins:meat"
+                  "tag": "shape-shifter-curse:meat"
                 }
               },
               {
-                "type": "origins:meat"
+                "type": "apoli:meat"
               }
             ]
           },
@@ -40,17 +40,17 @@
         ]
       },
       {
-        "type": "origins:food"
+        "type": "apoli:food"
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-          "tag": "origins:ignore_diet"
+          "tag": "shape-shifter-curse:ignore_diet"
         },
         "inverted": true
       },
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
           "tag": "shape-shifter-curse:ignore_vc_eat"
         },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_vegetarian_food_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_vegetarian_food_down.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifier": {
         "name": "Decreased food points",
         "operation": "multiply_base_multiplicative",
@@ -11,28 +11,28 @@
         "value": -0.5
     },
     "item_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:meat"
+                    "tag": "shape-shifter-curse:meat"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:meat",
+                "type": "apoli:meat",
                 "inverted": true
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:ignore_diet"
+                    "tag": "shape-shifter-curse:ignore_diet"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
                     "tag": "shape-shifter-curse:ignore_vc_eat"
                 },

--- a/src/main/resources/data/shape-shifter-curse/powers/form_vegetarian_food_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_vegetarian_food_up.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_food",
+    "type": "apoli:modify_food",
     "food_modifiers": [
         {
             "name": "increase food points",
@@ -25,23 +25,23 @@
         }
     ],
     "item_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:or",
+                "type": "apoli:or",
                 "conditions": [
                     {
-                        "type": "origins:and",
+                        "type": "apoli:and",
                         "conditions": [
                             {
-                                "type": "origins:ingredient",
+                                "type": "apoli:ingredient",
                                 "ingredient": {
-                                    "tag": "origins:meat"
+                                    "tag": "shape-shifter-curse:meat"
                                 },
                                 "inverted": true
                             },
                             {
-                                "type": "origins:meat",
+                                "type": "apoli:meat",
                                 "inverted": true
                             }
                         ]
@@ -53,14 +53,14 @@
                 ]
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:ignore_diet"
+                    "tag": "shape-shifter-curse:ignore_diet"
                 },
                 "inverted": true
             },
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
                     "tag": "shape-shifter-curse:ignore_vc_eat"
                 },

--- a/src/main/resources/data/shape-shifter-curse/powers/high_jump_2.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/high_jump_2.json
@@ -1,11 +1,11 @@
 {
-    "type": "origins:modify_jump",
+    "type": "apoli:modify_jump",
     "modifier": {
         "operation": "addition",
         "value": 0.2
     },
     "entity_action": {
-        "type": "origins:execute_command",
+        "type": "apoli:execute_command",
         "command": "particle cloud ~ ~ ~ 0.3 0.3 0.3 0.01 16 normal @a"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/hostile_iron_golem.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/hostile_iron_golem.json
@@ -1,3 +1,3 @@
 {
-  "type": "origins:simple"
+  "type": "apoli:simple"
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/hotblooded.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/hotblooded.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:effect_immunity",
+  "type": "apoli:effect_immunity",
   "effects": [
     "minecraft:poison",
     "minecraft:hunger"

--- a/src/main/resources/data/shape-shifter-curse/powers/hunger_immunity.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/hunger_immunity.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:effect_immunity",
+    "type": "apoli:effect_immunity",
     "effects": [
         "minecraft:hunger"
     ]

--- a/src/main/resources/data/shape-shifter-curse/powers/jump_out_water.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/jump_out_water.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:active_self",
+  "type": "apoli:active_self",
   "entity_action": {
-    "type": "origins:add_velocity",
+    "type": "apoli:add_velocity",
     "y": 0.8,
     "space": "world"
   },
@@ -14,16 +14,16 @@
     "continuous": true
   },
   "condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:fluid_height",
+        "type": "apoli:fluid_height",
         "fluid": "minecraft:water",
         "comparison": ">",
         "compare_to": 0
       },
       {
-        "type": "origins:fluid_height",
+        "type": "apoli:fluid_height",
         "fluid": "minecraft:water",
         "comparison": "<",
         "compare_to": 0.2

--- a/src/main/resources/data/shape-shifter-curse/powers/less_exhaustion.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/less_exhaustion.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_exhaustion",
+    "type": "apoli:modify_exhaustion",
     "modifier": {
         "name": "Less exhaustion",
         "value": -0.4,

--- a/src/main/resources/data/shape-shifter-curse/powers/like_water.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/like_water.json
@@ -1,3 +1,3 @@
 {
-  "type": "origins:simple"
+  "type": "apoli:simple"
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/modify_potion_stack_8.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/modify_potion_stack_8.json
@@ -1,7 +1,7 @@
 {
     "type": "shape-shifter-curse:modify_potion_stack",
     "condition": {
-        "type": "origins:constant",
+        "type": "apoli:constant",
         "value": true
     },
     "count": 8

--- a/src/main/resources/data/shape-shifter-curse/powers/more_exhaustion.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/more_exhaustion.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:modify_exhaustion",
+  "type": "apoli:modify_exhaustion",
   "modifier": {
     "name": "Extra exhaustion from large appetite",
     "value": 0.6,

--- a/src/main/resources/data/shape-shifter-curse/powers/no_exhaustion.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/no_exhaustion.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:modify_exhaustion",
+    "type": "apoli:modify_exhaustion",
     "modifier": {
         "name": "No exhaustion",
         "value": -0.9,

--- a/src/main/resources/data/shape-shifter-curse/powers/no_hurt_pet.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/no_hurt_pet.json
@@ -1,7 +1,7 @@
 {
-  "type": "origins:modify_damage_dealt",
+  "type": "apoli:modify_damage_dealt",
   "bientity_condition": {
-    "type": "origins:owner"
+    "type": "apoli:owner"
   },
   "modifier": {
     "operation": "multiply_total",

--- a/src/main/resources/data/shape-shifter-curse/powers/no_render_arm_when_sneaking.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/no_render_arm_when_sneaking.json
@@ -1,10 +1,10 @@
 {
     "type": "shape-shifter-curse:no_render_arm",
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:sneaking"
+                "type": "apoli:sneaking"
             }
         ]
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/no_shield.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/no_shield.json
@@ -1,12 +1,12 @@
 {
-  "type": "origins:prevent_item_use",
+  "type": "apoli:prevent_item_use",
   "item_condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:ingredient",
+        "type": "apoli:ingredient",
         "ingredient": {
-          "tag": "origins:shields"
+          "tag": "shape-shifter-curse:shields"
         }
       },
       {

--- a/src/main/resources/data/shape-shifter-curse/powers/no_step_sound.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/no_step_sound.json
@@ -1,7 +1,7 @@
 {
     "type": "shape-shifter-curse:no_step_sound",
     "condition": {
-        "type": "origins:constant",
+        "type": "apoli:constant",
         "value": true
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/pillager_friendly.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/pillager_friendly.json
@@ -1,7 +1,7 @@
 {
     "type": "shape-shifter-curse:pillager_friendly",
     "condition": {
-        "type": "origins:constant",
+        "type": "apoli:constant",
         "value": true
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/poison_immunity.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/poison_immunity.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:effect_immunity",
+    "type": "apoli:effect_immunity",
     "effects": [
         "minecraft:poison"
     ]

--- a/src/main/resources/data/shape-shifter-curse/powers/prevent_berry_effect.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/prevent_berry_effect.json
@@ -1,7 +1,7 @@
 {
     "type": "shape-shifter-curse:prevent_berry_effect",
     "condition": {
-        "type": "origins:constant",
+        "type": "apoli:constant",
         "value": true
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/prevent_ranged_weapon_use.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/prevent_ranged_weapon_use.json
@@ -1,12 +1,12 @@
 {
-    "type": "origins:prevent_item_use",
+    "type": "apoli:prevent_item_use",
     "item_condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:ingredient",
+                "type": "apoli:ingredient",
                 "ingredient": {
-                    "tag": "origins:ranged_weapons"
+                    "tag": "shape-shifter-curse:ranged_weapons"
                 }
             },
             {

--- a/src/main/resources/data/shape-shifter-curse/powers/prevent_sprinting.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/prevent_sprinting.json
@@ -1,7 +1,7 @@
 {
-    "type": "origins:prevent_sprinting",
+    "type": "apoli:prevent_sprinting",
     "condition": {
-        "type": "origins:constant",
+        "type": "apoli:constant",
         "value": true
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/scare_creepers.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/scare_creepers.json
@@ -1,3 +1,3 @@
 {
-  "type": "origins:simple"
+  "type": "apoli:simple"
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/scare_skeleton.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/scare_skeleton.json
@@ -1,3 +1,3 @@
 {
-  "type": "origins:simple"
+  "type": "apoli:simple"
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/scare_villager.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/scare_villager.json
@@ -1,7 +1,7 @@
 {
     "type": "shape-shifter-curse:scare_villager",
     "condition": {
-        "type": "origins:constant",
+        "type": "apoli:constant",
         "value": true
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/slow_falling.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/slow_falling.json
@@ -3,32 +3,32 @@
   "velocity": 0.01,
   "take_fall_damage": false,
   "condition": {
-    "type": "origins:or",
+    "type": "apoli:or",
     "conditions": [
       {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
           {
-            "type": "origins:sneaking"
+            "type": "apoli:sneaking"
           },
           {
-            "type": "origins:fall_flying"
+            "type": "apoli:fall_flying"
           }
         ]
       },
       {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
           {
-            "type": "origins:sneaking",
+            "type": "apoli:sneaking",
             "inverted": true
           },
           {
-            "type": "origins:fall_flying",
+            "type": "apoli:fall_flying",
             "inverted": true
           },
           {
-            "type": "origins:on_block",
+            "type": "apoli:on_block",
             "inverted": true
           },
           {

--- a/src/main/resources/data/shape-shifter-curse/powers/sneaking_speed_up.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/sneaking_speed_up.json
@@ -1,5 +1,5 @@
 {
-  "type": "origins:conditioned_attribute",
+  "type": "apoli:conditioned_attribute",
   "modifier": {
     "attribute": "minecraft:generic.movement_speed",
     "operation": "addition",
@@ -8,16 +8,16 @@
   },
   "tick_rate": 1,
   "condition": {
-    "type": "origins:and",
+    "type": "apoli:and",
     "conditions": [
       {
-        "type": "origins:fluid_height",
+        "type": "apoli:fluid_height",
         "fluid": "minecraft:water",
         "comparison": "<=",
         "compare_to": 0
       },
       {
-        "type": "origins:sneaking"
+        "type": "apoli:sneaking"
       }
     ]
   }

--- a/src/main/resources/data/shape-shifter-curse/powers/sneaking_speed_up_low.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/sneaking_speed_up_low.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "addition",
@@ -8,16 +8,16 @@
     },
     "tick_rate": 1,
     "condition": {
-        "type": "origins:and",
+        "type": "apoli:and",
         "conditions": [
             {
-                "type": "origins:fluid_height",
+                "type": "apoli:fluid_height",
                 "fluid": "minecraft:water",
                 "comparison": "<=",
                 "compare_to": 0
             },
             {
-                "type": "origins:sneaking"
+                "type": "apoli:sneaking"
             }
         ]
     }

--- a/src/main/resources/data/shape-shifter-curse/powers/speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/speed_down.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:attribute",
+    "type": "apoli:attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "multiply_total",

--- a/src/main/resources/data/shape-shifter-curse/powers/spider_friendly.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/spider_friendly.json
@@ -1,3 +1,3 @@
 {
-  "type": "origins:simple"
+  "type": "apoli:simple"
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/sprint_speed_down.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/sprint_speed_down.json
@@ -1,5 +1,5 @@
 {
-    "type": "origins:conditioned_attribute",
+    "type": "apoli:conditioned_attribute",
     "modifier": {
         "attribute": "minecraft:generic.movement_speed",
         "operation": "multiply_total",
@@ -8,6 +8,6 @@
     },
     "tick_rate": 1,
     "condition": {
-        "type": "origins:sprinting"
+        "type": "apoli:sprinting"
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/undead_group.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/undead_group.json
@@ -1,4 +1,4 @@
 {
-  "type": "origins:entity_group",
+  "type": "apoli:entity_group",
   "group": "undead"
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/velvet_paws.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/velvet_paws.json
@@ -1,4 +1,4 @@
 {
-  "type": "origins:prevent_game_event",
+  "type": "apoli:prevent_game_event",
   "event": "minecraft:step"
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/water_vision.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/water_vision.json
@@ -1,8 +1,8 @@
 {
-  "type": "origins:night_vision",
+  "type": "apoli:night_vision",
   "strength": 1.0,
   "condition": {
-    "type": "origins:submerged_in",
+    "type": "apoli:submerged_in",
     "fluid": "minecraft:water"
   }
 }

--- a/src/main/resources/data/shape-shifter-curse/powers/witch_friendly.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/witch_friendly.json
@@ -1,7 +1,7 @@
 {
     "type": "shape-shifter-curse:witch_friendly",
     "condition": {
-        "type": "origins:constant",
+        "type": "apoli:constant",
         "value": true
     }
 }

--- a/src/main/resources/data/shape-shifter-curse/tags/blocks/cobwebs.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/blocks/cobwebs.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "#origins:cobwebs",
+      "required": false
+    },
+    "minecraft:cobweb",
+    "shape-shifter-curse:dew_covered_cobweb"
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/blocks/leaves.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/blocks/leaves.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:oak_leaves",
+    "minecraft:spruce_leaves",
+    "minecraft:birch_leaves",
+    "minecraft:jungle_leaves",
+    "minecraft:acacia_leaves",
+    "minecraft:dark_oak_leaves",
+    "minecraft:mangrove_leaves",
+    "minecraft:azalea_leaves",
+    "minecraft:cherry_leaves",
+    "minecraft:flowering_azalea_leaves"
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/blocks/natural_wood.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/blocks/natural_wood.json
@@ -1,0 +1,27 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:oak_leaves",
+    "minecraft:spruce_leaves",
+    "minecraft:birch_leaves",
+    "minecraft:jungle_leaves",
+    "minecraft:acacia_leaves",
+    "minecraft:dark_oak_leaves",
+    "minecraft:mangrove_leaves",
+    "minecraft:azalea_leaves",
+    "minecraft:cherry_leaves",
+    "minecraft:flowering_azalea_leaves",
+    "minecraft:oak_log",
+    "minecraft:spruce_log",
+    "minecraft:birch_log",
+    "minecraft:jungle_log",
+    "minecraft:acacia_log",
+    "minecraft:dark_oak_log",
+    "minecraft:mangrove_log",
+    "minecraft:cherry_log",
+    "minecraft:crimson_stem",
+    "minecraft:warped_stem",
+    "minecraft:bamboo",
+    "minecraft:mangrove_roots"
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/blocks/puff_block.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/blocks/puff_block.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:sand",
+    "minecraft:red_sand",
+    "minecraft:gravel",
+    "minecraft:coarse_dirt",
+    "minecraft:snow_block",
+    "minecraft:snow",
+    "minecraft:soul_soil",
+    "minecraft:dirt"
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/blocks/unphasable.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/blocks/unphasable.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "#origins:unphasable",
+      "required": false
+    },
+    "minecraft:barrier",
+    "minecraft:bedrock",
+    "minecraft:crying_obsidian",
+    "minecraft:obsidian"
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/entity_types/fish.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/entity_types/fish.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:cod",
+    "minecraft:salmon",
+    "minecraft:tropical_fish",
+    "minecraft:pufferfish"
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/entity_types/livestock.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/entity_types/livestock.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:cow",
+    "minecraft:sheep",
+    "minecraft:chicken",
+    "minecraft:pig"
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/items/fish.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/items/fish.json
@@ -1,0 +1,395 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:cod",
+    "minecraft:cooked_cod",
+    "minecraft:cooked_salmon",
+    "minecraft:pufferfish",
+    "minecraft:salmon",
+    "minecraft:tropical_fish",
+    {
+      "id": "farmersdelight:baked_cod_stew",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:cod_roll",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:cod_slice",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:cooked_cod_slice",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:cooked_salmon_slice",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:grilled_salmon",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:salmon_slice",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:salmon_roll",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:squid_ink_pasta",
+      "required": false
+    },
+    {
+      "id": "tide:mint_carp",
+      "required": false
+    },
+    {
+      "id": "tide:trout",
+      "required": false
+    },
+    {
+      "id": "tide:angelfish",
+      "required": false
+    },
+    {
+      "id": "tide:barracuda",
+      "required": false
+    },
+    {
+      "id": "tide:sailfish",
+      "required": false
+    },
+    {
+      "id": "tide:catfish",
+      "required": false
+    },
+    {
+      "id": "tide:pike",
+      "required": false
+    },
+    {
+      "id": "tide:bass",
+      "required": false
+    },
+    {
+      "id": "tide:tuna",
+      "required": false
+    },
+    {
+      "id": "tide:yellow_perch",
+      "required": false
+    },
+    {
+      "id": "tide:ocean_perch",
+      "required": false
+    },
+    {
+      "id": "tide:bluegill",
+      "required": false
+    },
+    {
+      "id": "tide:mackerel",
+      "required": false
+    },
+    {
+      "id": "tide:glowfish",
+      "required": false
+    },
+    {
+      "id": "tide:anglerfish",
+      "required": false
+    },
+    {
+      "id": "tide:cave_crawler",
+      "required": false
+    },
+    {
+      "id": "tide:abyss_angler",
+      "required": false
+    },
+    {
+      "id": "tide:shadow_snapper",
+      "required": false
+    },
+    {
+      "id": "tide:deep_grouper",
+      "required": false
+    },
+    {
+      "id": "tide:cooked_fish",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:fugu_roll",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:fugu_slice",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:stuffed_cod",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:cabbage_wrapped_elder_guardian",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:cooked_stuffed_cod",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:elder_guardian_roll",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:cooked_elder_guardian_slice",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:elder_guardian_slice",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:elder_guardian_slab",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:bowl_of_guardian_soup",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:cooked_guardian_tail",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:guardian_tail",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:baked_tentacle_on_a_stick",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:tentacle_on_a_stick",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:squid_rings",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:cut_tentacles",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:tentacles",
+      "required": false
+    },
+    {
+      "id": "tide:clayfish",
+      "required": false
+    },
+    {
+      "id": "tide:hardened_clayfish",
+      "required": false
+    },
+    {
+      "id": "tide:guppy",
+      "required": false
+    },
+    {
+      "id": "tide:cave_eel",
+      "required": false
+    },
+    {
+      "id": "tide:crystal_shrimp",
+      "required": false
+    },
+    {
+      "id": "tide:iron_tetra",
+      "required": false
+    },
+    {
+      "id": "tide:gilded_minnow",
+      "required": false
+    },
+    {
+      "id": "tide:crystalline_carp",
+      "required": false
+    },
+    {
+      "id": "tide:lapis_lanternfish",
+      "required": false
+    },
+    {
+      "id": "tide:luminescent_jellyfish",
+      "required": false
+    },
+    {
+      "id": "tide:bedrock_tetra",
+      "required": false
+    },
+    {
+      "id": "tide:endstone_perch",
+      "required": false
+    },
+    {
+      "id": "tide:enderfin",
+      "required": false
+    },
+    {
+      "id": "tide:endergazer",
+      "required": false
+    },
+    {
+      "id": "tide:purpur_pike",
+      "required": false
+    },
+    {
+      "id": "tide:chorus_cod",
+      "required": false
+    },
+    {
+      "id": "tide:elytrout",
+      "required": false
+    },
+    {
+      "id": "tide:prarie_pike",
+      "required": false
+    },
+    {
+      "id": "tide:sandskipper",
+      "required": false
+    },
+    {
+      "id": "tide:blossom_bass",
+      "required": false
+    },
+    {
+      "id": "tide:oakfish",
+      "required": false
+    },
+    {
+      "id": "tide:frostbite_flounder",
+      "required": false
+    },
+    {
+      "id": "tide:mirage_catfish",
+      "required": false
+    },
+    {
+      "id": "tide:echofin_snapper",
+      "required": false
+    },
+    {
+      "id": "tide:sunspike_goby",
+      "required": false
+    },
+    {
+      "id": "tide:birch_trout",
+      "required": false
+    },
+    {
+      "id": "tide:stonefish",
+      "required": false
+    },
+    {
+      "id": "tide:dripstone_darter",
+      "required": false
+    },
+    {
+      "id": "tide:slimefin_snapper",
+      "required": false
+    },
+    {
+      "id": "tide:sporestalker",
+      "required": false
+    },
+    {
+      "id": "tide:leafback",
+      "required": false
+    },
+    {
+      "id": "tide:fluttergill",
+      "required": false
+    },
+    {
+      "id": "tide:pine_perch",
+      "required": false
+    },
+    {
+      "id": "tide:ember_koi",
+      "required": false
+    },
+    {
+      "id": "tide:inferno_guppy",
+      "required": false
+    },
+    {
+      "id": "tide:obsidian_pike",
+      "required": false
+    },
+    {
+      "id": "tide:volcano_tuna",
+      "required": false
+    },
+    {
+      "id": "tide:magma_mackerel",
+      "required": false
+    },
+    {
+      "id": "tide:warped_guppy",
+      "required": false
+    },
+    {
+      "id": "tide:crimson_fangjaw",
+      "required": false
+    },
+    {
+      "id": "tide:ashen_perch",
+      "required": false
+    },
+    {
+      "id": "tide:witherfin",
+      "required": false
+    },
+    {
+      "id": "tide:soulscaler",
+      "required": false
+    },
+    {
+      "id": "tide:aquathorn",
+      "required": false
+    },
+    {
+      "id": "tide:midas_fish",
+      "required": false
+    },
+    {
+      "id": "tide:voidseeker",
+      "required": false
+    },
+    {
+      "id": "tide:shooting_starfish",
+      "required": false
+    },
+    {
+      "id": "natures_delight:fafaru",
+      "required": false
+    },
+    {
+      "id": "naturalist:cooked_bass",
+      "required": false
+    },
+    {
+      "id": "naturalist:cooked_catfish",
+      "required": false
+    }
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/items/fruit.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/items/fruit.json
@@ -1,0 +1,90 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:apple",
+    "minecraft:chorus_fruit",
+    "minecraft:glow_berries",
+    "minecraft:melon_slice",
+    "minecraft:sweet_berries",
+    {
+      "id": "farmersdelight:apple_pie",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:apple_pie_slice",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:fruit_salad",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:glow_berry_custard",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:melon_popsicle",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:sweet_berry_cheesecake",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:sweet_berry_cheesecake_slice",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:sweet_berry_cookie",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:tomato",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:tomato_sauce",
+      "required": false
+    },
+    {
+      "id": "vinery:red_grape",
+      "required": false
+    },
+    {
+      "id": "vinery:white_grape",
+      "required": false
+    },
+    {
+      "id": "vinery:savanna_grapes_red",
+      "required": false
+    },
+    {
+      "id": "vinery:savanna_grapes_white",
+      "required": false
+    },
+    {
+      "id": "vinery:taiga_grapes_red",
+      "required": false
+    },
+    {
+      "id": "vinery:taiga_grapes_white",
+      "required": false
+    },
+    {
+      "id": "vinery:jungle_grapes_red",
+      "required": false
+    },
+    {
+      "id": "vinery:jungle_grapes_white",
+      "required": false
+    },
+    {
+      "id":"vinery:cherry",
+      "required":false
+    },
+    {
+      "id": "farm_and_charm:strawberry",
+      "required": false
+    }
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/items/ignore_diet.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/items/ignore_diet.json
@@ -1,0 +1,78 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "#origins:ignore_diet",
+      "required": false
+    },
+    "minecraft:enchanted_golden_apple",
+    "minecraft:golden_apple",
+    "minecraft:golden_carrot",
+    "minecraft:milk_bucket",
+    "shape-shifter-curse:catalyst",
+    "shape-shifter-curse:creative_inhibitor",
+    "shape-shifter-curse:inhibitor",
+    "shape-shifter-curse:powerful_catalyst",
+    "shape-shifter-curse:powerful_inhibitor",
+    {
+      "id": "farmersdelight:apple_cider",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:bone_broth",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:cabbage_rolls",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:chocolate_pie",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:glow_berry_custard",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:hot_cocoa",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:honey_cookie",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:milk_bottle",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:melon_juice",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:melon_popsicle",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:egg_sandwich",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:fried_egg",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:honey_fried_kelp",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:propelpearl",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:magma_gelatin",
+      "required": false
+    }
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/items/meat.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/items/meat.json
@@ -1,0 +1,670 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "#origins:meat",
+      "required": false
+    },
+    "minecraft:beef",
+    "minecraft:chicken",
+    "minecraft:cod",
+    "minecraft:cooked_beef",
+    "minecraft:cooked_chicken",
+    "minecraft:cooked_cod",
+    "minecraft:cooked_mutton",
+    "minecraft:cooked_porkchop",
+    "minecraft:cooked_rabbit",
+    "minecraft:cooked_salmon",
+    "minecraft:mutton",
+    "minecraft:porkchop",
+    "minecraft:pufferfish",
+    "minecraft:rabbit",
+    "minecraft:rabbit_stew",
+    "minecraft:rotten_flesh",
+    "minecraft:salmon",
+    "minecraft:tropical_fish",
+    {
+      "id": "farmersdelight:bacon",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:bacon_and_eggs",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:bacon_sandwich",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:baked_cod_stew",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:barbecue_stick",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:beef_patty",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:beef_stew",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:bone_broth",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:chicken_cuts",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:chicken_sandwich",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:chicken_soup",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:cod_roll",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:cod_slice",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:cooked_bacon",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:cooked_chicken_cuts",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:cooked_cod_slice",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:cooked_mutton_chops",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:cooked_salmon_slice",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:dumplings",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:fish_stew",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:grilled_salmon",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:ham",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:hamburger",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:honey_glazed_ham",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:minced_beef",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:mutton_chops",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:mutton_wrap",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:noodle_soup",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:pasta_with_meatballs",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:pasta_with_mutton_chop",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:pumpkin_soup",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:roast_chicken",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:roasted_mutton_chops",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:salmon_roll",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:salmon_slice",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:shepherds_pie",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:smoked_ham",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:steak_and_potatoes",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:stuffed_potato",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:stuffed_pumpkin",
+      "required": false
+    },
+    {
+      "id": "tide:clayfish",
+      "required": false
+    },
+    {
+      "id": "tide:hardened_clayfish",
+      "required": false
+    },
+    {
+      "id": "tide:guppy",
+      "required": false
+    },
+    {
+      "id": "tide:cave_eel",
+      "required": false
+    },
+    {
+      "id": "tide:crystal_shrimp",
+      "required": false
+    },
+    {
+      "id": "tide:iron_tetra",
+      "required": false
+    },
+    {
+      "id": "tide:gilded_minnow",
+      "required": false
+    },
+    {
+      "id": "tide:crystalline_carp",
+      "required": false
+    },
+    {
+      "id": "tide:lapis_lanternfish",
+      "required": false
+    },
+    {
+      "id": "tide:luminescent_jellyfish",
+      "required": false
+    },
+    {
+      "id": "tide:bedrock_tetra",
+      "required": false
+    },
+    {
+      "id": "tide:endstone_perch",
+      "required": false
+    },
+    {
+      "id": "tide:enderfin",
+      "required": false
+    },
+    {
+      "id": "tide:endergazer",
+      "required": false
+    },
+    {
+      "id": "tide:purpur_pike",
+      "required": false
+    },
+    {
+      "id": "tide:chorus_cod",
+      "required": false
+    },
+    {
+      "id": "tide:elytrout",
+      "required": false
+    },
+    {
+      "id": "tide:prarie_pike",
+      "required": false
+    },
+    {
+      "id": "tide:sandskipper",
+      "required": false
+    },
+    {
+      "id": "tide:blossom_bass",
+      "required": false
+    },
+    {
+      "id": "tide:oakfish",
+      "required": false
+    },
+    {
+      "id": "tide:frostbite_flounder",
+      "required": false
+    },
+    {
+      "id": "tide:mirage_catfish",
+      "required": false
+    },
+    {
+      "id": "tide:echofin_snapper",
+      "required": false
+    },
+    {
+      "id": "tide:sunspike_goby",
+      "required": false
+    },
+    {
+      "id": "tide:birch_trout",
+      "required": false
+    },
+    {
+      "id": "tide:stonefish",
+      "required": false
+    },
+    {
+      "id": "tide:dripstone_darter",
+      "required": false
+    },
+    {
+      "id": "tide:slimefin_snapper",
+      "required": false
+    },
+    {
+      "id": "tide:sporestalker",
+      "required": false
+    },
+    {
+      "id": "tide:leafback",
+      "required": false
+    },
+    {
+      "id": "tide:fluttergill",
+      "required": false
+    },
+    {
+      "id": "tide:pine_perch",
+      "required": false
+    },
+    {
+      "id": "tide:ember_koi",
+      "required": false
+    },
+    {
+      "id": "tide:inferno_guppy",
+      "required": false
+    },
+    {
+      "id": "tide:obsidian_pike",
+      "required": false
+    },
+    {
+      "id": "tide:volcano_tuna",
+      "required": false
+    },
+    {
+      "id": "tide:magma_mackerel",
+      "required": false
+    },
+    {
+      "id": "tide:warped_guppy",
+      "required": false
+    },
+    {
+      "id": "tide:crimson_fangjaw",
+      "required": false
+    },
+    {
+      "id": "tide:ashen_perch",
+      "required": false
+    },
+    {
+      "id": "tide:witherfin",
+      "required": false
+    },
+    {
+      "id": "tide:soulscaler",
+      "required": false
+    },
+    {
+      "id": "tide:aquathorn",
+      "required": false
+    },
+    {
+      "id": "tide:midas_fish",
+      "required": false
+    },
+    {
+      "id": "tide:voidseeker",
+      "required": false
+    },
+    {
+      "id": "tide:shooting_starfish",
+      "required": false
+    },
+    {
+      "id": "tide:cooked_fish",
+      "required": false
+    },
+    {
+      "id": "tide:fish_slice",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:fugu_roll",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:fugu_slice",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:stuffed_cod",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:cabbage_wrapped_elder_guardian",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:cooked_stuffed_cod",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:elder_guardian_roll",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:cooked_elder_guardian_slice",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:elder_guardian_slice",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:elder_guardian_slab",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:bowl_of_guardian_soup",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:cooked_guardian_tail",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:guardian_tail",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:baked_tentacle_on_a_stick",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:tentacle_on_a_stick",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:squid_rings",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:cut_tentacles",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:tentacles",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:hoglin_loin",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:strider_slice",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:ground_strider",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:hoglin_sirloin",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:warped_moldy_meat",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:grilled_strider",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:strider_moss_stew",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:hoglin_ear",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:plate_of_stuffed_hoglin_snout",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:plate_of_stuffed_hoglin_ham",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:plate_of_stuffed_hoglin_roast",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:minced_beef",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:lamb_ham",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:chicken_parts",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:bacon",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:baked_lamb_ham",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:lamb_with_corn",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:goulash",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:beef_patty_with_vegetables",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:potato_with_roast_meat",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:stuffed_chicken",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:roasted_chicken",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:chicken_wrapped_in_bacon",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:cooked_cod",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:cooked_salmon",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:stuffed_rabbit",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:sausage_with_oat_patty",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:bacon_with_eggs",
+      "required": false
+    }
+  ,
+    {
+      "id": "meadow:cooked_buffalo_meat",
+      "required": false
+    }
+  ,
+    {
+      "id": "meadow:raw_buffalo_meat",
+      "required": false
+    }
+  ,
+    {
+      "id": "wildernature:bison_meat",
+      "required": false
+    },
+    {
+      "id": "wildernature:cooked_bison_meat",
+      "required": false
+    },
+    {
+      "id": "wildernature:cassowary_meat",
+      "required": false
+    },
+    {
+      "id": "wildernature:cooked_cassowary_meat",
+      "required": false
+    },
+    {
+      "id": "wildernature:pelican_meat",
+      "required": false
+    },
+    {
+      "id": "wildernature:cooked_pelican_meat",
+      "required": false
+    },
+    {
+      "id": "wildernature:turkey_meat",
+      "required": false
+    },
+    {
+      "id": "wildernature:cooked_turkey_meat",
+      "required": false
+    },
+    {
+      "id": "wildernature:venison",
+      "required": false
+    },
+    {
+      "id": "wildernature:cooked_venison",
+      "required": false
+    },
+    {
+      "id": "naturalist:bass",
+      "required": false
+    },
+    {
+      "id": "naturalist:catfish",
+      "required": false
+    },
+    {
+      "id": "naturalist:cooked_bass",
+      "required": false
+    },
+    {
+      "id": "naturalist:cooked_catfish",
+      "required": false
+    },
+    {
+      "id": "naturalist:duck",
+      "required": false
+    },
+    {
+      "id": "naturalist:cooked_duck",
+      "required": false
+    },
+    {
+      "id": "naturalist:cooked_lizard_tail",
+      "required": false
+    },
+    {
+      "id": "naturalist:lizard_tail",
+      "required": false
+    },
+    {
+      "id": "naturalist:venison",
+      "required": false
+    },
+    {
+      "id": "naturalist:cooked_venison",
+      "required": false
+    },
+    {
+      "id": "naturalist:bushmeat",
+      "required": false
+    },
+    {
+      "id": "naturalist:cooked_bushmeat",
+      "required": false
+    },
+    {
+      "id": "natures_delight:alfredo_pasta",
+      "required": false
+    },
+    {
+      "id": "natures_delight:fafaru",
+      "required": false
+    }
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/items/melee_weapons.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/items/melee_weapons.json
@@ -1,0 +1,387 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:diamond_axe",
+    "minecraft:diamond_sword",
+    "minecraft:golden_axe",
+    "minecraft:golden_sword",
+    "minecraft:iron_axe",
+    "minecraft:iron_sword",
+    "minecraft:netherite_axe",
+    "minecraft:netherite_sword",
+    "minecraft:stone_axe",
+    "minecraft:stone_sword",
+    "minecraft:trident",
+    "minecraft:wooden_axe",
+    "minecraft:wooden_sword",
+
+    {
+      "id": "betterend:aeternium_sword",
+      "required": false
+    },
+    {
+      "id": "betterend:aeternium_axe",
+      "required": false
+    },
+    {
+      "id": "betterend:aeternium_hammer",
+      "required": false
+    },
+    {
+      "id": "betterend:thallasium_sword",
+      "required": false
+    },
+    {
+      "id": "betterend:thallasium_axe",
+      "required": false
+    },
+    {
+      "id": "betterend:thallasium_hammer",
+      "required": false
+    },
+    {
+      "id": "betterend:terminite_sword",
+      "required": false
+    },
+    {
+      "id": "betterend:terminite_axe",
+      "required": false
+    },
+    {
+      "id": "betterend:terminite_hammer",
+      "required": false
+    },
+    {
+      "id": "betterend:iron_hammer",
+      "required": false
+    },
+    {
+      "id": "betterend:golden_hammer",
+      "required": false
+    },
+    {
+      "id": "betterend:diamond_hammer",
+      "required": false
+    },
+    {
+      "id": "betterend:netherite_hammer",
+      "required": false
+    },
+    {
+      "id": "betternether:cincinnasite_sword",
+      "required": false
+    },
+    {
+      "id": "betternether:cincinnasite_axe",
+      "required": false
+    },
+    {
+      "id": "betternether:nether_ruby_sword",
+      "required": false
+    },
+    {
+      "id": "betternether:nether_ruby_axe",
+      "required": false
+    },
+    {
+      "id": "betternether:cincinnasite_sword_diamond",
+      "required": false
+    },
+    {
+      "id": "betternether:cincinnasite_axe_diamond",
+      "required": false
+    },
+    {
+      "id": "betternether:flaming_ruby_sword",
+      "required": false
+    },
+    {
+      "id": "betternether:flaming_ruby_axe",
+      "required": false
+    },
+    {
+      "id": "deeperdarker:resonarium_sword",
+      "required": false
+    },
+    {
+      "id": "deeperdarker:resonarium_axe",
+      "required": false
+    },
+    {
+      "id": "deeperdarker:warden_sword",
+      "required": false
+    },
+    {
+      "id": "deeperdarker:warden_axe",
+      "required": false
+    },
+    {
+      "id": "paradise_lost:olvite_sword",
+      "required": false
+    },
+    {
+      "id": "paradise_lost:olvite_axe",
+      "required": false
+    },
+    {
+      "id": "paradise_lost:surtrum_sword",
+      "required": false
+    },
+    {
+      "id": "paradise_lost:surtrum_axe",
+      "required": false
+    },
+    {
+      "id": "paradise_lost:glazed_gold_sword",
+      "required": false
+    },
+    {
+      "id": "paradise_lost:glazed_gold_axe",
+      "required": false
+    },
+    {
+      "id": "twilightforest:ironwood_sword",
+      "required": false
+    },
+    {
+      "id": "twilightforest:ironwood_axe",
+      "required": false
+    },
+    {
+      "id": "twilightforest:steeleaf_sword",
+      "required": false
+    },
+    {
+      "id": "twilightforest:steeleaf_axe",
+      "required": false
+    },
+    {
+      "id": "twilightforest:knightmetal_sword",
+      "required": false
+    },
+    {
+      "id": "twilightforest:knightmetal_axe",
+      "required": false
+    },
+    {
+      "id": "twilightforest:fiery_sword",
+      "required": false
+    },
+    {
+      "id": "twilightforest:gold_minotaur_axe",
+      "required": false
+    },
+    {
+      "id": "twilightforest:diamond_minotaur_axe",
+      "required": false
+    },
+    {
+      "id": "twilightforest:glass_sword",
+      "required": false
+    },
+    {
+      "id": "archers:flint_spear",
+      "required": false
+    },
+    {
+      "id": "archers:iron_spear",
+      "required": false
+    },
+    {
+      "id": "archers:golden_spear",
+      "required": false
+    },
+    {
+      "id": "archers:diamond_spear",
+      "required": false
+    },
+    {
+      "id": "archers:netherite_spear",
+      "required": false
+    },
+    {
+      "id": "archers:aeternium_spear",
+      "required": false
+    },
+    {
+      "id": "archers:ruby_spear",
+      "required": false
+    },
+    {
+      "id": "paladins:stone_claymore",
+      "required": false
+    },
+    {
+      "id": "paladins:iron_claymore",
+      "required": false
+    },
+    {
+      "id": "paladins:golden_claymore",
+      "required": false
+    },
+    {
+      "id": "paladins:diamond_claymore",
+      "required": false
+    },
+    {
+      "id": "paladins:netherite_claymore",
+      "required": false
+    },
+    {
+      "id": "paladins:ruby_claymore",
+      "required": false
+    },
+    {
+      "id": "paladins:aeternium_claymore",
+      "required": false
+    },
+    {
+      "id": "paladins:wooden_great_hammer",
+      "required": false
+    },
+    {
+      "id": "paladins:stone_great_hammer",
+      "required": false
+    },
+    {
+      "id": "paladins:iron_great_hammer",
+      "required": false
+    },
+    {
+      "id": "paladins:golden_great_hammer",
+      "required": false
+    },
+    {
+      "id": "paladins:diamond_great_hammer",
+      "required": false
+    },
+    {
+      "id": "paladins:netherite_great_hammer",
+      "required": false
+    },
+    {
+      "id": "paladins:ruby_great_hammer",
+      "required": false
+    },
+    {
+      "id": "paladins:aeternium_great_hammer",
+      "required": false
+    },
+    {
+      "id": "paladins:iron_mace",
+      "required": false
+    },
+    {
+      "id": "paladins:golden_mace",
+      "required": false
+    },
+    {
+      "id": "paladins:diamond_mace",
+      "required": false
+    },
+    {
+      "id": "paladins:netherite_mace",
+      "required": false
+    },
+    {
+      "id": "paladins:ruby_mace",
+      "required": false
+    },
+    {
+      "id": "paladins:aeternium_mace",
+      "required": false
+    },
+    {
+      "id": "rogues:flint_dagger",
+      "required": false
+    },
+    {
+      "id": "rogues:iron_dagger",
+      "required": false
+    },
+    {
+      "id": "rogues:golden_dagger",
+      "required": false
+    },
+    {
+      "id": "rogues:diamond_dagger",
+      "required": false
+    },
+    {
+      "id": "rogues:netherite_dagger",
+      "required": false
+    },
+    {
+      "id": "rogues:ruby_dagger",
+      "required": false
+    },
+    {
+      "id": "rogues:aeternium_dagger",
+      "required": false
+    },
+    {
+      "id": "rogues:iron_sickle",
+      "required": false
+    },
+    {
+      "id": "rogues:golden_sickle",
+      "required": false
+    },
+    {
+      "id": "rogues:diamond_sickle",
+      "required": false
+    },
+    {
+      "id": "rogues:netherite_sickle",
+      "required": false
+    },
+    {
+      "id": "rogues:ruby_sickle",
+      "required": false
+    },
+    {
+      "id": "rogues:aeternium_sickle",
+      "required": false
+    },
+    {
+      "id": "rogues:stone_double_axe",
+      "required": false
+    },
+    {
+      "id": "rogues:iron_double_axe",
+      "required": false
+    },
+    {
+      "id": "rogues:golden_double_axe",
+      "required": false
+    },
+    {
+      "id": "rogues:diamond_double_axe",
+      "required": false
+    },
+    {
+      "id": "rogues:netherite_double_axe",
+      "required": false
+    },
+    {
+      "id": "rogues:ruby_double_axe",
+      "required": false
+    },
+    {
+      "id": "rogues:aeternium_double_axe",
+      "required": false
+    },
+    {
+      "id": "tide:sailfish",
+      "required": false
+    },
+    {
+      "id": "tide:swordfish",
+      "required": false
+    },
+    {
+      "id": "tide:blazing_swordfish",
+      "required": false
+    }
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/items/ranged_weapons.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/items/ranged_weapons.json
@@ -1,0 +1,84 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "#origins:ranged_weapons",
+      "required": false
+    },
+    "minecraft:bow",
+    "minecraft:crossbow",
+    "minecraft:trident",
+    {
+      "id": "archers:composite_longbow",
+      "required": false
+    },
+    {
+      "id": "archers:mechanic_shortbow",
+      "required": false
+    },
+    {
+      "id": "archers:royal_longbow",
+      "required": false
+    },
+    {
+      "id": "archers:netherite_shortbow",
+      "required": false
+    },
+    {
+      "id": "archers:netherite_longbow",
+      "required": false
+    },
+    {
+      "id": "archers:rapid_crossbow",
+      "required": false
+    },
+    {
+      "id": "archers:heavy_crossbow",
+      "required": false
+    },
+    {
+      "id": "archers:netherite_rapid_crossbow",
+      "required": false
+    },
+    {
+      "id": "archers:netherite_heavy_crossbow",
+      "required": false
+    },
+    {
+      "id": "archers:crystal_shortbow",
+      "required": false
+    },
+    {
+      "id": "archers:crystal_longbow",
+      "required": false
+    },
+    {
+      "id": "archers:ruby_rapid_crossbow",
+      "required": false
+    },
+    {
+      "id": "archers:ruby_heavy_crossbow",
+      "required": false
+    },
+    {
+      "id": "tide:starlight_bow",
+      "required": false
+    },
+    {
+      "id": "twilightforest:triple_bow",
+      "required": false
+    },
+    {
+      "id": "twilightforest:seeker_bow",
+      "required": false
+    },
+    {
+      "id": "twilightforest:ice_bow",
+      "required": false
+    },
+    {
+      "id": "twilightforest:ender_bow",
+      "required": false
+    }
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/items/raw_fish.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/items/raw_fish.json
@@ -1,0 +1,557 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:cod",
+    "minecraft:pufferfish",
+    "minecraft:salmon",
+    "minecraft:tropical_fish",
+    {
+      "id": "farmersdelight:cod_slice",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:salmon_slice",
+      "required": false
+    },
+    {
+      "id": "tide:clayfish",
+      "required": false
+    },
+    {
+      "id": "tide:hardened_clayfish",
+      "required": false
+    },
+    {
+      "id": "tide:guppy",
+      "required": false
+    },
+    {
+      "id": "tide:cave_eel",
+      "required": false
+    },
+    {
+      "id": "tide:crystal_shrimp",
+      "required": false
+    },
+    {
+      "id": "tide:iron_tetra",
+      "required": false
+    },
+    {
+      "id": "tide:gilded_minnow",
+      "required": false
+    },
+    {
+      "id": "tide:crystalline_carp",
+      "required": false
+    },
+    {
+      "id": "tide:lapis_lanternfish",
+      "required": false
+    },
+    {
+      "id": "tide:luminescent_jellyfish",
+      "required": false
+    },
+    {
+      "id": "tide:bedrock_tetra",
+      "required": false
+    },
+    {
+      "id": "tide:endstone_perch",
+      "required": false
+    },
+    {
+      "id": "tide:enderfin",
+      "required": false
+    },
+    {
+      "id": "tide:endergazer",
+      "required": false
+    },
+    {
+      "id": "tide:purpur_pike",
+      "required": false
+    },
+    {
+      "id": "tide:chorus_cod",
+      "required": false
+    },
+    {
+      "id": "tide:elytrout",
+      "required": false
+    },
+    {
+      "id": "tide:prarie_pike",
+      "required": false
+    },
+    {
+      "id": "tide:sandskipper",
+      "required": false
+    },
+    {
+      "id": "tide:blossom_bass",
+      "required": false
+    },
+    {
+      "id": "tide:oakfish",
+      "required": false
+    },
+    {
+      "id": "tide:frostbite_flounder",
+      "required": false
+    },
+    {
+      "id": "tide:mirage_catfish",
+      "required": false
+    },
+    {
+      "id": "tide:echofin_snapper",
+      "required": false
+    },
+    {
+      "id": "tide:sunspike_goby",
+      "required": false
+    },
+    {
+      "id": "tide:birch_trout",
+      "required": false
+    },
+    {
+      "id": "tide:stonefish",
+      "required": false
+    },
+    {
+      "id": "tide:dripstone_darter",
+      "required": false
+    },
+    {
+      "id": "tide:slimefin_snapper",
+      "required": false
+    },
+    {
+      "id": "tide:sporestalker",
+      "required": false
+    },
+    {
+      "id": "tide:leafback",
+      "required": false
+    },
+    {
+      "id": "tide:fluttergill",
+      "required": false
+    },
+    {
+      "id": "tide:pine_perch",
+      "required": false
+    },
+    {
+      "id": "tide:ember_koi",
+      "required": false
+    },
+    {
+      "id": "tide:inferno_guppy",
+      "required": false
+    },
+    {
+      "id": "tide:obsidian_pike",
+      "required": false
+    },
+    {
+      "id": "tide:volcano_tuna",
+      "required": false
+    },
+    {
+      "id": "tide:magma_mackerel",
+      "required": false
+    },
+    {
+      "id": "tide:warped_guppy",
+      "required": false
+    },
+    {
+      "id": "tide:crimson_fangjaw",
+      "required": false
+    },
+    {
+      "id": "tide:ashen_perch",
+      "required": false
+    },
+    {
+      "id": "tide:witherfin",
+      "required": false
+    },
+    {
+      "id": "tide:soulscaler",
+      "required": false
+    },
+    {
+      "id": "tide:aquathorn",
+      "required": false
+    },
+    {
+      "id": "tide:midas_fish",
+      "required": false
+    },
+    {
+      "id": "tide:voidseeker",
+      "required": false
+    },
+    {
+      "id": "tide:shooting_starfish",
+      "required": false
+    },
+    {
+      "id": "tide:fish_slice",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:fugu_roll",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:fugu_slice",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:stuffed_cod",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:cabbage_wrapped_elder_guardian",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:elder_guardian_roll",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:elder_guardian_slice",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:elder_guardian_slab",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:guardian_tail",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:tentacle_on_a_stick",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:cut_tentacles",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:tentacles",
+      "required": false
+    },
+    {
+      "id": "naturalist:bass",
+      "required": false
+    },
+    {
+      "id": "naturalist:catfish",
+      "required": false
+    },
+    {
+      "id": "betterend:end_fish_raw",
+      "required": false
+    },
+    {
+      "id": "crittersandcompanions:koi_fish",
+      "required": false
+    },
+    {
+      "id": "tide:rainbow_trout",
+      "required": false
+    },
+    {
+      "id": "tide:brook_trout",
+      "required": false
+    },
+    {
+      "id": "tide:largemouth_bass",
+      "required": false
+    },
+    {
+      "id": "tide:smallmouth_bass",
+      "required": false
+    },
+    {
+      "id": "tide:white_crappie",
+      "required": false
+    },
+    {
+      "id": "tide:black_crappie",
+      "required": false
+    },
+    {
+      "id": "tide:yellow_perch",
+      "required": false
+    },
+    {
+      "id": "tide:carp",
+      "required": false
+    },
+    {
+      "id": "tide:pike",
+      "required": false
+    },
+    {
+      "id": "tide:bluegill",
+      "required": false
+    },
+    {
+      "id": "tide:catfish",
+      "required": false
+    },
+    {
+      "id": "tide:walleye",
+      "required": false
+    },
+    {
+      "id": "tide:arapaima",
+      "required": false
+    },
+    {
+      "id": "tide:sand_tiger_shark",
+      "required": false
+    },
+    {
+      "id": "tide:slimy_salmon",
+      "required": false
+    },
+    {
+      "id": "tide:sturgeon",
+      "required": false
+    },
+    {
+      "id": "tide:spore_stalker",
+      "required": false
+    },
+    {
+      "id": "tide:mooneye",
+      "required": false
+    },
+    {
+      "id": "tide:bull_shark",
+      "required": false
+    },
+    {
+      "id": "tide:ocean_perch",
+      "required": false
+    },
+    {
+      "id": "tide:red_snapper",
+      "required": false
+    },
+    {
+      "id": "tide:flounder",
+      "required": false
+    },
+    {
+      "id": "tide:anchovy",
+      "required": false
+    },
+    {
+      "id": "tide:tuna",
+      "required": false
+    },
+    {
+      "id": "tide:mackarel",
+      "required": false
+    },
+    {
+      "id": "tide:snook",
+      "required": false
+    },
+    {
+      "id": "tide:angelfish",
+      "required": false
+    },
+    {
+      "id": "tide:mahi_mahi",
+      "required": false
+    },
+    {
+      "id": "tide:sailfish",
+      "required": false
+    },
+    {
+      "id": "tide:swordfish",
+      "required": false
+    },
+    {
+      "id": "tide:manta_ray",
+      "required": false
+    },
+    {
+      "id": "tide:neptune_koi",
+      "required": false
+    },
+    {
+      "id": "tide:pluto_snail",
+      "required": false
+    },
+    {
+      "id": "tide:sun_emblem",
+      "required": false
+    },
+    {
+      "id": "tide:saturn_cuttlefish",
+      "required": false
+    },
+    {
+      "id": "tide:marstilus",
+      "required": false
+    },
+    {
+      "id": "tide:uranias_pisces",
+      "required": false
+    },
+    {
+      "id": "tide:great_white_shark",
+      "required": false
+    },
+    {
+      "id": "tide:coelacanth",
+      "required": false
+    },
+    {
+      "id": "tide:cave_crawler",
+      "required": false
+    },
+    {
+      "id": "tide:deep_grouper",
+      "required": false
+    },
+    {
+      "id": "tide:shadow_snapper",
+      "required": false
+    },
+    {
+      "id": "tide:glowfish",
+      "required": false
+    },
+    {
+      "id": "tide:anglerfish",
+      "required": false
+    },
+    {
+      "id": "tide:abyss_angler",
+      "required": false
+    },
+    {
+      "id": "tide:chasm_eel",
+      "required": false
+    },
+    {
+      "id": "tide:echo_snapper",
+      "required": false
+    },
+    {
+      "id": "tide:devils_hole_pupfish",
+      "required": false
+    },
+    {
+      "id": "tide:incandescent_larva",
+      "required": false
+    },
+    {
+      "id": "tide:bedrock_bug",
+      "required": false
+    },
+    {
+      "id": "tide:sleepy_carp",
+      "required": false
+    },
+    {
+      "id": "tide:blue_neonfish",
+      "required": false
+    },
+    {
+      "id": "tide:judgement_fish",
+      "required": false
+    },
+    {
+      "id": "tide:deep_blue",
+      "required": false
+    },
+    {
+      "id": "tide:nephrosilu",
+      "required": false
+    },
+    {
+      "id": "tide:vengeance",
+      "required": false
+    },
+    {
+      "id": "tide:pentapus",
+      "required": false
+    },
+    {
+      "id": "tide:darkness_eater",
+      "required": false
+    },
+    {
+      "id": "tide:shadow_shark",
+      "required": false
+    },
+    {
+      "id": "tide:alpha_fish",
+      "required": false
+    },
+    {
+      "id": "tide:ash_perch",
+      "required": false
+    },
+    {
+      "id": "tide:soulscale",
+      "required": false
+    },
+    {
+      "id": "tide:blazing_swordfish",
+      "required": false
+    },
+    {
+      "id": "tide:pale_clubfish",
+      "required": false
+    },
+    {
+      "id": "tide:amber_rockfish",
+      "required": false
+    },
+    {
+      "id": "tide:ender_glider",
+      "required": false
+    },
+    {
+      "id": "tide:violet_carp",
+      "required": false
+    },
+    {
+      "id": "tide:red_40",
+      "required": false
+    },
+    {
+      "id": "tide:dutchman_sock",
+      "required": false
+    },
+    {
+      "id": "tide:mantyvern",
+      "required": false
+    },
+    {
+      "id": "tide:snatcher_squid",
+      "required": false
+    },
+    {
+      "id": "tide:dragon_fish",
+      "required": false
+    }
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/items/raw_meat.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/items/raw_meat.json
@@ -1,0 +1,434 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:beef",
+    "minecraft:chicken",
+    "minecraft:cod",
+    "minecraft:mutton",
+    "minecraft:porkchop",
+    "minecraft:pufferfish",
+    "minecraft:rabbit",
+    "minecraft:salmon",
+    "minecraft:tropical_fish",
+    {
+      "id": "farmersdelight:bacon",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:chicken_cuts",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:cod_slice",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:dog_food",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:ham",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:minced_beef",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:mutton_chops",
+      "required": false
+    },
+    {
+      "id": "farmersdelight:salmon_slice",
+      "required": false
+    },
+    {
+      "id": "tide:mint_carp",
+      "required": false
+    },
+    {
+      "id": "tide:trout",
+      "required": false
+    },
+    {
+      "id": "tide:angelfish",
+      "required": false
+    },
+    {
+      "id": "tide:barracuda",
+      "required": false
+    },
+    {
+      "id": "tide:sailfish",
+      "required": false
+    },
+    {
+      "id": "tide:catfish",
+      "required": false
+    },
+    {
+      "id": "tide:pike",
+      "required": false
+    },
+    {
+      "id": "tide:bass",
+      "required": false
+    },
+    {
+      "id": "tide:tuna",
+      "required": false
+    },
+    {
+      "id": "tide:yellow_perch",
+      "required": false
+    },
+    {
+      "id": "tide:ocean_perch",
+      "required": false
+    },
+    {
+      "id": "tide:bluegill",
+      "required": false
+    },
+    {
+      "id": "tide:mackerel",
+      "required": false
+    },
+    {
+      "id": "tide:glowfish",
+      "required": false
+    },
+    {
+      "id": "tide:anglerfish",
+      "required": false
+    },
+    {
+      "id": "tide:cave_crawler",
+      "required": false
+    },
+    {
+      "id": "tide:abyss_angler",
+      "required": false
+    },
+    {
+      "id": "tide:shadow_snapper",
+      "required": false
+    },
+    {
+      "id": "tide:deep_grouper",
+      "required": false
+    },
+    {
+      "id": "tide:fish_slice",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:fugu_roll",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:fugu_slice",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:stuffed_cod",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:cabbage_wrapped_elder_guardian",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:elder_guardian_roll",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:elder_guardian_slice",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:elder_guardian_slab",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:guardian_tail",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:tentacle_on_a_stick",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:cut_tentacles",
+      "required": false
+    },
+    {
+      "id": "oceansdelight:tentacles",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:hoglin_loin",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:strider_slice",
+      "required": false
+    },
+    {
+      "id": "nethersdelight:ground_strider",
+      "required": false
+    },
+    {
+      "id": "tide:clayfish",
+      "required": false
+    },
+    {
+      "id": "tide:hardened_clayfish",
+      "required": false
+    },
+    {
+      "id": "tide:guppy",
+      "required": false
+    },
+    {
+      "id": "tide:cave_eel",
+      "required": false
+    },
+    {
+      "id": "tide:crystal_shrimp",
+      "required": false
+    },
+    {
+      "id": "tide:iron_tetra",
+      "required": false
+    },
+    {
+      "id": "tide:gilded_minnow",
+      "required": false
+    },
+    {
+      "id": "tide:crystalline_carp",
+      "required": false
+    },
+    {
+      "id": "tide:lapis_lanternfish",
+      "required": false
+    },
+    {
+      "id": "tide:luminescent_jellyfish",
+      "required": false
+    },
+    {
+      "id": "tide:bedrock_tetra",
+      "required": false
+    },
+    {
+      "id": "tide:endstone_perch",
+      "required": false
+    },
+    {
+      "id": "tide:enderfin",
+      "required": false
+    },
+    {
+      "id": "tide:endergazer",
+      "required": false
+    },
+    {
+      "id": "tide:purpur_pike",
+      "required": false
+    },
+    {
+      "id": "tide:chorus_cod",
+      "required": false
+    },
+    {
+      "id": "tide:elytrout",
+      "required": false
+    },
+    {
+      "id": "tide:prarie_pike",
+      "required": false
+    },
+    {
+      "id": "tide:sandskipper",
+      "required": false
+    },
+    {
+      "id": "tide:blossom_bass",
+      "required": false
+    },
+    {
+      "id": "tide:oakfish",
+      "required": false
+    },
+    {
+      "id": "tide:frostbite_flounder",
+      "required": false
+    },
+    {
+      "id": "tide:mirage_catfish",
+      "required": false
+    },
+    {
+      "id": "tide:echofin_snapper",
+      "required": false
+    },
+    {
+      "id": "tide:sunspike_goby",
+      "required": false
+    },
+    {
+      "id": "tide:birch_trout",
+      "required": false
+    },
+    {
+      "id": "tide:stonefish",
+      "required": false
+    },
+    {
+      "id": "tide:dripstone_darter",
+      "required": false
+    },
+    {
+      "id": "tide:slimefin_snapper",
+      "required": false
+    },
+    {
+      "id": "tide:sporestalker",
+      "required": false
+    },
+    {
+      "id": "tide:leafback",
+      "required": false
+    },
+    {
+      "id": "tide:fluttergill",
+      "required": false
+    },
+    {
+      "id": "tide:pine_perch",
+      "required": false
+    },
+    {
+      "id": "tide:ember_koi",
+      "required": false
+    },
+    {
+      "id": "tide:inferno_guppy",
+      "required": false
+    },
+    {
+      "id": "tide:obsidian_pike",
+      "required": false
+    },
+    {
+      "id": "tide:volcano_tuna",
+      "required": false
+    },
+    {
+      "id": "tide:magma_mackerel",
+      "required": false
+    },
+    {
+      "id": "tide:warped_guppy",
+      "required": false
+    },
+    {
+      "id": "tide:crimson_fangjaw",
+      "required": false
+    },
+    {
+      "id": "tide:ashen_perch",
+      "required": false
+    },
+    {
+      "id": "tide:witherfin",
+      "required": false
+    },
+    {
+      "id": "tide:soulscaler",
+      "required": false
+    },
+    {
+      "id": "tide:aquathorn",
+      "required": false
+    },
+    {
+      "id": "tide:midas_fish",
+      "required": false
+    },
+    {
+      "id": "tide:voidseeker",
+      "required": false
+    },
+    {
+      "id": "tide:shooting_starfish",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:minced_beef",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:lamb_ham",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:chicken_parts",
+      "required": false
+    },
+    {
+      "id": "farm_and_charm:bacon",
+      "required": false
+    },
+    {
+      "id": "meadow:raw_buffalo_meat",
+      "required": false
+    },
+    {
+      "id": "wildernature:bison_meat",
+      "required": false
+    },
+    {
+      "id": "wildernature:cassowary_meat",
+      "required": false
+    },
+    {
+      "id": "wildernature:pelican_meat",
+      "required": false
+    },
+    {
+      "id": "wildernature:turkey_meat",
+      "required": false
+    },
+    {
+      "id": "wildernature:venison",
+      "required": false
+    },
+    {
+      "id": "naturalist:bass",
+      "required": false
+    },
+    {
+      "id": "naturalist:catfish",
+      "required": false
+    },
+    {
+      "id": "naturalist:duck",
+      "required": false
+    },
+    {
+      "id": "naturalist:lizard_tail",
+      "required": false
+    },
+    {
+      "id": "naturalist:venison",
+      "required": false
+    },
+    {
+      "id": "naturalist:bushmeat",
+      "required": false
+    }
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/items/shields.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/items/shields.json
@@ -1,0 +1,42 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "#origins:shield",
+      "required": false
+    },
+    "minecraft:shield",
+    {
+      "id": "endermanoverhaul:corrupted_shield",
+      "required": false
+    },
+    {
+      "id": "paladins:iron_kite_shield",
+      "required": false
+    },
+    {
+      "id": "paladins:golden_kite_shield",
+      "required": false
+    },
+    {
+      "id": "paladins:diamond_kite_shield",
+      "required": false
+    },
+    {
+      "id": "paladins:netherite_kite_shield",
+      "required": false
+    },
+    {
+      "id": "paladins:ruby_kite_shield",
+      "required": false
+    },
+    {
+      "id": "paladins:aeternium_kite_shield",
+      "required": false
+    },
+    {
+      "id": "twilightforest:knightmetal_shield",
+      "required": false
+	}
+  ]
+}

--- a/src/main/resources/data/shape-shifter-curse/tags/items/tools.json
+++ b/src/main/resources/data/shape-shifter-curse/tags/items/tools.json
@@ -1,0 +1,29 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:diamond_axe",
+    "minecraft:diamond_hoe",
+    "minecraft:diamond_pickaxe",
+    "minecraft:diamond_shovel",
+    "minecraft:golden_axe",
+    "minecraft:golden_hoe",
+    "minecraft:golden_pickaxe",
+    "minecraft:golden_shovel",
+    "minecraft:iron_axe",
+    "minecraft:iron_hoe",
+    "minecraft:iron_pickaxe",
+    "minecraft:iron_shovel",
+    "minecraft:netherite_axe",
+    "minecraft:netherite_hoe",
+    "minecraft:netherite_pickaxe",
+    "minecraft:netherite_shovel",
+    "minecraft:stone_axe",
+    "minecraft:stone_hoe",
+    "minecraft:stone_pickaxe",
+    "minecraft:stone_shovel",
+    "minecraft:wooden_axe",
+    "minecraft:wooden_hoe",
+    "minecraft:wooden_pickaxe",
+    "minecraft:wooden_shovel"
+  ]
+}


### PR DESCRIPTION
没发1.10.0 不知道为什么要用1.10.1

迁移用的是正则`(?:(?<!"tag": ")|^)origins:`批量替换 可能需要测试一下Power能否正常工作(仅测试一下没弹日志) tag直接复制了Origins的Tag 并让新tag包着Origins的Tag(仅限Origins原版就有的Tag)

`ignore_armor_restriction` tag 其实也能用 `morph_scale_item` tag 来实现 但考虑到未来SSC或拓展可能会对塑形物品提供特殊效果 所以还是新加tag吧