### PR TITLE
将饰品Power挂载点由form改为layer 修复攀爬无法悬停的Bug(或许是Bug吧)

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalPowers.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalPowers.java
@@ -90,6 +90,7 @@ public class AdditionalPowers {
         register(TANFormTemperatureModifierPower.createFactory());
         register(TANPreventDirtyWaterThirstEffectPower.createFactory());
         register(TANModifyThirstExhaustionPower.createFactory());
+        register(ClimbingEXPower.createFactory());
     }
 
     public static PowerFactory<?> register(PowerFactory<?> powerFactory) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/ClimbingEXPower.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/ClimbingEXPower.java
@@ -1,0 +1,67 @@
+package net.onixary.shapeShifterCurseFabric.additional_power;
+
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.ClimbingPower;
+import io.github.apace100.apoli.power.PowerType;
+import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+
+import java.util.function.Predicate;
+
+public class ClimbingEXPower extends ClimbingPower {
+    public final Predicate<Entity> startClimbCondition;
+    public final Predicate<Entity> continueClimbCondition;
+    public final Predicate<Entity> holdingCondition;
+    public final boolean allowHolding;
+
+    public boolean lastIsClimbing = false;
+
+    public ClimbingEXPower(PowerType<?> type, LivingEntity entity, Predicate<Entity> startClimbCondition, Predicate<Entity> continueClimbCondition, Predicate<Entity> holdingCondition, boolean allowHolding) {
+        super(type, entity, holdingCondition, allowHolding);
+        this.startClimbCondition = startClimbCondition;
+        this.continueClimbCondition = continueClimbCondition;
+        this.holdingCondition = holdingCondition;
+        this.allowHolding = allowHolding;
+    }
+
+    public boolean canHold() {
+        if (!this.allowHolding) {
+            return false;
+        }
+        if (this.holdingCondition == null) {
+            return entity.isSneaking();
+        }
+        return this.holdingCondition.test(this.entity);
+    }
+
+    @Override
+    public boolean isActive() {
+        if (!super.isActive()) {
+            return false;
+        }
+        boolean active;
+        if (lastIsClimbing) {
+            active = continueClimbCondition == null || continueClimbCondition.test(this.entity);
+        } else {
+            active = startClimbCondition == null || startClimbCondition.test(this.entity);
+        }
+        lastIsClimbing = active;
+        return active;
+    }
+
+    public static PowerFactory<?> createFactory() {
+        return new PowerFactory<>(
+                ShapeShifterCurseFabric.identifier("climbing_ex"),
+                new SerializableData()
+                        .add("start_climb_condition", ApoliDataTypes.ENTITY_CONDITION, null)
+                        .add("continue_climb_condition", ApoliDataTypes.ENTITY_CONDITION, null)
+                        .add("holding_condition", ApoliDataTypes.ENTITY_CONDITION, null)
+                        .add("allow_holding", SerializableDataTypes.BOOLEAN, true),
+                data -> (type, entity) -> new ClimbingEXPower(type, entity, data.get("start_climb_condition"), data.get("continue_climb_condition"), data.get("holding_condition"), data.get("allow_holding"))
+        ).allowCondition();
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/v3/AnimSystem.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/v3/AnimSystem.java
@@ -28,7 +28,6 @@ public class AnimSystem {
         public IForm playerForm;
         public boolean IsOnGround = true;
         public Vec3d LastPosition;
-        public long LastPosYChange = 0;  // 持续增长使用long防止溢出 顺便可以不用做最大值判断
         public long ContinueSwingAnimCounter = 0;  // 持续增长使用long防止溢出 顺便可以不用做最大值判断
         public boolean IsWalking = false;
         public NbtCompound customData;  // 用于存储其他拓展Mod的数据 在本模组中不使用
@@ -88,22 +87,26 @@ public class AnimSystem {
         return null;
     }
 
+    public static boolean checkOnGroundSuper(PlayerEntity player) {
+        if (player.isOnGround()) {
+            return true;
+        }
+        if (player.getAbilities().flying) {
+            return false;
+        }
+        return !player.getWorld().isSpaceEmpty(player.getBoundingBox().offset(0, -0.01, 0).withMaxY(player.getY()));
+    }
+
     private void PreProcessAnimSystemData() {
         this.data.playerForm = FormTextureUtils.getPlayerForm_Render(this.player);
         this.data.IsWalking = !this.data.LastPosition.equals(this.player.getPos());
-        if (this.player.getPos().getY() == this.data.LastPosition.getY()) {
-            this.data.LastPosYChange ++;
-        }
-        else {
-            this.data.LastPosYChange = 0;
-        }
         if (this.player.handSwinging) {
             this.data.ContinueSwingAnimCounter ++;
         }
         else {
             this.data.ContinueSwingAnimCounter = 0;
         }
-        this.data.IsOnGround = (player.isOnGround() || (!player.getAbilities().flying && this.data.LastPosYChange > 10));
+        this.data.IsOnGround = checkOnGroundSuper(this.player);
         this.NPPA_Tick();
     }
 

--- a/src/main/resources/data/shape-shifter-curse/accessory_power/amulet_bracelet.json
+++ b/src/main/resources/data/shape-shifter-curse/accessory_power/amulet_bracelet.json
@@ -5,55 +5,57 @@
       "add": [],
       "remove": []
     },
-    "forms": {
-      "shape-shifter-curse:familiar_fox_0": {
-        "add": [
-          "shape-shifter-curse:witch_friendly_neutral"
-        ],
-        "remove": [
-          "shape-shifter-curse:witch_friendly",
-          "shape-shifter-curse:form_familiar_fox_0_dizzy_when_attack_witch"
-        ]
-      },
-      "shape-shifter-curse:familiar_fox_1": {
-        "add": [
-          "shape-shifter-curse:witch_friendly_neutral",
-          "shape-shifter-curse:pillager_friendly_neutral"
-        ],
-        "remove": [
-          "shape-shifter-curse:witch_friendly",
-          "shape-shifter-curse:pillager_friendly",
-          "shape-shifter-curse:form_familiar_fox_1_dizzy_when_attack_illager"
-        ]
-      },
-      "shape-shifter-curse:familiar_fox_2": {
-        "add": [
-          "shape-shifter-curse:witch_friendly_neutral",
-          "shape-shifter-curse:pillager_friendly_neutral",
-          "shape-shifter-curse:form_familiar_fox_amulet_bracelet_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:witch_friendly",
-          "shape-shifter-curse:pillager_friendly",
-          "shape-shifter-curse:form_familiar_fox_2_attract_to_witch",
-          "shape-shifter-curse:form_familiar_fox_3_no_attack_witch",
-          "shape-shifter-curse:form_familiar_fox_3_use_enemy_creature"
-        ]
-      },
-      "shape-shifter-curse:familiar_fox_3": {
-        "add": [
-          "shape-shifter-curse:witch_friendly_neutral",
-          "shape-shifter-curse:pillager_friendly_neutral",
-          "shape-shifter-curse:form_familiar_fox_amulet_bracelet_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:witch_friendly",
-          "shape-shifter-curse:pillager_friendly",
-          "shape-shifter-curse:form_familiar_fox_3_no_attack_witch",
-          "shape-shifter-curse:form_familiar_fox_3_attract_to_witch2",
-          "shape-shifter-curse:form_familiar_fox_3_hurt_when_attack_witch",
-          "shape-shifter-curse:form_familiar_fox_3_use_enemy_creature"
-        ]
+    "layers": {
+      "origins:origin": {
+        "shape-shifter-curse:form_familiar_fox_0": {
+          "add": [
+            "shape-shifter-curse:witch_friendly_neutral"
+          ],
+          "remove": [
+            "shape-shifter-curse:witch_friendly",
+            "shape-shifter-curse:form_familiar_fox_0_dizzy_when_attack_witch"
+          ]
+        },
+        "shape-shifter-curse:form_familiar_fox_1": {
+          "add": [
+            "shape-shifter-curse:witch_friendly_neutral",
+            "shape-shifter-curse:pillager_friendly_neutral"
+          ],
+          "remove": [
+            "shape-shifter-curse:witch_friendly",
+            "shape-shifter-curse:pillager_friendly",
+            "shape-shifter-curse:form_familiar_fox_1_dizzy_when_attack_illager"
+          ]
+        },
+        "shape-shifter-curse:form_familiar_fox_2": {
+          "add": [
+            "shape-shifter-curse:witch_friendly_neutral",
+            "shape-shifter-curse:pillager_friendly_neutral",
+            "shape-shifter-curse:form_familiar_fox_amulet_bracelet_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:witch_friendly",
+            "shape-shifter-curse:pillager_friendly",
+            "shape-shifter-curse:form_familiar_fox_2_attract_to_witch",
+            "shape-shifter-curse:form_familiar_fox_3_no_attack_witch",
+            "shape-shifter-curse:form_familiar_fox_3_use_enemy_creature"
+          ]
+        },
+        "shape-shifter-curse:form_familiar_fox_3": {
+          "add": [
+            "shape-shifter-curse:witch_friendly_neutral",
+            "shape-shifter-curse:pillager_friendly_neutral",
+            "shape-shifter-curse:form_familiar_fox_amulet_bracelet_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:witch_friendly",
+            "shape-shifter-curse:pillager_friendly",
+            "shape-shifter-curse:form_familiar_fox_3_no_attack_witch",
+            "shape-shifter-curse:form_familiar_fox_3_attract_to_witch2",
+            "shape-shifter-curse:form_familiar_fox_3_hurt_when_attack_witch",
+            "shape-shifter-curse:form_familiar_fox_3_use_enemy_creature"
+          ]
+        }
       }
     }
   }

--- a/src/main/resources/data/shape-shifter-curse/accessory_power/attach_hook.json
+++ b/src/main/resources/data/shape-shifter-curse/accessory_power/attach_hook.json
@@ -5,36 +5,38 @@
       "add": [],
       "remove": []
     },
-    "forms": {
-      "shape-shifter-curse:bat_0": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:bat_1": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:bat_2": {
-        "add": [
-          "shape-shifter-curse:form_bat_attach_hook_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:drop_tool_after_digging",
-          "shape-shifter-curse:drop_weapon_after_hit"
-        ]
-      },
-      "shape-shifter-curse:bat_3": {
-        "add": [
-          "shape-shifter-curse:form_bat_attach_hook_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:drop_tool_after_digging",
-          "shape-shifter-curse:drop_weapon_after_hit"
-        ]
+    "layers": {
+      "origins:origin": {
+        "shape-shifter-curse:form_bat_0": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_bat_1": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_bat_2": {
+          "add": [
+            "shape-shifter-curse:form_bat_attach_hook_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:drop_tool_after_digging",
+            "shape-shifter-curse:drop_weapon_after_hit"
+          ]
+        },
+        "shape-shifter-curse:form_bat_3": {
+          "add": [
+            "shape-shifter-curse:form_bat_attach_hook_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:drop_tool_after_digging",
+            "shape-shifter-curse:drop_weapon_after_hit"
+          ]
+        }
       }
     }
   }

--- a/src/main/resources/data/shape-shifter-curse/accessory_power/charm_of_hollow_fang.json
+++ b/src/main/resources/data/shape-shifter-curse/accessory_power/charm_of_hollow_fang.json
@@ -5,40 +5,42 @@
       "add": [],
       "remove": []
     },
-    "forms": {
-      "shape-shifter-curse:bat_0": {
-        "add": [
-          "shape-shifter-curse:form_bat_charm_of_hollow_fang_trinket"
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:bat_1": {
-        "add": [
-          "shape-shifter-curse:form_bat_charm_of_hollow_fang_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_meat_food_down",
-          "shape-shifter-curse:form_vegetarian_food_up"
-        ]
-      },
-      "shape-shifter-curse:bat_2": {
-        "add": [
-          "shape-shifter-curse:form_bat_charm_of_hollow_fang_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_vegetarian",
-          "shape-shifter-curse:form_vegetarian_food_up"
-        ]
-      },
-      "shape-shifter-curse:bat_3": {
-        "add": [
-          "shape-shifter-curse:form_bat_charm_of_hollow_fang_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_vegetarian",
-          "shape-shifter-curse:form_vegetarian_food_up"
-        ]
+    "layers": {
+      "origins:origin": {
+        "shape-shifter-curse:form_bat_0": {
+          "add": [
+            "shape-shifter-curse:form_bat_charm_of_hollow_fang_trinket"
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_bat_1": {
+          "add": [
+            "shape-shifter-curse:form_bat_charm_of_hollow_fang_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_meat_food_down",
+            "shape-shifter-curse:form_vegetarian_food_up"
+          ]
+        },
+        "shape-shifter-curse:form_bat_2": {
+          "add": [
+            "shape-shifter-curse:form_bat_charm_of_hollow_fang_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_vegetarian",
+            "shape-shifter-curse:form_vegetarian_food_up"
+          ]
+        },
+        "shape-shifter-curse:form_bat_3": {
+          "add": [
+            "shape-shifter-curse:form_bat_charm_of_hollow_fang_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_vegetarian",
+            "shape-shifter-curse:form_vegetarian_food_up"
+          ]
+        }
       }
     }
   }

--- a/src/main/resources/data/shape-shifter-curse/accessory_power/charm_of_night_crystal.json
+++ b/src/main/resources/data/shape-shifter-curse/accessory_power/charm_of_night_crystal.json
@@ -5,34 +5,36 @@
       "add": [],
       "remove": []
     },
-    "forms": {
-      "shape-shifter-curse:bat_0": {
-        "add": [
-        ],
-        "remove": [
-          "shape-shifter-curse:form_bat_0_sun_health"
-        ]
-      },
-      "shape-shifter-curse:bat_1": {
-        "add": [
-        ],
-        "remove": [
-          "shape-shifter-curse:form_bat_1_sun_health"
-        ]
-      },
-      "shape-shifter-curse:bat_2": {
-        "add": [
-        ],
-        "remove": [
-          "shape-shifter-curse:form_bat_2_sun_health"
-        ]
-      },
-      "shape-shifter-curse:bat_3": {
-        "add": [
-        ],
-        "remove": [
-          "shape-shifter-curse:form_bat_2_sun_health"
-        ]
+    "layers": {
+      "origins:origin": {
+        "shape-shifter-curse:form_bat_0": {
+          "add": [
+          ],
+          "remove": [
+            "shape-shifter-curse:form_bat_0_sun_health"
+          ]
+        },
+        "shape-shifter-curse:form_bat_1": {
+          "add": [
+          ],
+          "remove": [
+            "shape-shifter-curse:form_bat_1_sun_health"
+          ]
+        },
+        "shape-shifter-curse:form_bat_2": {
+          "add": [
+          ],
+          "remove": [
+            "shape-shifter-curse:form_bat_2_sun_health"
+          ]
+        },
+        "shape-shifter-curse:form_bat_3": {
+          "add": [
+          ],
+          "remove": [
+            "shape-shifter-curse:form_bat_2_sun_health"
+          ]
+        }
       }
     }
   }

--- a/src/main/resources/data/shape-shifter-curse/accessory_power/charm_of_reverse_thermometer.json
+++ b/src/main/resources/data/shape-shifter-curse/accessory_power/charm_of_reverse_thermometer.json
@@ -5,38 +5,40 @@
       "add": [],
       "remove": []
     },
-    "forms": {
-      "shape-shifter-curse:snow_fox_0": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:snow_fox_1": {
-        "add": [
-          "shape-shifter-curse:form_snow_fox_1_charm_of_reverse_thermometer_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_snow_fox_1_desert_health"
-        ]
-      },
-      "shape-shifter-curse:snow_fox_2": {
-        "add": [
-          "shape-shifter-curse:form_snow_fox_2_charm_of_reverse_thermometer_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_snow_fox_2_desert_health",
-          "shape-shifter-curse:form_snow_fox_2_plain_health"
-        ]
-      },
-      "shape-shifter-curse:snow_fox_3": {
-        "add": [
-          "shape-shifter-curse:form_snow_fox_3_charm_of_reverse_thermometer_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_snow_fox_3_desert_health",
-          "shape-shifter-curse:form_snow_fox_3_plain_health"
-        ]
+    "layers": {
+      "origins:origin": {
+        "shape-shifter-curse:form_snow_fox_0": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_snow_fox_1": {
+          "add": [
+            "shape-shifter-curse:form_snow_fox_1_charm_of_reverse_thermometer_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_snow_fox_1_desert_health"
+          ]
+        },
+        "shape-shifter-curse:form_snow_fox_2": {
+          "add": [
+            "shape-shifter-curse:form_snow_fox_2_charm_of_reverse_thermometer_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_snow_fox_2_desert_health",
+            "shape-shifter-curse:form_snow_fox_2_plain_health"
+          ]
+        },
+        "shape-shifter-curse:form_snow_fox_3": {
+          "add": [
+            "shape-shifter-curse:form_snow_fox_3_charm_of_reverse_thermometer_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_snow_fox_3_desert_health",
+            "shape-shifter-curse:form_snow_fox_3_plain_health"
+          ]
+        }
       }
     }
   }

--- a/src/main/resources/data/shape-shifter-curse/accessory_power/collar_of_tension.json
+++ b/src/main/resources/data/shape-shifter-curse/accessory_power/collar_of_tension.json
@@ -5,37 +5,39 @@
       "add": [],
       "remove": []
     },
-    "forms": {
-      "shape-shifter-curse:ocelot_0": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:ocelot_1": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:ocelot_2": {
-        "add": [
-          "shape-shifter-curse:form_ocelot_collar_of_tension_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:barehand_attack_up",
-          "shape-shifter-curse:form_ocelot_2_arrow_dodge"
-        ]
-      },
-      "shape-shifter-curse:ocelot_3": {
-        "add": [
-          "shape-shifter-curse:form_ocelot_collar_of_tension_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:barehand_attack_up",
-          "shape-shifter-curse:form_ocelot_3_sneaking_jump_clash",
-          "shape-shifter-curse:form_ocelot_2_arrow_dodge"
-        ]
+    "layers": {
+      "origins:origin": {
+        "shape-shifter-curse:form_ocelot_0": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_ocelot_1": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_ocelot_2": {
+          "add": [
+            "shape-shifter-curse:form_ocelot_collar_of_tension_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:barehand_attack_up",
+            "shape-shifter-curse:form_ocelot_2_arrow_dodge"
+          ]
+        },
+        "shape-shifter-curse:form_ocelot_3": {
+          "add": [
+            "shape-shifter-curse:form_ocelot_collar_of_tension_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:barehand_attack_up",
+            "shape-shifter-curse:form_ocelot_3_sneaking_jump_clash",
+            "shape-shifter-curse:form_ocelot_2_arrow_dodge"
+          ]
+        }
       }
     }
   }

--- a/src/main/resources/data/shape-shifter-curse/accessory_power/collar_of_whiskers.json
+++ b/src/main/resources/data/shape-shifter-curse/accessory_power/collar_of_whiskers.json
@@ -5,34 +5,36 @@
       "add": [],
       "remove": []
     },
-    "forms": {
-      "shape-shifter-curse:ocelot_0": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:ocelot_1": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:ocelot_2": {
-        "add": [
-          "shape-shifter-curse:form_ocelot_collar_of_whiskers_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_ocelot_2_arrow_dodge"
-        ]
-      },
-      "shape-shifter-curse:ocelot_3": {
-        "add": [
-          "shape-shifter-curse:form_ocelot_collar_of_whiskers_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_ocelot_2_arrow_dodge"
-        ]
+    "layers": {
+      "origins:origin": {
+        "shape-shifter-curse:form_ocelot_0": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_ocelot_1": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_ocelot_2": {
+          "add": [
+            "shape-shifter-curse:form_ocelot_collar_of_whiskers_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_ocelot_2_arrow_dodge"
+          ]
+        },
+        "shape-shifter-curse:form_ocelot_3": {
+          "add": [
+            "shape-shifter-curse:form_ocelot_collar_of_whiskers_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_ocelot_2_arrow_dodge"
+          ]
+        }
       }
     }
   }

--- a/src/main/resources/data/shape-shifter-curse/accessory_power/digestion_fiber_ball.json
+++ b/src/main/resources/data/shape-shifter-curse/accessory_power/digestion_fiber_ball.json
@@ -5,36 +5,38 @@
       "add": [],
       "remove": []
     },
-    "forms": {
-      "shape-shifter-curse:ocelot_0": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:ocelot_1": {
-        "add": [
-          "shape-shifter-curse:form_ocelot_digestion_fiber_ball_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_carnivore"
-        ]
-      },
-      "shape-shifter-curse:ocelot_2": {
-        "add": [
-          "shape-shifter-curse:form_ocelot_digestion_fiber_ball_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_ocelot_2_raw_meat_only"
-        ]
-      },
-      "shape-shifter-curse:ocelot_3": {
-        "add": [
-          "shape-shifter-curse:form_ocelot_digestion_fiber_ball_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_ocelot_2_raw_meat_only"
-        ]
+    "layers": {
+      "origins:origin": {
+        "shape-shifter-curse:form_ocelot_0": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_ocelot_1": {
+          "add": [
+            "shape-shifter-curse:form_ocelot_digestion_fiber_ball_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_carnivore"
+          ]
+        },
+        "shape-shifter-curse:form_ocelot_2": {
+          "add": [
+            "shape-shifter-curse:form_ocelot_digestion_fiber_ball_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_ocelot_2_raw_meat_only"
+          ]
+        },
+        "shape-shifter-curse:form_ocelot_3": {
+          "add": [
+            "shape-shifter-curse:form_ocelot_digestion_fiber_ball_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_ocelot_2_raw_meat_only"
+          ]
+        }
       }
     }
   }

--- a/src/main/resources/data/shape-shifter-curse/accessory_power/fountain_belt.json
+++ b/src/main/resources/data/shape-shifter-curse/accessory_power/fountain_belt.json
@@ -5,33 +5,35 @@
       "add": [],
       "remove": []
     },
-    "forms": {
-      "shape-shifter-curse:axolotl_0": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:axolotl_1": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:axolotl_2": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:axolotl_3": {
-        "add": [
-          "shape-shifter-curse:form_axolotl_fountain_belt_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_axolotl_3_sprinting_sneaking_water_explode",
-          "shape-shifter-curse:form_axolotl_2_falling_protection"
-        ]
+    "layers": {
+      "origins:origin": {
+        "shape-shifter-curse:form_axolotl_0": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_axolotl_1": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_axolotl_2": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_axolotl_3": {
+          "add": [
+            "shape-shifter-curse:form_axolotl_fountain_belt_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_axolotl_3_sprinting_sneaking_water_explode",
+            "shape-shifter-curse:form_axolotl_2_falling_protection"
+          ]
+        }
       }
     }
   }

--- a/src/main/resources/data/shape-shifter-curse/accessory_power/frost_pawglove.json
+++ b/src/main/resources/data/shape-shifter-curse/accessory_power/frost_pawglove.json
@@ -5,36 +5,38 @@
       "add": [],
       "remove": []
     },
-    "forms": {
-      "shape-shifter-curse:snow_fox_0": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:snow_fox_1": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:snow_fox_2": {
-        "add": [
-          "shape-shifter-curse:form_snow_fox_frost_pawglove_trinket",
-          "shape-shifter-curse:form_snow_fox_snowball_effect_cooldown"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_snow_fox_2_snowball_up"
-        ]
-      },
-      "shape-shifter-curse:snow_fox_3": {
-        "add": [
-          "shape-shifter-curse:form_snow_fox_frost_pawglove_trinket",
-          "shape-shifter-curse:form_snow_fox_snowball_effect_cooldown"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_snow_fox_3_snowball_up"
-        ]
+    "layers": {
+      "origins:origin": {
+        "shape-shifter-curse:form_snow_fox_0": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_snow_fox_1": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_snow_fox_2": {
+          "add": [
+            "shape-shifter-curse:form_snow_fox_frost_pawglove_trinket",
+            "shape-shifter-curse:form_snow_fox_snowball_effect_cooldown"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_snow_fox_2_snowball_up"
+          ]
+        },
+        "shape-shifter-curse:form_snow_fox_3": {
+          "add": [
+            "shape-shifter-curse:form_snow_fox_frost_pawglove_trinket",
+            "shape-shifter-curse:form_snow_fox_snowball_effect_cooldown"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_snow_fox_3_snowball_up"
+          ]
+        }
       }
     }
   }

--- a/src/main/resources/data/shape-shifter-curse/accessory_power/resonant_core.json
+++ b/src/main/resources/data/shape-shifter-curse/accessory_power/resonant_core.json
@@ -5,14 +5,16 @@
       "add": [],
       "remove": []
     },
-    "forms": {
-      "shape-shifter-curse:allay_sp": {
-        "add": [
-          "shape-shifter-curse:form_allay_sp_resonant_core_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:can_eat_amethyst_shard"
-        ]
+    "layers": {
+      "origins:origin": {
+        "shape-shifter-curse:form_allay_sp": {
+          "add": [
+            "shape-shifter-curse:form_allay_sp_resonant_core_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:can_eat_amethyst_shard"
+          ]
+        }
       }
     }
   }

--- a/src/main/resources/data/shape-shifter-curse/accessory_power/withered_bandage.json
+++ b/src/main/resources/data/shape-shifter-curse/accessory_power/withered_bandage.json
@@ -5,34 +5,36 @@
       "add": [],
       "remove": []
     },
-    "forms": {
-      "shape-shifter-curse:anubis_wolf_0": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:anubis_wolf_1": {
-        "add": [
-        ],
-        "remove": [
-        ]
-      },
-      "shape-shifter-curse:anubis_wolf_2": {
-        "add": [
-          "shape-shifter-curse:form_anubis_wolf_2_withered_bandage_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_anubis_wolf_2_wither_on_hit"
-        ]
-      },
-      "shape-shifter-curse:anubis_wolf_3": {
-        "add": [
-          "shape-shifter-curse:form_anubis_wolf_3_withered_bandage_trinket"
-        ],
-        "remove": [
-          "shape-shifter-curse:form_anubis_wolf_3_wither_on_hit"
-        ]
+    "layers": {
+      "origins:origin": {
+        "shape-shifter-curse:form_anubis_wolf_0": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_anubis_wolf_1": {
+          "add": [
+          ],
+          "remove": [
+          ]
+        },
+        "shape-shifter-curse:form_anubis_wolf_2": {
+          "add": [
+            "shape-shifter-curse:form_anubis_wolf_2_withered_bandage_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_anubis_wolf_2_wither_on_hit"
+          ]
+        },
+        "shape-shifter-curse:form_anubis_wolf_3": {
+          "add": [
+            "shape-shifter-curse:form_anubis_wolf_3_withered_bandage_trinket"
+          ],
+          "remove": [
+            "shape-shifter-curse:form_anubis_wolf_3_wither_on_hit"
+          ]
+        }
       }
     }
   }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_climb_wood.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_2_climb_wood.json
@@ -1,6 +1,6 @@
 {
-    "type": "apoli:climbing",
-    "condition": {
+    "type": "shape-shifter-curse:climbing_ex",
+    "start_climb_condition": {
         "type": "apoli:and",
         "conditions": [
             {
@@ -15,8 +15,8 @@
                             "type": "apoli:in_tag",
                             "tag": "shape-shifter-curse:natural_wood"
                         },
-                        "offset_x": 0.1,
-                        "offset_z": 0.1
+                        "offset_x": 0.05,
+                        "offset_z": 0.05
                     },
                     {
                         "type": "apoli:block_collision",
@@ -24,8 +24,40 @@
                             "type": "apoli:in_tag",
                             "tag": "shape-shifter-curse:natural_wood"
                         },
-                        "offset_x": -0.1,
-                        "offset_z": -0.1
+                        "offset_x": -0.05,
+                        "offset_z": -0.05
+                    }
+                ]
+            }
+        ]
+    },
+    "continue_climb_condition": {
+        "type": "apoli:and",
+        "conditions": [
+            {
+                "type": "apoli:on_block",
+                "inverted": true
+            },
+            {
+                "type": "apoli:or",
+                "conditions": [
+                    {
+                        "type": "apoli:block_collision",
+                        "block_condition": {
+                            "type": "apoli:in_tag",
+                            "tag": "shape-shifter-curse:natural_wood"
+                        },
+                        "offset_x": 0.01,
+                        "offset_z": 0.01
+                    },
+                    {
+                        "type": "apoli:block_collision",
+                        "block_condition": {
+                            "type": "apoli:in_tag",
+                            "tag": "shape-shifter-curse:natural_wood"
+                        },
+                        "offset_x": -0.01,
+                        "offset_z": -0.01
                     }
                 ]
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_3_climb_all.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_ocelot_3_climb_all.json
@@ -1,6 +1,6 @@
 {
-    "type": "apoli:climbing",
-    "condition": {
+    "type": "shape-shifter-curse:climbing_ex",
+    "start_climb_condition": {
         "type": "apoli:and",
         "conditions": [
             {
@@ -11,13 +11,37 @@
                 "conditions": [
                     {
                         "type": "apoli:block_collision",
-                        "offset_x": 0.1,
-                        "offset_z": 0.1
+                        "offset_x": 0.05,
+                        "offset_z": 0.05
                     },
                     {
                         "type": "apoli:block_collision",
-                        "offset_x": -0.1,
-                        "offset_z": -0.1
+                        "offset_x": -0.05,
+                        "offset_z": -0.05
+                    }
+                ]
+            }
+        ]
+    },
+    "continue_climb_condition": {
+        "type": "apoli:and",
+        "conditions": [
+            {
+                "type": "apoli:on_block",
+                "inverted": true
+            },
+            {
+                "type": "apoli:or",
+                "conditions": [
+                    {
+                        "type": "apoli:block_collision",
+                        "offset_x": 0.01,
+                        "offset_z": 0.01
+                    },
+                    {
+                        "type": "apoli:block_collision",
+                        "offset_x": -0.01,
+                        "offset_z": -0.01
                     }
                 ]
             }

--- a/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_climb.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/form_spider_3_climb.json
@@ -1,6 +1,6 @@
 {
-    "type": "apoli:climbing",
-    "condition": {
+    "type": "shape-shifter-curse:climbing_ex",
+    "start_climb_condition": {
         "type": "apoli:and",
         "conditions": [
             {
@@ -11,13 +11,37 @@
                 "conditions": [
                     {
                         "type": "apoli:block_collision",
-                        "offset_x": 0.1,
-                        "offset_z": 0.1
+                        "offset_x": 0.05,
+                        "offset_z": 0.05
                     },
                     {
                         "type": "apoli:block_collision",
-                        "offset_x": -0.1,
-                        "offset_z": -0.1
+                        "offset_x": -0.05,
+                        "offset_z": -0.05
+                    }
+                ]
+            }
+        ]
+    },
+    "continue_climb_condition": {
+        "type": "apoli:and",
+        "conditions": [
+            {
+                "type": "apoli:on_block",
+                "inverted": true
+            },
+            {
+                "type": "apoli:or",
+                "conditions": [
+                    {
+                        "type": "apoli:block_collision",
+                        "offset_x": 0.01,
+                        "offset_z": 0.01
+                    },
+                    {
+                        "type": "apoli:block_collision",
+                        "offset_x": -0.01,
+                        "offset_z": -0.01
                     }
                 ]
             }


### PR DESCRIPTION
饰品Power挂载改为由layer判断 拓展不用这么修改 用于子形态
现在所有攀爬应该都能悬停了 **不过有一个问题我解决不了 需要给所有有攀爬动画的形态做一套悬停动画**
修改了动画控制器判断是否onGround的实现逻辑 旧逻辑会对攀爬悬停出Bug