### PR TITLE
子形态class 以及对应样例

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/DynamicForm.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/DynamicForm.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
-public class DynamicForm implements IForm, NeedCheckUsableForm {
+public class DynamicForm implements IForm, ISubForm, NeedCheckUsableForm {
     public static final UUID PublicUUID = UUID.fromString("00000000-0000-0000-0000-000000000000");
 
     public @NotNull Identifier formID;
@@ -58,6 +58,7 @@ public class DynamicForm implements IForm, NeedCheckUsableForm {
     private int TempPowerIndex = 0;
 
     public Identifier fallbackFormID = null;
+    public IForm masterForm = null;
 
     public DynamicForm(@Nullable Identifier formID, JsonObject formData) {
         this.formID = formID;
@@ -91,6 +92,7 @@ public class DynamicForm implements IForm, NeedCheckUsableForm {
         this.formTier = formTier;
     }
 
+
     @Override
     public @NotNull Pair<Identifier, Identifier> getFormLayer() {
         if (this.layerOverwrite != null) {
@@ -106,26 +108,31 @@ public class DynamicForm implements IForm, NeedCheckUsableForm {
 
     @Override
     public @Nullable IForm getNextForm(PlayerEntity player, ITransformReason reason) {
-        return IForm.super.getNextForm(player, reason);
+        return ISubForm.super.getNextForm(player, reason);
     }
 
     @Override
     public @Nullable IForm getPrevForm(PlayerEntity player, ITransformReason reason) {
-        return IForm.super.getPrevForm(player, reason);
+        return ISubForm.super.getPrevForm(player, reason);
     }
 
     @Override
     public @NotNull IForm getDefaultNextForm(PlayerEntity player, ITransformReason reason) {
-        return IForm.super.getDefaultNextForm(player, reason);
+        return ISubForm.super.getDefaultNextForm(player, reason);
     }
 
     @Override
     public @NotNull IForm getDefaultPrevForm(PlayerEntity player, ITransformReason reason) {
-        return IForm.super.getDefaultPrevForm(player, reason);
+        return ISubForm.super.getDefaultPrevForm(player, reason);
+    }
+
+    @Override
+    public @Nullable Pair<Identifier, Identifier> getRenderLayerOverride() {
+        return this.layerRenderOverwrite;
     }
 
     public Pair<Identifier, Identifier> getCurrentRenderLayer() {
-        return Objects.requireNonNullElseGet(this.layerRenderOverwrite, this::getFormLayer);
+        return Objects.requireNonNullElseGet(this.getRenderLayerOverride(), this::getFormLayer);
     }
 
     public boolean isModelExist() {
@@ -252,10 +259,7 @@ public class DynamicForm implements IForm, NeedCheckUsableForm {
         }
         if (formData.has("MasterForm")) {
             Identifier masterFormID = Identifier.tryParse(formData.get("MasterForm").getAsString());
-            IForm masterForm = RegPlayerForms.getPlayerForm(masterFormID);
-            if (masterFormID != null) {
-                RegPlayerForms.registerSubForm(masterForm, this);
-            }
+            this.masterForm = RegPlayerForms.getPlayerForm(masterFormID);
         }
     }
 
@@ -375,6 +379,22 @@ public class DynamicForm implements IForm, NeedCheckUsableForm {
     @Override
     public boolean isDynamicForm() {
         return true;
+    }
+
+    @Override
+    public @Nullable Pair<List<Identifier>, List<Identifier>> getLayerModifier() {
+        return null;
+    }
+
+
+    @Override
+    public Boolean isSubForm() {
+        return masterForm != null;
+    }
+
+    @Override
+    public IForm getMasterForm() {
+        return masterForm;
     }
 
     @Override

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/IForm.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/IForm.java
@@ -32,6 +32,9 @@ public interface IForm {
     // 临时能力系统 等Origins移除后再写
     public @NotNull Pair<Identifier, Identifier> getFormLayer();
 
+    public default @Nullable Pair<Identifier, Identifier> getRenderLayerOverride() {
+        return null;
+    }
 
     public @NotNull PlayerFormBodyType getBodyType();
 
@@ -121,6 +124,8 @@ public interface IForm {
         return new Pair<>(false, null);
     }
 
+    default void onRegister() { }
+
     // 3个Hook 顺序为当前形态onTransform_To 目标形态onTransform_From 目标形态onTransform_Finish
     default void onTransform_From(PlayerEntity player, IForm prevForm) { }
 
@@ -143,9 +148,23 @@ public interface IForm {
         return form != null && this.getFormID().equals(form.getFormID());
     }
 
+    default boolean isSoftEquals(IForm form) {
+        IForm ThisMasterForm = this instanceof ISubForm subForm ? subForm.getMasterForm() : this;
+        IForm FormMasterForm = form instanceof ISubForm subForm ? subForm.getMasterForm() : form;
+        if (ThisMasterForm == null || FormMasterForm == null) {
+            return false;
+        }
+        return ThisMasterForm.isEquals(FormMasterForm);
+    }
+
     default boolean isPlayerForm(PlayerEntity player) {
         IForm playerForm = FormUtils.getPlayerForm(player);
         return this.isEquals(playerForm);
+    }
+
+    default boolean isPlayerFormSoft(PlayerEntity player) {
+        IForm playerForm = FormUtils.getPlayerForm(player);
+        return this.isSoftEquals(playerForm);
     }
 
     default boolean isDynamicForm() {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/ISubForm.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/ISubForm.java
@@ -1,0 +1,61 @@
+package net.onixary.shapeShifterCurseFabric.player_form;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Pair;
+import net.onixary.shapeShifterCurseFabric.player_form.utils.FormUtils;
+import net.onixary.shapeShifterCurseFabric.player_form.utils.PlayerFormComponent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public interface ISubForm extends IForm {
+    default Boolean isSubForm() {
+        return true;
+    }
+
+    @Nullable IForm getMasterForm();
+
+    // 默认使用主形态的能力
+    @Override
+    default @NotNull Pair<Identifier, Identifier> getFormLayer() {
+        IForm masterForm = this.getMasterForm();
+        if (masterForm != null) {
+            return masterForm.getFormLayer();
+        }
+        throw new RuntimeException("Master form is null");
+    }
+
+    @Nullable Pair<List<Identifier>, List<Identifier>> getLayerModifier();
+
+    @Override
+    default void afterApplyLayer(PlayerEntity player) {
+        Pair<List<Identifier>, List<Identifier>> modifier = getLayerModifier();
+        if (modifier != null) {
+            Identifier powerSource = getFormLayer().getRight();
+            List<Identifier> addPowerList = modifier.getLeft();
+            List<Identifier> removePowerList = modifier.getRight();
+            for (Identifier powerID : addPowerList) {
+                FormUtils.applyPower(player, powerID, powerSource);
+            }
+            for (Identifier powerID : removePowerList) {
+                FormUtils.removePower(player, powerID, powerSource);
+            }
+        }
+    }
+
+    @Override
+    default void onTransform_Finish(PlayerEntity player) {
+        PlayerFormComponent pfc = PlayerFormComponent.COMPONENT.get(player);
+        pfc.setFallbackForm(this.getMasterForm().getFormID());
+    }
+
+    @Override
+    default void onRegister() {
+        IForm masterForm = this.getMasterForm();
+        if (masterForm != null) {
+            RegPlayerForms.registerSubForm(masterForm, this);
+        }
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/NormalSubForm.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/NormalSubForm.java
@@ -1,0 +1,134 @@
+package net.onixary.shapeShifterCurseFabric.player_form;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Pair;
+import net.onixary.shapeShifterCurseFabric.player_animation.AnimationHolder;
+import net.onixary.shapeShifterCurseFabric.player_animation.v3.AbstractAnimStateController;
+import net.onixary.shapeShifterCurseFabric.player_animation.v3.AnimSystem;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NormalSubForm extends NormalForm implements ISubForm {
+    public final @NotNull IForm masterForm;
+    public final @NotNull List<Identifier> power_ADD = new ArrayList<>();
+    public final @NotNull List<Identifier> power_REMOVE = new ArrayList<>();
+
+    public NormalSubForm(Identifier formID, @NotNull IForm masterForm) {
+        super(formID);
+        this.masterForm = masterForm;
+        this.loadAllDataFormMasterForm();
+    }
+
+    @Override
+    public @NotNull IForm getMasterForm() {
+        return masterForm;
+    }
+
+    @Override
+    public @Nullable Pair<List<Identifier>, List<Identifier>> getLayerModifier() {
+        return new Pair<>(power_ADD, power_REMOVE);
+    }
+
+    public void addPower(Identifier... powerIDs) {
+        for (Identifier powerID : powerIDs) {
+            if (!power_ADD.contains(powerID)) {
+                power_ADD.add(powerID);
+            }
+        }
+    }
+
+    public void removePower(Identifier... powerIDs) {
+        for (Identifier powerID : powerIDs) {
+            if (!power_REMOVE.contains(powerID)) {
+                power_REMOVE.add(powerID);
+            }
+        }
+    }
+
+    public void loadAllDataFormMasterForm() {
+        IForm masterForm = this.getMasterForm();
+        this.bodyType(masterForm.getBodyType());
+        IFormGroup masterGroup = masterForm.getFormGroup();
+        if (masterGroup != null) {
+            masterGroup.registerForm(masterForm.getFormTier(), 0, this);
+        }
+        this.formFlag(masterForm.getFormFlag().toArray(new String[0]));
+    }
+
+    @Override
+    public @NotNull IForm _getNextForm(PlayerEntity player, ITransformReason reason) {
+        return this.getMasterForm()._getNextForm(player, reason);
+    }
+
+    @Override
+    public @NotNull IForm _getPrevForm(PlayerEntity player, ITransformReason reason) {
+        return this.getMasterForm()._getPrevForm(player, reason);
+    }
+
+    @Override
+    public @Nullable AbstractAnimStateController getAnimStateController(PlayerEntity player, AnimSystem.AnimSystemData animSystemData, @NotNull Identifier animStateID) {
+        return this.getMasterForm().getAnimStateController(player, animSystemData, animStateID);
+    }
+
+    @Override
+    public void registerPowerAnim(PlayerEntity player, AnimSystem.AnimSystemData animSystemData) {
+        this.getMasterForm().registerPowerAnim(player, animSystemData);
+    }
+
+
+    @Override
+    public boolean isPowerAnimRegistered(PlayerEntity player, AnimSystem.AnimSystemData animSystemData) {
+        return this.getMasterForm().isPowerAnimRegistered(player, animSystemData);
+    }
+
+    @Override
+    public @NotNull Pair<Boolean, @Nullable AnimationHolder> getPowerAnim(PlayerEntity player, AnimSystem.AnimSystemData animSystemData, @NotNull Identifier powerAnimID) {
+        return this.getMasterForm().getPowerAnim(player, animSystemData, powerAnimID);
+    }
+
+    @Override
+    public void applyScale(PlayerEntity player) {
+        this.getMasterForm().applyScale(player);
+    }
+
+    @Override
+    public void onTransform_From(PlayerEntity player, IForm prevForm) {
+        this.getMasterForm().onTransform_From(player, prevForm);
+    }
+
+    @Override
+    public void onTransform_To(PlayerEntity player, IForm nextForm) {
+        this.getMasterForm().onTransform_To(player, nextForm);
+    }
+
+    @Override
+    public void onTransform_Finish(PlayerEntity player) {
+        this.getMasterForm().onTransform_Finish(player);
+        ISubForm.super.onTransform_Finish(player);
+    }
+
+    @Override
+    public void afterApplyLayer(PlayerEntity player) {
+        this.getMasterForm().afterApplyLayer(player);
+        ISubForm.super.afterApplyLayer(player);
+    }
+
+    @Override
+    public void onApplyPowerEnd(PlayerEntity player) {
+        this.getMasterForm().onApplyPowerEnd(player);
+    }
+
+    @Override
+    public void onRegister() {
+        ISubForm.super.onRegister();
+    }
+
+    @Override
+    public @NotNull Pair<Identifier, Identifier> getFormLayer() {
+        return ISubForm.super.getFormLayer();
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/RegPlayerForms.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/RegPlayerForms.java
@@ -76,8 +76,12 @@ public class RegPlayerForms {
     public static IForm FERAL_CAT_SP = registerPlayerForm(new Form_FeralCatSP(ShapeShifterCurseFabric.identifier("feral_cat_sp")).formFlag(NoInstinct, NoCursedMoonEffect, SpecialForm).bodyType(PlayerFormBodyType.FERAL).applyScaleFunc(NORMAL_SCALE_FUNC_BUILDER.apply(0.55f,0.6f)));
     public static IFormGroup FERAL_CAT_FORM = registerPlayerFormGroup(new NormalGroup(ShapeShifterCurseFabric.identifier("feral_cat_form")).registerForm(1, 1, FERAL_CAT_SP));
 
+    // EXAMPLE_SUB_FORM
+    public static IForm EXAMPLE_SUB_FORM = registerPlayerForm(new ExampleSubForm(ShapeShifterCurseFabric.identifier("example_sub_form")));
+
     public static <T extends IForm> T registerPlayerForm(T form) {
         playerForms.put(form.getFormID(), form);
+        form.onRegister();
         return form;
     }
 
@@ -88,7 +92,7 @@ public class RegPlayerForms {
         return registerPlayerForm(form);
     }
 
-    public static void registerSubForm(IForm masterForm, IForm subForm) {
+    public static void registerSubForm(IForm masterForm, ISubForm subForm) {
         List<Identifier> subFormList = subFormMap.computeIfAbsent(masterForm.getFormID(), k -> new ArrayList<>());
         if (!subFormList.contains(subForm.getFormID())) {
             subFormList.add(subForm.getFormID());

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/forms/ExampleSubForm.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/forms/ExampleSubForm.java
@@ -1,0 +1,21 @@
+package net.onixary.shapeShifterCurseFabric.player_form.forms;
+
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Pair;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+import net.onixary.shapeShifterCurseFabric.player_form.NormalSubForm;
+import net.onixary.shapeShifterCurseFabric.player_form.RegPlayerForms;
+import org.jetbrains.annotations.Nullable;
+
+// TODO 发布时一定得移除
+public class ExampleSubForm extends NormalSubForm {
+    public ExampleSubForm(Identifier formID) {
+        super(formID, RegPlayerForms.FERAL_CAT_SP);
+        this.removePower(ShapeShifterCurseFabric.identifier("form_disable_leg_armor"), ShapeShifterCurseFabric.identifier("form_disable_feet_armor"));
+    }
+
+    @Override
+    public @Nullable Pair<Identifier, Identifier> getRenderLayerOverride() {
+        return RegPlayerForms.ALLAY_SP.getFormLayer();
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/render/form_render/FormRenderUtils.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/render/form_render/FormRenderUtils.java
@@ -95,19 +95,31 @@ public class FormRenderUtils {
             return formRenderers;
         }
         try {
+            // IForm playerFormBase = FormUtils.getPlayerForm(player);
+            // if (playerFormBase instanceof DynamicForm pfd) {
+            //     List<FormRenderer> formRenderers = new ArrayList<>();
+            //     Pair<Identifier, Identifier> currentLayer = pfd.getCurrentRenderLayer();
+            //     if (currentLayer != null) {
+            //         FormRenderer formRenderer = FormRenderUtils.getFormRenderer(currentLayer.getLeft(), currentLayer.getRight());
+            //         if (formRenderer == null) {
+            //             ShapeShifterCurseFabric.LOGGER.warn("ShapeShifterCurseFabric: PlayerFormDynamic.layerRenderOverwrite is not null, but the model is not registered: {} - {}", currentLayer.getLeft(), currentLayer.getRight());
+            //             return new ArrayList<>();
+            //         }
+            //         formRenderers.add(formRenderer);
+            //         return formRenderers;
+            //     }
+            // }
             IForm playerFormBase = FormUtils.getPlayerForm(player);
-            if (playerFormBase instanceof DynamicForm pfd) {
+            Pair<Identifier, Identifier> currentLayer = playerFormBase.getRenderLayerOverride();
+            if (currentLayer != null) {
                 List<FormRenderer> formRenderers = new ArrayList<>();
-                Pair<Identifier, Identifier> currentLayer = pfd.getCurrentRenderLayer();
-                if (currentLayer != null) {
-                    FormRenderer formRenderer = FormRenderUtils.getFormRenderer(currentLayer.getLeft(), currentLayer.getRight());
-                    if (formRenderer == null) {
-                        ShapeShifterCurseFabric.LOGGER.warn("ShapeShifterCurseFabric: PlayerFormDynamic.layerRenderOverwrite is not null, but the model is not registered: {} - {}", currentLayer.getLeft(), currentLayer.getRight());
-                        return new ArrayList<>();
-                    }
-                    formRenderers.add(formRenderer);
-                    return formRenderers;
+                FormRenderer formRenderer = FormRenderUtils.getFormRenderer(currentLayer.getLeft(), currentLayer.getRight());
+                if (formRenderer == null) {
+                    ShapeShifterCurseFabric.LOGGER.warn("ShapeShifterCurseFabric: IForm.layerRenderOverwrite is not null, but the model is not registered: {} - {}", currentLayer.getLeft(), currentLayer.getRight());
+                    return new ArrayList<>();
                 }
+                formRenderers.add(formRenderer);
+                return formRenderers;
             }
         } catch (Exception ignored) {}
         PlayerOriginComponent poc = (PlayerOriginComponent) ModComponents.ORIGIN.get(player);


### PR DESCRIPTION
写了一个SubForm的样例 由于离线验证没写 所以对应判断是否可用逻辑我之后加 我先设计几天离线验证方案(用什么方式存之类的底层设计 尽量保证文件小一些 还得尽量让后续不用修改验证文件逻辑(修改一次后旧验证文件全部失效))

SubForm基本继承了MasterForm的所有数据 所以只需要重载需要修改的部分(比如示例我改了一下Power和渲染模型) addPower/removePower为Append逻辑 所以可以一条写完也能分条写完
SubForm必须在主形态组注册完后再注册(Static写在Group后面) 因为形态数据有一部分由Group提供 太早拿不到组数据
**样例SubForm发布时记得删** (因为注册时机有需求 所以把注册也给写了)

有什么问题可以微信/QQ问我(比较着急的问题 不着急可以Github问) Github回复速度取决于我手机邮箱接收频率(~30min) 不太及时