### PR TITLE
修复美西螈原版爬行倒立

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/v3/AnimFSM/OnGroundFSM.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/v3/AnimFSM/OnGroundFSM.java
@@ -26,6 +26,9 @@ public class OnGroundFSM extends AbstractAnimFSM {
         if (UniversalStateResult != null) {
             return UniversalStateResult;
         }
+        if (player.isCrawling()) {
+            return ANIM_STATE_CRAWL;
+        }
         if (animSystemData.IsWalking) {
             if (player.isSprinting()) {
                 return ANIM_STATE_SPRINT;

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/v3/AnimRegistries.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/v3/AnimRegistries.java
@@ -35,6 +35,7 @@ public class AnimRegistries {
     public static Identifier ANIM_STATE_WALK = AnimRegistry.registerAnimState(ShapeShifterCurseFabric.identifier("walk_state"), new AnimRegistry.AnimState(new EmptyController()));
     public static Identifier ANIM_STATE_SPRINT = AnimRegistry.registerAnimState(ShapeShifterCurseFabric.identifier("sprint_state"), new AnimRegistry.AnimState(new EmptyController()));
     public static Identifier ANIM_STATE_IDLE = AnimRegistry.registerAnimState(ShapeShifterCurseFabric.identifier("idle_state"), new AnimRegistry.AnimState(new EmptyController()));
+    public static Identifier ANIM_STATE_CRAWL = AnimRegistry.registerAnimState(ShapeShifterCurseFabric.identifier("crawl_state"), new AnimRegistry.AnimState(new EmptyController()));
 
     // AnimFSM注册
     public static Identifier FSM_ON_GROUND = AnimRegistry.registerAnimFSM(ShapeShifterCurseFabric.identifier("on_ground"), new OnGroundFSM());

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/v3/AnimStateEnum.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_animation/v3/AnimStateEnum.java
@@ -24,7 +24,8 @@ public enum AnimStateEnum {
     ANIM_STATE_ATTACK,
     ANIM_STATE_WALK,
     ANIM_STATE_SPRINT,
-    ANIM_STATE_IDLE;
+    ANIM_STATE_IDLE,
+    ANIM_STATE_CRAWL;
 
     public static final HashMap <Identifier, AnimStateEnum> stateMap = new HashMap<>();
 
@@ -43,6 +44,7 @@ public enum AnimStateEnum {
         stateMap.put(AnimRegistries.ANIM_STATE_WALK, ANIM_STATE_WALK);
         stateMap.put(AnimRegistries.ANIM_STATE_SPRINT, ANIM_STATE_SPRINT);
         stateMap.put(AnimRegistries.ANIM_STATE_IDLE, ANIM_STATE_IDLE);
+        stateMap.put(AnimRegistries.ANIM_STATE_CRAWL, ANIM_STATE_CRAWL);
     }
 
     public static @Nullable AnimStateEnum getStateEnum(Identifier stateID) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/forms/Form_Axolotl3.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/forms/Form_Axolotl3.java
@@ -33,6 +33,7 @@ public class Form_Axolotl3 extends NormalForm {
     public static final AbstractAnimStateController MINING_CONTROLLER = new WithSneakAnimController(null, new AnimUtils.AnimationHolderData(ShapeShifterCurseFabric.identifier("axolotl_2_crawling_tool_swing")));
     public static final AbstractAnimStateController FLYING_CONTROLLER = new OneAnimController(new AnimUtils.AnimationHolderData(ShapeShifterCurseFabric.identifier("axolotl_3_creative_flight")));
     public static final AbstractAnimStateController SLEEP_CONTROLLER = new OneAnimController(ANIM_SLEEP);
+    public static final AbstractAnimStateController CRAWL_CONTROLLER = new OneAnimController(new AnimUtils.AnimationHolderData(ShapeShifterCurseFabric.identifier("axolotl_3_idle")));
 
     @Override
     public @Nullable AbstractAnimStateController getAnimStateController(PlayerEntity player, AnimSystem.AnimSystemData animSystemData, @NotNull Identifier animStateID) {
@@ -58,7 +59,9 @@ public class Form_Axolotl3 extends NormalForm {
                 case ANIM_STATE_FLYING:
                     return FLYING_CONTROLLER;
                 case ANIM_STATE_SLEEP:
-                        return SLEEP_CONTROLLER;
+                    return SLEEP_CONTROLLER;
+                case ANIM_STATE_CRAWL:
+                    return CRAWL_CONTROLLER;
                 default:
                     return null;
             }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/forms/Form_Bat3.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/forms/Form_Bat3.java
@@ -58,8 +58,7 @@ public class Form_Bat3 extends NormalForm implements ModifyCapeRender {
     public static final AbstractAnimStateController FALL_CONTROLLER = new OneAnimController(new AnimUtils.AnimationHolderData(ShapeShifterCurseFabric.identifier("bat_2_slow_falling")));
     public static final AbstractAnimStateController RIDE_CONTROLLER = new RideAnimController(new AnimUtils.AnimationHolderData(ShapeShifterCurseFabric.identifier("bat_3_riding")), new AnimUtils.AnimationHolderData(ShapeShifterCurseFabric.identifier("bat_1_sneak_idle")));
     public static final AbstractAnimStateController FLYING_CONTROLLER = new OneAnimController(new AnimUtils.AnimationHolderData(ShapeShifterCurseFabric.identifier("bat_2_slow_falling")));
-    public static final AbstractAnimStateController CLIMB_CONTROLLER =
-            new ClimbAnimController(ANIM_CLIMB_IDLE, ANIM_CLIMB);
+    public static final AbstractAnimStateController CLIMB_CONTROLLER = new ClimbAnimController(ANIM_CLIMB_IDLE, ANIM_CLIMB);
     public static final AbstractAnimStateController SLEEP_CONTROLLER = new OneAnimController(ANIM_SLEEP);
 
     public @Nullable AbstractAnimStateController getAnimStateController(PlayerEntity player, AnimSystem.AnimSystemData animSystemData, @NotNull Identifier animStateID) {
@@ -90,6 +89,8 @@ public class Form_Bat3 extends NormalForm implements ModifyCapeRender {
                     return IDLE_CONTROLLER;
                 case ANIM_STATE_SLEEP:
                     return SLEEP_CONTROLLER;
+                case ANIM_STATE_CRAWL:
+                    return FLYING_CONTROLLER;
                 default:
                     return null;
             }


### PR DESCRIPTION
蝙蝠其实没有倒立 只是动画+旋转90度像倒立 把模型拿掉就能看出来不是倒立 目前是爬行和鞘翅飞行共用一个动画控制器 如果看上去还不行 可以新建一个动画+控制器 不过触发概率低(蝙蝠矮 一般触发不了原版爬行) 可以先凑活用鞘翅飞行动画
美西螈倒立是原版爬行配上潜行IDLE 2个90度旋转导致倒立 解决方式是将原版爬行单拉一个控制器 使用正常IDLE就修好了
研究了快1个半小时了(仅倒立Bug) 有什么其他Bug明天再说吧