### PR TITLE
现在蜘蛛攀爬应该不会摔伤了

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/ClimbingEXPower.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/ClimbingEXPower.java
@@ -26,6 +26,7 @@ public class ClimbingEXPower extends ClimbingPower {
         this.continueClimbCondition = continueClimbCondition;
         this.holdingCondition = holdingCondition;
         this.allowHolding = allowHolding;
+        this.setTicking();
     }
 
     public boolean canHold() {
@@ -36,6 +37,13 @@ public class ClimbingEXPower extends ClimbingPower {
             return entity.isSneaking();
         }
         return this.holdingCondition.test(this.entity);
+    }
+
+    @Override
+    public void tick() {
+        if (this.isActive()) {
+            entity.fallDistance = 0;
+        }
     }
 
     @Override


### PR DESCRIPTION
给SSC的攀爬power加一个tick函数 只要攀爬激活就每tick重置摔落高度 就算是摔也摔不了多少伤害