### PR TITLE
修改暴击注入方法 修改蜘蛛友好Power实现

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/CriticalDamageModifierPower.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/CriticalDamageModifierPower.java
@@ -37,7 +37,7 @@ public class CriticalDamageModifierPower extends Power {
                 ShapeShifterCurseFabric.identifier("critical_damage_modifier"),
                 new SerializableData()
                         .add("action", ApoliDataTypes.ENTITY_ACTION, null)
-                        .add("multiplier", SerializableDataTypes.FLOAT, 1.5f),
+                        .add("multiplier", SerializableDataTypes.FLOAT, 1.0f),
                 data -> (type, entity) -> new CriticalDamageModifierPower(
                         type,
                         entity,

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerEntityAttackMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerEntityAttackMixin.java
@@ -2,17 +2,18 @@ package net.onixary.shapeShifterCurseFabric.mixin;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.player.PlayerEntity;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
 import net.onixary.shapeShifterCurseFabric.additional_power.AlwaysSweepingPower;
 import net.onixary.shapeShifterCurseFabric.additional_power.CriticalDamageModifierPower;
 import net.onixary.shapeShifterCurseFabric.additional_power.EnhancedFallingAttackPower;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.*;
 
 import java.util.List;
 
@@ -40,77 +41,37 @@ public abstract class PlayerEntityAttackMixin {
         return value;
     }
 
-
-    /**
-     * 精确注入到 attack 方法中，在原版暴击伤害计算之后修改伤害值。
-     * local variable `f` (float) at index 2.
-     */
-    @WrapOperation(
-            method = "attack(Lnet/minecraft/entity/Entity;)V",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/entity/Entity;damage(Lnet/minecraft/entity/damage/DamageSource;F)Z"
-            )
-    )
-    private boolean modifyCritDamage(Entity target, DamageSource source, float amount, Operation<Boolean> original, @Local(ordinal = 2) boolean isCrit) {
-        if (!isCrit) {
-            return original.call(target, source, amount);
-        }
-
+    // 直接改暴击的常量岂不是兼容性更好 对了 之前的版本会导致攻击附魔暴击伤害计算错误
+    @ModifyExpressionValue(method = "attack(Lnet/minecraft/entity/Entity;)V", at = @At(value = "CONSTANT", args = {"floatValue=1.5F"}))
+    private float modifyCritMultiplier(float critMultiplier, @Local(ordinal = 0, argsOnly = true) Entity target) {
         PlayerEntity player = (PlayerEntity) (Object) this;
-
-        // 获取相关的 Power
+        float finalMultiplier = critMultiplier;
         List<CriticalDamageModifierPower> critModifierPowers = PowerHolderComponent.getPowers(player, CriticalDamageModifierPower.class);
         List<EnhancedFallingAttackPower> fallingAttackPowers = PowerHolderComponent.getPowers(player, EnhancedFallingAttackPower.class);
-
-        // 计算基础伤害（去除原版1.5倍跳劈倍数）
-        float baseDamage = amount / 1.5f;
-
-        // 第一步：应用跳劈伤害提升
-        float critMultiplier = 1.5f; // 原版跳劈倍数
         for (CriticalDamageModifierPower power : critModifierPowers) {
-            if (power.isActive()) {
-                critMultiplier *= power.getMultiplier();
-                power.executeAction();
-                break; // 只使用第一个激活的 power
-            }
+            finalMultiplier *= power.getMultiplier();
+            power.executeAction();
         }
-
-        float enhancedCritDamage = baseDamage * critMultiplier;
-
-        // 第二步：检查是否有下落增伤 power
-        boolean hasFallingAttackPower = fallingAttackPowers.stream().anyMatch(p -> p.isActive());
-
-        if (hasFallingAttackPower) {
-            // 计算下落增伤倍数
+        if (!fallingAttackPowers.isEmpty()) {
             float minFall = 1.0f;
             float maxFall = 2.0f;
             float minMultiplier = 1.0f;
             float maxMultiplier = 2.0f;
-
             float fallMultiplier;
             if (player.fallDistance <= minFall) {
                 fallMultiplier = minMultiplier;
             } else if (player.fallDistance >= maxFall) {
                 fallMultiplier = maxMultiplier;
             } else {
-                // 在 [minFall, maxFall] 区间内进行线性插值
                 float progress = (player.fallDistance - minFall) / (maxFall - minFall);
                 fallMultiplier = minMultiplier + (maxMultiplier - minMultiplier) * progress;
             }
-
-            // 执行下落攻击的 action
-            fallingAttackPowers.forEach(power -> {
-                if (power.isActive()) {
-                    power.executeTargetAction(target);
-                    power.executeSelfAction();
-                }
-            });
-
-            // 应用下落增伤到已经提升的跳劈伤害上
-            enhancedCritDamage = enhancedCritDamage * fallMultiplier;
+            finalMultiplier *= fallMultiplier;
+            for (EnhancedFallingAttackPower power : fallingAttackPowers) {
+                power.executeTargetAction(target);
+                power.executeSelfAction();
+            }
         }
-
-        return original.call(target, source, enhancedCritDamage);
+        return finalMultiplier;
     }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerEntityAttackMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerEntityAttackMixin.java
@@ -13,6 +13,7 @@ import net.onixary.shapeShifterCurseFabric.additional_power.AlwaysSweepingPower;
 import net.onixary.shapeShifterCurseFabric.additional_power.CriticalDamageModifierPower;
 import net.onixary.shapeShifterCurseFabric.additional_power.EnhancedFallingAttackPower;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.*;
 
 import java.util.List;
@@ -42,7 +43,9 @@ public abstract class PlayerEntityAttackMixin {
     }
 
     // 直接改暴击的常量岂不是兼容性更好 对了 之前的版本会导致攻击附魔暴击伤害计算错误
-    @ModifyExpressionValue(method = "attack(Lnet/minecraft/entity/Entity;)V", at = @At(value = "CONSTANT", args = {"floatValue=1.5F"}))
+    // 修改常量容易出现量子态(你观测(打断点 打日志(这个不是100%))就能生效 不观测就不生效) 而且日志里的值是正确的 但就是没生效(可能和常量优化有关系) 调了快1个小时了
+    // @ModifyExpressionValue(method = "attack(Lnet/minecraft/entity/Entity;)V", at = @At(value = "CONSTANT", args = {"floatValue=1.5F"}))
+    @ModifyVariable(method = "attack(Lnet/minecraft/entity/Entity;)V", ordinal = 0, at = @At(value = "STORE", ordinal = 2))
     private float modifyCritMultiplier(float critMultiplier, @Local(ordinal = 0, argsOnly = true) Entity target) {
         PlayerEntity player = (PlayerEntity) (Object) this;
         float finalMultiplier = critMultiplier;

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/mob/SpiderEntityMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/mob/SpiderEntityMixin.java
@@ -1,18 +1,20 @@
 package net.onixary.shapeShifterCurseFabric.mixin.mob;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.entity.EntityType;
-import net.minecraft.entity.ai.goal.Goal;
-import net.minecraft.entity.ai.goal.GoalSelector;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.goal.*;
 import net.minecraft.entity.mob.HostileEntity;
 import net.minecraft.entity.mob.SpiderEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.world.World;
 import net.onixary.shapeShifterCurseFabric.additional_power.AdditionalPowers;
-import net.onixary.shapeShifterCurseFabric.util.ActiveTargetGoalWithCondition;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Set;
+import java.util.function.Predicate;
 
 @Mixin(SpiderEntity.class)
 public class SpiderEntityMixin extends HostileEntity {
@@ -20,9 +22,19 @@ public class SpiderEntityMixin extends HostileEntity {
         super(entityType, world);
     }
 
-    @WrapOperation(at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ai/goal/GoalSelector;add(ILnet/minecraft/entity/ai/goal/Goal;)V", ordinal = 7), method = "initGoals")
-    private void modifyTargetGoal(GoalSelector goalSelector, int priority, Goal goal, Operation<Void> original) {
-        Goal newGoal = new ActiveTargetGoalWithCondition<>(this, PlayerEntity.class, 10, true, false, e -> !AdditionalPowers.SPIDER_FRIENDLY.isActive(e), e -> e.getBrightnessAtEyes() < 0.5f);
-        original.call(goalSelector, priority, newGoal);
+    @Inject(at = @At("TAIL"), method = "initGoals")
+    private void addGoals(CallbackInfo info) {
+        Set<PrioritizedGoal> goals = this.targetSelector.getGoals();
+        for (PrioritizedGoal prioritizedGoal : goals) {
+            if (prioritizedGoal.getGoal() instanceof ActiveTargetGoal<?> atg && prioritizedGoal.getPriority() == 2 && atg.targetClass == PlayerEntity.class) {
+                Predicate<LivingEntity> targetPredicate = atg.targetPredicate.predicate;
+                if (targetPredicate == null) {
+                    targetPredicate = e -> !AdditionalPowers.SPIDER_FRIENDLY.isActive(e);
+                } else {
+                    targetPredicate = targetPredicate.and(e -> !AdditionalPowers.SPIDER_FRIENDLY.isActive(e));
+                }
+                atg.targetPredicate.setPredicate(targetPredicate);
+            }
+        }
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -67,6 +67,12 @@
       "contact": {
         "github": "https://github.com/MimiRabbit87"
       }
+    },
+    {
+      "name": "Sh1roCu",
+      "contact": {
+        "github": "https://github.com/Sh1roCu"
+      }
     }
   ],
 


### PR DESCRIPTION
旧暴击伤害计算有问题 会导致附魔伤害异常(原版是先算暴击 后算附魔增伤 总数直接除1.5后乘暴击倍率会导致附魔出现额外增伤)
蜘蛛友好Power修改Goal的方法改为新版实现方法(类似骷髅和苦力怕) 兼容性更强