### PR TITLE
修复塑形装备warn+无法渲染附魔发光的Bug

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/items/armors/MorphscaleArmorMaterial.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/items/armors/MorphscaleArmorMaterial.java
@@ -56,8 +56,8 @@ public class MorphscaleArmorMaterial  implements ArmorMaterial {
 
     @Override
     public String getName() {
-        // Must be all lowercase
-        return "morphscale";
+        // return "morphscale";
+        return "diamond";
     }
 
     @Override

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/items/armors/NetheriteMorphscaleArmorMaterial.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/items/armors/NetheriteMorphscaleArmorMaterial.java
@@ -57,8 +57,8 @@ public class NetheriteMorphscaleArmorMaterial implements ArmorMaterial {
 
     @Override
     public String getName() {
-        // Must be all lowercase
-        return "netherite_morphscale";
+        // return "netherite_morphscale";
+        return "netherite";
     }
 
     @Override


### PR DESCRIPTION
应该是属于geckolib的Bug(没有完全跳过原版装备渲染 导致尝试读取`"textures/models/armor/" + item.getMaterial().getName() + "_layer_" + (secondLayer ? 2 : 1) + (overlay == null ? "" : "_" + overlay) + ".png";`的贴图) 会爆4个warn并导致附魔视觉效果失效
总共修了快2个小时 最开始打断点一路打到RenderPhase(实际调用读取贴图的函数) 最后发现是GeckoLib修改前原版就设置了贴图 最后又去看了Wiki和其他用GeckoLib的Mod 也没有相关处理 应该确定是GeckoLib的Bug了 wiki的视频还是GeckoLib3的 里面也没相关处理(不过可能GeckoLib3的注入点不一样)
最终还是改了一下材料名称 原版就只有盔甲渲染用了getName 修改为原版的ID应该没问题