### PR TITLE
替换thread.sleep为tick计时

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2C.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2C.java
@@ -38,6 +38,7 @@ import net.onixary.shapeShifterCurseFabric.util.Verify.AuthClient;
 import net.onixary.shapeShifterCurseFabric.util.Verify.AuthFile;
 import org.jetbrains.annotations.Nullable;
 import net.onixary.shapeShifterCurseFabric.util.PatronUtils;
+import net.onixary.shapeShifterCurseFabric.util.ClientTicker;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -241,18 +242,21 @@ public class ModPacketsS2C {
     public static void onPlayerConnectServer(MinecraftClient client, ClientPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
         // 还原FPM设置 或许可以通过注入式修改配置来减少此类Bug 比如在FPM读取offset时修改返回值
         TransformManager.executeClientFirstPersonReset();
-        new Thread(() -> {
-            // 延时5s, 等待服务器component加载完成 重复12次 共计1min
-            for (int i = 0; i < 60; i++) {
-                try {
-                    Thread.sleep(1000);
-                    sendUpdateCustomSetting();
-                    return;
-                } catch (Exception ignored) {
-                }
-            }
+        retrySendCustomSetting(60);
+    }
+
+    private static void retrySendCustomSetting(int attemptsLeft) {
+        if (attemptsLeft <= 0) {
             ShapeShifterCurseFabric.LOGGER.error("Failed to send custom setting to server after 60 seconds");
-        }).start();
+            return;
+        }
+        new ClientTicker(MinecraftClient.getInstance(), () -> {
+            try {
+                sendUpdateCustomSetting();
+            } catch (Exception e) {
+                retrySendCustomSetting(attemptsLeft - 1);
+            }
+        }, 20, true).start();
     }
 
     public static void sendUpdateCustomColor(FormTextureUtils.ColorSetting colorSetting, boolean sendRAW, boolean sendExtraData, boolean keepOriginalSkin, boolean enableFormColorSystem) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/utils/FormUtils.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/utils/FormUtils.java
@@ -23,6 +23,7 @@ import net.onixary.shapeShifterCurseFabric.player_form.RegPlayerForms;
 import net.onixary.shapeShifterCurseFabric.status_effects.attachment.EffectManager;
 import net.onixary.shapeShifterCurseFabric.util.TrinketUtils;
 import net.onixary.shapeShifterCurseFabric.util.Verify.PatronDataSegment;
+import net.onixary.shapeShifterCurseFabric.util.ServerTicker;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -81,31 +82,26 @@ public class FormUtils {
             }
         }
         else {
-            new Thread(() -> {
-                try {
-                    boolean FoundPower = false;
-                    for (int i = 0; i < 20; i++) {
-                        Thread.sleep(100);
-                        if (PowerTypeRegistry.contains(powerId)) {
-                            FoundPower = true;
-                            break;
-                        }
-                    }
-                    if (FoundPower) {
-                        PowerType<?> powerType = PowerTypeRegistry.get(powerId);
-                        if (powerType != null) {
-                            PowerHolderComponent powerHolder = PowerHolderComponent.KEY.get(player);
-                            powerHolder.addPower(powerType, powerSource);
-                        }
-                    }
-                    else {
-                        ShapeShifterCurseFabric.LOGGER.warn("Failed to apply power " + powerId.toString() + " for player " + player.getName() + " after 2 seconds");
-                    }
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-            }).start();
+            retryApplyPower(player, powerId, powerSource, 40);
         }
+    }
+
+    private static void retryApplyPower(PlayerEntity player, Identifier powerId, Identifier powerSource, int attemptsLeft) {
+        if (attemptsLeft <= 0) {
+            ShapeShifterCurseFabric.LOGGER.warn("Failed to apply power {} for player {} after 2 seconds", powerId, player.getName());
+            return;
+        }
+        new ServerTicker(() -> {
+            if (PowerTypeRegistry.contains(powerId)) {
+                PowerType<?> powerType = PowerTypeRegistry.get(powerId);
+                if (powerType != null) {
+                    PowerHolderComponent powerHolder = PowerHolderComponent.KEY.get(player);
+                    powerHolder.addPower(powerType, powerSource);
+                }
+            } else {
+                retryApplyPower(player, powerId, powerSource, attemptsLeft - 1);
+            }
+        }, 1, true).start();
     }
 
     public static void removePower(PlayerEntity player, Identifier powerId, Identifier powerSource) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/utils/TransformManager.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/player_form/utils/TransformManager.java
@@ -5,6 +5,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.PacketByteBuf;
@@ -19,6 +20,7 @@ import net.onixary.shapeShifterCurseFabric.player_form.IForm;
 import net.onixary.shapeShifterCurseFabric.player_form.effect.PlayerTransformEffectManager;
 import net.onixary.shapeShifterCurseFabric.screen_effect.TransformOverlay;
 import net.onixary.shapeShifterCurseFabric.status_effects.attachment.EffectManager;
+import net.onixary.shapeShifterCurseFabric.util.ClientTicker;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -220,16 +222,12 @@ public class TransformManager {
             fpm.getConfig().xOffset = 0;
             fpm.getConfig().sitXOffset = 0;
             fpm.getConfig().sneakXOffset = 0;
-            new Thread(() -> {
-                for (int i = 0; i < 20; i++) {
-                    try {
-                        Thread.sleep(50);
-                    } catch (InterruptedException ignored) { }
-                    fpm.getConfig().xOffset = 0;
-                    fpm.getConfig().sitXOffset = 0;
-                    fpm.getConfig().sneakXOffset = 0;
-                }
-            }).start();
+            ClientTicker ticker = new ClientTicker(MinecraftClient.getInstance(), () -> {
+                fpm.getConfig().xOffset = 0;
+                fpm.getConfig().sitXOffset = 0;
+                fpm.getConfig().sneakXOffset = 0;
+            }, 20);
+            ticker.start();
         }
     }
 

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/ClientTicker.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/ClientTicker.java
@@ -9,19 +9,30 @@ public class ClientTicker implements ClientTickable {
     private final MinecraftClient client;
     private final Runnable task;
     private int ticksRemaining;
+    private final boolean runOnce;
 
-    public ClientTicker(MinecraftClient client, Runnable task, int durationTicks) {
+    public ClientTicker(MinecraftClient client, Runnable task, int durationTicks, boolean runOnce) {
         this.client = client;
         this.task = task;
         this.ticksRemaining = durationTicks;
+        this.runOnce = runOnce;
+    }
+
+    public ClientTicker(MinecraftClient client, Runnable task, int durationTicks) {
+        this(client, task, durationTicks, false);
     }
 
     @Override
     public void tick() {
-        //ShapeShifterCurseFabric.LOGGER.info("Client ticker tick");
         if (ticksRemaining > 0) {
-            task.run();
+            if (!runOnce) {
+                task.run();
+            }
             ticksRemaining--;
+            if (runOnce && ticksRemaining == 0) {
+                task.run();
+                TickManager.removeTickable(this);
+            }
         } else {
             TickManager.removeTickable(this);
         }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/FormColorData.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/FormColorData.java
@@ -240,15 +240,8 @@ public class FormColorData {
             ModPacketsS2C.sendUpdateCustomColor(this.formDefaultSetting.get(form), false, false,false, false);
         }
         this.unlockForm(form);
-        // 延时一下 好同步 "sendUpdateCustomSetting" 的更新
-        new Thread(() -> {
-            try {
-                Thread.sleep(1000);
-                onFormChangeListeners.forEach(listener -> listener.accept(form));
-            } catch (InterruptedException ignored) {
-                onFormChangeListeners.forEach(listener -> listener.accept(form));
-            }
-        }).start();
+        // 延时 20 tick 确保 "sendUpdateCustomSetting" 的更新同步完成
+        new ClientTicker(MinecraftClient.getInstance(), () -> onFormChangeListeners.forEach(listener -> listener.accept(form)), 20, true).start();
     }
 
     public Path getConfigPath() {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/PatronUtils.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/PatronUtils.java
@@ -58,15 +58,21 @@ public class PatronUtils {
             // 开启服务器时无论如何都要更新一次
             PatronUtils.UpdateDataPack(server);
         }
-        long sleepSeconds = commonConfig.CheckUpdateInterval;
-        if (sleepSeconds > 0) {
-            new ServerTicker(() -> {
+        new Thread(() -> {  // 如果之后有需要持续监控更新(长时间线程) 需要搓一个系统合并一下
+            try {
+                long SleepTime = commonConfig.CheckUpdateInterval;
+                if (SleepTime <= 0) {
+                    return;
+                }
+                Thread.sleep(SleepTime * 1000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
                 PatronUtils.UpdatePatronData(server);
                 if (commonConfig.enablePatronFormSystem) {
                     PatronUtils.CheckDataPackUpdate(server);
                 }
-            }, (int)(sleepSeconds * 20), true).start();
-        }
+        }).start();
     }
 
     private static List<JsonObject> ReadDataPackZip(byte[] dataPackZip) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/PatronUtils.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/PatronUtils.java
@@ -58,21 +58,15 @@ public class PatronUtils {
             // 开启服务器时无论如何都要更新一次
             PatronUtils.UpdateDataPack(server);
         }
-        new Thread(() -> {  // 如果之后有需要持续监控更新(长时间线程) 需要搓一个系统合并一下
-            try {
-                long SleepTime = commonConfig.CheckUpdateInterval;
-                if (SleepTime <= 0) {
-                    return;
+        long sleepSeconds = commonConfig.CheckUpdateInterval;
+        if (sleepSeconds > 0) {
+            new ServerTicker(() -> {
+                PatronUtils.UpdatePatronData(server);
+                if (commonConfig.enablePatronFormSystem) {
+                    PatronUtils.CheckDataPackUpdate(server);
                 }
-                Thread.sleep(SleepTime * 1000);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-            PatronUtils.UpdatePatronData(server);
-            if (commonConfig.enablePatronFormSystem) {
-                PatronUtils.CheckDataPackUpdate(server);
-            }
-        }).start();
+            }, (int)(sleepSeconds * 20), true).start();
+        }
     }
 
     private static List<JsonObject> ReadDataPackZip(byte[] dataPackZip) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/PlayerEventHandler.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/PlayerEventHandler.java
@@ -80,22 +80,12 @@ public class PlayerEventHandler {
 
             // 添加延迟同步，确保客户端完全加载后再次发送状态
             // 延迟40个tick（2秒）再次同步
-            // 反正都得延时2秒 先不在主线程处跑了 等新建的线程等完2秒后再切进主线程
-            new Thread(() -> {
-                try {
-                    Thread.sleep(2000);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
+            new ServerTicker(() -> {
+                if (player.networkHandler != null && !player.isDisconnected()) {
+                    ServerWorld currentWorld = player.getServerWorld();
+                    ModPacketsS2CServer.sendCursedMoonData(player, CursedMoon.isCursedMoonDay(currentWorld));
                 }
-
-                // 在主线程中执行同步
-                server.execute(() -> {
-                    if (player.networkHandler != null && !player.isDisconnected()) {
-                        ServerWorld currentWorld = player.getServerWorld();
-                        ModPacketsS2CServer.sendCursedMoonData(player, CursedMoon.isCursedMoonDay(currentWorld));
-                    }
-                });
-            }).start();
+            }, 40, true).start();
 
             // Set doDaylightCycle to true forced
             //server.getGameRules().get(GameRules.DO_DAYLIGHT_CYCLE).set(true, server);

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/ServerTicker.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/ServerTicker.java
@@ -1,24 +1,32 @@
 // src/main/java/net/onixary/shapeShifterCurseFabric/util/ServerTicker.java
 package net.onixary.shapeShifterCurseFabric.util;
 
-import net.minecraft.server.MinecraftServer;
-
 public class ServerTicker implements ServerTickable {
-    private final MinecraftServer server;
     private final Runnable task;
     private int ticksRemaining;
+    private final boolean runOnce;
 
-    public ServerTicker(MinecraftServer server, Runnable task, int durationTicks) {
-        this.server = server;
+    public ServerTicker(Runnable task, int durationTicks, boolean runOnce) {
         this.task = task;
         this.ticksRemaining = durationTicks;
+        this.runOnce = runOnce;
+    }
+
+    public ServerTicker(Runnable task, int durationTicks) {
+        this(task, durationTicks, false);
     }
 
     @Override
     public void tick() {
         if (ticksRemaining > 0) {
-            task.run();
+            if (!runOnce) {
+                task.run();
+            }
             ticksRemaining--;
+            if (runOnce && ticksRemaining == 0) {
+                task.run();
+                TickManager.removeTickable(this);
+            }
         } else {
             TickManager.removeTickable(this);
         }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/Verify/AuthServer.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/Verify/AuthServer.java
@@ -9,6 +9,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.onixary.shapeShifterCurseFabric.networking.ModPacketsS2CServer;
 import net.onixary.shapeShifterCurseFabric.player_form.IForm;
 import net.onixary.shapeShifterCurseFabric.player_form.utils.FormUtils;
+import net.onixary.shapeShifterCurseFabric.util.ServerTicker;
 
 import java.util.HashMap;
 import java.util.UUID;
@@ -129,14 +130,7 @@ public final class AuthServer {
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
             ServerPlayerEntity player = handler.getPlayer();
             ModPacketsS2CServer.requestPatronAuthFile(player);
-            new Thread(() -> {
-                try {
-                    Thread.sleep(30 * 1000);  // 30s
-                } catch (InterruptedException e) {
-                    checkPatronStatus(handler.getPlayer());
-                }
-                checkPatronStatus(handler.getPlayer());
-            }).start();
+            new ServerTicker(() -> checkPatronStatus(handler.getPlayer()), 600, true).start();
         });
     }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/Verify/AuthServer.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/Verify/AuthServer.java
@@ -9,7 +9,6 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.onixary.shapeShifterCurseFabric.networking.ModPacketsS2CServer;
 import net.onixary.shapeShifterCurseFabric.player_form.IForm;
 import net.onixary.shapeShifterCurseFabric.player_form.utils.FormUtils;
-import net.onixary.shapeShifterCurseFabric.util.ServerTicker;
 
 import java.util.HashMap;
 import java.util.UUID;
@@ -130,7 +129,14 @@ public final class AuthServer {
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
             ServerPlayerEntity player = handler.getPlayer();
             ModPacketsS2CServer.requestPatronAuthFile(player);
-            new ServerTicker(() -> checkPatronStatus(handler.getPlayer()), 600, true).start();
+            new Thread(() -> {
+                try {
+                    Thread.sleep(30 * 1000);  // 30s
+                } catch (InterruptedException e) {
+                    checkPatronStatus(handler.getPlayer());
+                }
+                checkPatronStatus(handler.getPlayer());
+            }).start();
         });
     }
 }


### PR DESCRIPTION
对于常规的代码逻辑，我改造`ClientTicker`/`ServerTicker`然后以此替换`thread.sleep`，tick计时会更准确，在我的sscu经过了很多个版本的验证

对于对于`AuthServer`和`PatronUtils`，这两个涉及的交互就不在MC的范围内了，所以维持原模式

我一贯的想法是，MC游戏状态的修改应该是严格绑定游戏tick的

现在写的没以前那么激进了，写的很短，从性能上来看，没有改进，但是采取Tick计数会更准确

虽然服务器低TPS时，实际等待的时间会延长，但从游戏逻辑来看是合理的

关于`PatronUtils`和`AuthServer`的验证，我之前想过用`ScheduledExecutorService`，但是我不太会写，也就不敢让AI动