### PR TITLE
修复FCS的子形态渲染异常Bug

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/FormColorSelectMenu.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/FormColorSelectMenu.java
@@ -1544,7 +1544,8 @@ public class FormColorSelectMenu extends Screen implements FormTextureUtils.Temp
 
     @Override
     public Identifier getLayerID() {
-        return this.getForm().getFormLayer().getRight();
+        IForm playerForm = this.getForm();
+        return playerForm.getRenderLayerOverride() == null ? playerForm.getFormLayer().getRight() : playerForm.getRenderLayerOverride().getRight();
     }
 
     @Override

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/FormColorSelectMenuV2.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/FormColorSelectMenuV2.java
@@ -298,7 +298,8 @@ public class FormColorSelectMenuV2 extends Screen implements FormTextureUtils.Te
 
     @Override
     public Identifier getLayerID() {
-        return this.getForm().getFormLayer().getRight();
+        IForm playerForm = this.getForm();
+        return playerForm.getRenderLayerOverride() == null ? playerForm.getFormLayer().getRight() : playerForm.getRenderLayerOverride().getRight();
     }
 
     @Override


### PR DESCRIPTION
给子形态加的接口忘了改FCS了 现在子形态渲染正常了