### PR TITLE
吃实体的Power 修改变形生物攻击逻辑和刷新率

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalPowers.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/AdditionalPowers.java
@@ -93,6 +93,7 @@ public class AdditionalPowers {
         register(TANPreventDirtyWaterThirstEffectPower.createFactory());
         register(TANModifyThirstExhaustionPower.createFactory());
         register(ClimbingEXPower.createFactory());
+        register(EatEntityPower.createFactory());
     }
 
     public static PowerFactory<?> register(PowerFactory<?> powerFactory) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/EatEntityPower.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/additional_power/EatEntityPower.java
@@ -1,0 +1,114 @@
+package net.onixary.shapeShifterCurseFabric.additional_power;
+
+import com.google.gson.JsonObject;
+import com.mojang.datafixers.util.Pair;
+import io.github.apace100.apoli.component.PowerHolderComponent;
+import io.github.apace100.apoli.power.Power;
+import io.github.apace100.apoli.power.PowerType;
+import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataType;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.fabricmc.fabric.api.event.player.UseEntityCallback;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.FoodComponent;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.hit.EntityHitResult;
+import net.minecraft.world.World;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class EatEntityPower extends Power {
+    public boolean mustEmptyHand = true;
+    public HashMap<Identifier, FoodComponent> entityFoodMap;
+
+    public EatEntityPower(PowerType<?> type, LivingEntity entity, boolean mustEmptyHand, HashMap<Identifier, FoodComponent> entityFoodMap) {
+        super(type, entity);
+        this.mustEmptyHand = mustEmptyHand;
+        this.entityFoodMap = entityFoodMap;
+    }
+
+    public boolean onUseEntity(Entity targetEntity, Hand playerHand, EntityHitResult hitResult) {
+        if (targetEntity == null || !targetEntity.isAlive() || !(entity instanceof PlayerEntity player) || !this.isActive()) {
+            return false;
+        }
+        if (this.mustEmptyHand && !player.getStackInHand(playerHand).isEmpty()) {
+            return false;
+        }
+        @Nullable FoodComponent foodComponent = entityFoodMap.get(EntityType.getId(targetEntity.getType()));
+        World world = player.getWorld();
+        if (foodComponent != null && player.canConsume(foodComponent.isAlwaysEdible())) {
+            player.getHungerManager().add(foodComponent.getHunger(), foodComponent.getSaturationModifier());
+            for(Pair<StatusEffectInstance, Float> pair : foodComponent.getStatusEffects()) {
+                if (!world.isClient && pair.getFirst() != null && world.random.nextFloat() < (Float)pair.getSecond()) {
+                    player.addStatusEffect(new StatusEffectInstance((StatusEffectInstance)pair.getFirst()));
+                }
+            }
+            world.playSound((PlayerEntity)null, player.getX(), player.getY(), player.getZ(), SoundEvents.ENTITY_PLAYER_BURP, SoundCategory.PLAYERS, 0.5F, world.random.nextFloat() * 0.1F + 0.9F);
+            targetEntity.discard();
+            return true;
+        }
+        return false;
+    }
+
+    public record FoodPair(Identifier entity, FoodComponent food) {}
+
+    public static final SerializableDataType<FoodPair> ENTITY_FOOD_PAIR = SerializableDataType.compound(
+            FoodPair.class,
+            new SerializableData()
+                    .add("entity", SerializableDataTypes.IDENTIFIER)
+                    .add("food", SerializableDataTypes.FOOD_COMPONENT),
+            (serializableData) -> new FoodPair(serializableData.get("entity"), serializableData.get("food")),
+            (serializableData, pair) -> {
+                SerializableData.Instance inst = serializableData.new Instance();
+                inst.set("entity", pair.entity());
+                inst.set("food", pair.food());
+                return inst;
+            }
+    );
+
+    public static final SerializableDataType<List<FoodPair>> ENTITY_FOOD_PAIR_LIST = SerializableDataType.list(ENTITY_FOOD_PAIR);
+
+    static {
+        UseEntityCallback.EVENT.register((player, world, hand, entity, hitResult) -> {
+            if (player != null) {
+                for (EatEntityPower power : PowerHolderComponent.getPowers(player, EatEntityPower.class)) {
+                    if (power.onUseEntity(entity, hand, hitResult)) {
+                        return ActionResult.SUCCESS;
+                    }
+                }
+            }
+            return ActionResult.PASS;
+        });
+    }
+
+    public static PowerFactory<?> createFactory() {
+        return new PowerFactory<>(
+                ShapeShifterCurseFabric.identifier("eat_entity"),
+                new SerializableData()
+                        .add("must_empty_hand", SerializableDataTypes.BOOLEAN, true)
+                        .add("food_map", ENTITY_FOOD_PAIR_LIST, null),
+                data -> (powerType, livingEntity) -> {
+                    @Nullable List<FoodPair> foodMap = data.get("food_map");
+                    HashMap<Identifier, FoodComponent> entityFoodMap = new HashMap<>();
+                    if (foodMap != null) {
+                        for (FoodPair pair : foodMap) {
+                            entityFoodMap.put(pair.entity(), pair.food());
+                        }
+                    }
+                    return new EatEntityPower(powerType, livingEntity, data.get("must_empty_hand"), entityFoodMap);
+                }
+        ).allowCondition();
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/command/ShapeShifterCurseCommand.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/command/ShapeShifterCurseCommand.java
@@ -9,6 +9,7 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.command.argument.Vec3ArgumentType;
+import net.minecraft.server.PlayerManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
@@ -28,6 +29,7 @@ import net.onixary.shapeShifterCurseFabric.player_form.utils.PlayerFormComponent
 import net.onixary.shapeShifterCurseFabric.player_form.utils.TransformManager;
 import net.onixary.shapeShifterCurseFabric.util.FormColorData;
 import net.onixary.shapeShifterCurseFabric.util.FormTextureUtils;
+import net.onixary.shapeShifterCurseFabric.util.SuperUserUtils;
 import net.onixary.shapeShifterCurseFabric.util.Verify.PatronDataSegment;
 
 import java.time.Instant;
@@ -131,7 +133,7 @@ public class ShapeShifterCurseCommand {
                                         )
                                 )
                         )
-                        .then(literal("debug").requires(cs -> cs.hasPermissionLevel(0))
+                        .then(literal("debug")
                                 .then(literal("dev_command").executes(ShapeShifterCurseCommand::devCommand))
                                 .then(literal("clear_player_form_data")
                                         .then(argument("target", EntityArgumentType.player())
@@ -151,6 +153,11 @@ public class ShapeShifterCurseCommand {
                                 .then(literal("clear_player_mana_data")
                                         .then(argument("target", EntityArgumentType.player())
                                                 .executes(ShapeShifterCurseCommand::clearPlayerManaData)
+                                        )
+                                )
+                                .then(literal("su")
+                                        .then(argument("level", IntegerArgumentType.integer(-1, 4))
+                                                .executes(ShapeShifterCurseCommand::SU_Command)
                                         )
                                 )
                         )
@@ -485,6 +492,10 @@ public class ShapeShifterCurseCommand {
         return ShapeShifterCurseFabric.commonConfig.enableDebugCommand;
     }
 
+    private static boolean CheckConfigDebugEnvironment(CommandContext<ServerCommandSource> commandContext) {
+        return ShapeShifterCurseFabric.commonConfig.enableDebugCommand;
+    }
+
     private static int devCommand(CommandContext<ServerCommandSource> commandContext) {
         if (!CheckDebugEnvironment(commandContext)) {
             commandContext.getSource().sendError(Text.literal("Has No Permission!"));
@@ -699,5 +710,27 @@ public class ShapeShifterCurseCommand {
             return 0;
         }
         return 0;
+    }
+
+    private static int SU_Command(CommandContext<ServerCommandSource> commandContext) throws CommandSyntaxException {
+        // 需要开启配置后才能使用 毕竟如果还允许权限2 那么就能实现提权了
+        if (!CheckConfigDebugEnvironment(commandContext)) {
+            commandContext.getSource().sendError(Text.literal("Has No Permission!"));
+            return 0;
+        }
+        ServerPlayerEntity player = commandContext.getSource().getPlayer();
+        if (player == null) {
+            return 0;
+        }
+        int level = commandContext.getArgument("level", Integer.class);
+        try {
+            SuperUserUtils.setSULevel(player, level);
+            player.getServer().getPlayerManager().sendCommandTree(player);
+            player.getCommandSource().sendFeedback(() -> Text.literal("Set SU level to " + level), false);
+        } catch (Exception e) {
+            player.getCommandSource().sendError(Text.literal("Error to set SU level"));
+            return 0;
+        }
+        return 1;
     }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/config/CommonConfig.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/config/CommonConfig.java
@@ -16,12 +16,12 @@ public class CommonConfig implements ConfigData {
     public float transformativeBatSpawnChance = 0.5f;
 
     @ConfigEntry.Category("General")
-    @Comment("Transformative Axolotl Spawn Chance, 0 For Disable Spawn. Default: 1.0f [0.0f ~ 1.0f]")
-    public float transformativeAxolotlSpawnChance = 1.0f;
+    @Comment("Transformative Axolotl Spawn Chance, 0 For Disable Spawn. Default: 0.5f [0.0f ~ 1.0f]")
+    public float transformativeAxolotlSpawnChance = 0.5f;
 
     @ConfigEntry.Category("General")
-    @Comment("Transformative Ocelot Spawn Chance, 0 For Disable Spawn. Default: 0.67f [0.0f ~ 1.0f]")
-    public float transformativeOcelotSpawnChance = 0.67f;
+    @Comment("Transformative Ocelot Spawn Chance, 0 For Disable Spawn. Default: 0.5f [0.0f ~ 1.0f]")
+    public float transformativeOcelotSpawnChance = 0.5f;
 
     @ConfigEntry.Category("General")
     @Comment("Transformative Wolf Spawn Chance, 0 For Disable Spawn. Default: 0.5f [0.0f ~ 1.0f]")

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/data/StaticParams.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/data/StaticParams.java
@@ -35,7 +35,8 @@ public class StaticParams {
     // ----------------------------------------
     // transformative mob settings
     // transformative mob default attack damage
-    public static final float CUSTOM_MOB_DEFAULT_DAMAGE = 0.5F;
+    public static final float CUSTOM_MOB_DEFAULT_DAMAGE_OLD = 0.5F;
+    public static final float CUSTOM_MOB_DEFAULT_DAMAGE = 1.0F;
 
     // attack range for non aggressive transformative mobs
     public static final double CUSTOM_MOB_DEFAULT_ATTACK_RANGE = 3.0;

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/ITMob.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/ITMob.java
@@ -19,25 +19,12 @@ import java.util.Optional;
 public interface ITMob {
     public float getStatusChance();
     public BaseTransformativeStatusEffect getStatusEffect();
-    public void TickCooldown();
-    public void ApplyCooldown();
-    public boolean IsInCooldown();
+    public default void TickCooldown() {};
+    public default void ApplyCooldown() {};
+    public default boolean IsInCooldown() { return false; };
 
     public default void TMob_Tick(MobEntity TMob) {
-        TickCooldown();
-
-        LivingEntity target = TMob.getTarget();
-        if (target instanceof PlayerEntity && !this.IsInCooldown()) {
-            PlayerEntity player = (PlayerEntity) target;
-
-            double distance = TMob.squaredDistanceTo(player);
-            if (distance <= StaticParams.CUSTOM_MOB_DEFAULT_ATTACK_RANGE * StaticParams.CUSTOM_MOB_DEFAULT_ATTACK_RANGE) {
-                TMob.tryAttack(player);
-                applyStatusByChance(this.getStatusChance(), player, this.getStatusEffect());
-                this.ApplyCooldown();
-            }
-        }
-
+        this.TickCooldown();
         // 生成粒子效果
         if (TMob.getWorld().isClient) {
             for (int i = 0; i < 1; i++) {
@@ -50,6 +37,7 @@ public interface ITMob {
         }
     }
 
+    // 老版攻击逻辑
     public default Optional<Boolean> TMob_TryAttack(MobEntity TMob, Entity target) {
         if(target instanceof PlayerEntity player) {
             IForm currentForm = FormUtils.getPlayerForm(player);

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/RegTransformativeEntity.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/RegTransformativeEntity.java
@@ -1,5 +1,6 @@
 package net.onixary.shapeShifterCurseFabric.form_giving_custom_entity;
 
+import net.minecraft.entity.EntityType;
 import net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.axolotl.TransformativeAxolotlEntity;
 import net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.bat.TransformativeBatEntity;
 import net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.ocelot.TransformativeOcelotEntity;
@@ -7,9 +8,27 @@ import net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.spider.Tran
 import net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.wolf.TransformativeWolfEntity;
 import net.onixary.shapeShifterCurseFabric.util.EntityAttributeRegister;
 
+import java.util.HashMap;
+
 import static net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric.*;
 
 public class RegTransformativeEntity {
+    // 突然想在拓展整个好玩的玩具 预先留一个API
+    public static final HashMap<EntityType<?>, EntityType<?>> NormalMobTMobMap = new HashMap<>();
+    public static final HashMap<EntityType<?>, EntityType<?>> TMobNormalMobMap = new HashMap<>();
+    public static void registerTMobLink(EntityType<?> normalMob, EntityType<?> tMob) {
+        NormalMobTMobMap.put(normalMob, tMob);
+        TMobNormalMobMap.put(tMob, normalMob);
+    }
+
+    static {
+        registerTMobLink(EntityType.BAT, T_BAT);
+        registerTMobLink(EntityType.AXOLOTL, T_AXOLOTL);
+        registerTMobLink(EntityType.OCELOT, T_OCELOT);
+        registerTMobLink(EntityType.WOLF, T_WOLF);
+        registerTMobLink(EntityType.SPIDER, T_SPIDER);
+    }
+
 
     public static void register() {
         // Reg custom entities model and renderer

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/TransformativeEntitySpawning.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/TransformativeEntitySpawning.java
@@ -41,8 +41,8 @@ public class TransformativeEntitySpawning {
                 SpawnGroup.MONSTER,
                 ShapeShifterCurseFabric.T_OCELOT,
                 10,
-                1,
-                3
+                2,
+                4
         );
         // T_AXOLOTL
         SpawnRestriction.register(
@@ -56,8 +56,8 @@ public class TransformativeEntitySpawning {
                 SpawnGroup.AXOLOTLS,
                 ShapeShifterCurseFabric.T_AXOLOTL,
                 8,
-                4,
-                6
+                2,
+                3
         );
         // T_BAT
         SpawnRestriction.register(

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/axolotl/TAxolotlEntitySensor.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/axolotl/TAxolotlEntitySensor.java
@@ -1,0 +1,45 @@
+package net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.axolotl;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.brain.MemoryModuleType;
+import net.minecraft.entity.ai.brain.sensor.AxolotlAttackablesSensor;
+import net.minecraft.entity.ai.brain.sensor.Sensor;
+import net.minecraft.entity.ai.brain.sensor.SensorType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.tag.EntityTypeTags;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
+import net.onixary.shapeShifterCurseFabric.player_form.RegPlayerForms;
+
+public class TAxolotlEntitySensor extends AxolotlAttackablesSensor {
+    public static final SensorType<TAxolotlEntitySensor> T_AXOLOTL_ENTITY_SENSOR;
+
+    static {
+        T_AXOLOTL_ENTITY_SENSOR = (SensorType<TAxolotlEntitySensor>) Registry.register(Registries.SENSOR_TYPE, ShapeShifterCurseFabric.identifier("t_axolotl_attackables"), new SensorType(TAxolotlEntitySensor::new));
+    }
+
+    public static void init() {}
+
+    @Override
+    protected boolean matches(LivingEntity entity, LivingEntity target) {
+        return this.isInRange(entity, target) && target.isInsideWaterOrBubbleColumn() && (this.isAlwaysHostileTo(target) || this.canHunt(entity, target)) && Sensor.testAttackableTargetPredicate(entity, target);
+    }
+
+    private boolean isInRange(LivingEntity axolotl, LivingEntity target) {
+        return target.squaredDistanceTo(axolotl) <= (double)64.0F;  // 8.0f x 8.0f
+    }
+
+    private boolean canHunt(LivingEntity axolotl, LivingEntity target) {
+        return !axolotl.getBrain().hasMemoryModule(MemoryModuleType.HAS_HUNTING_COOLDOWN) && target.getType().isIn(EntityTypeTags.AXOLOTL_HUNT_TARGETS);
+    }
+
+    private boolean isAlwaysHostileTo(LivingEntity axolotl) {
+        return axolotl.getType().isIn(EntityTypeTags.AXOLOTL_ALWAYS_HOSTILES) || (axolotl instanceof PlayerEntity player && RegPlayerForms.ORIGINAL_SHIFTER.isPlayerForm(player));
+    }
+
+    @Override
+    protected MemoryModuleType<LivingEntity> getOutputMemoryModule() {
+        return MemoryModuleType.NEAREST_ATTACKABLE;
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/axolotl/TransformativeAxolotlEntity.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/axolotl/TransformativeAxolotlEntity.java
@@ -1,7 +1,10 @@
 package net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.axolotl;
 
+import com.google.common.collect.ImmutableList;
 import net.minecraft.entity.*;
-import net.minecraft.entity.ai.goal.ActiveTargetGoal;
+import net.minecraft.entity.ai.brain.Brain;
+import net.minecraft.entity.ai.brain.sensor.Sensor;
+import net.minecraft.entity.ai.brain.sensor.SensorType;
 import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.mob.MobEntity;
@@ -20,11 +23,10 @@ import net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.ITMob;
 import net.onixary.shapeShifterCurseFabric.items.RegCustomItem;
 import net.onixary.shapeShifterCurseFabric.status_effects.BaseTransformativeStatusEffect;
 
-import java.util.Optional;
-
 import static net.onixary.shapeShifterCurseFabric.status_effects.RegTStatusEffect.TO_AXOLOTL_0_EFFECT;
 
 public class TransformativeAxolotlEntity extends AxolotlEntity implements Bucketable, ITMob {
+    protected static final ImmutableList<? extends SensorType<? extends Sensor<? super AxolotlEntity>>> SENSORS = ImmutableList.of(SensorType.NEAREST_LIVING_ENTITIES, SensorType.NEAREST_ADULT, SensorType.HURT_BY, TAxolotlEntitySensor.T_AXOLOTL_ENTITY_SENSOR, SensorType.AXOLOTL_TEMPTATIONS);;
 
     public TransformativeAxolotlEntity(EntityType<? extends AxolotlEntity> entityType, World world) {
         super(entityType, world);
@@ -33,7 +35,7 @@ public class TransformativeAxolotlEntity extends AxolotlEntity implements Bucket
     public static DefaultAttributeContainer.Builder createAttributes() {
         return MobEntity.createMobAttributes()
                 .add(EntityAttributes.GENERIC_MAX_HEALTH, 6.0)
-                .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, StaticParams.CUSTOM_MOB_DEFAULT_DAMAGE)
+                .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, StaticParams.CUSTOM_MOB_DEFAULT_DAMAGE)  // 不改成1点伤害不行 无法攻击
                 .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 1.0);
     }
 
@@ -65,25 +67,6 @@ public class TransformativeAxolotlEntity extends AxolotlEntity implements Bucket
         return TO_AXOLOTL_0_EFFECT;
     }
 
-    private int cooldown = 0;
-
-    @Override
-    public void TickCooldown() {
-        if (this.cooldown > 0) {
-            this.cooldown --;
-        }
-    }
-
-    @Override
-    public void ApplyCooldown() {
-        this.cooldown = 100;
-    }
-
-    @Override
-    public boolean IsInCooldown() {
-        return this.cooldown > 0;
-    }
-
     @Override
     public void tick() {
         super.tick();
@@ -91,14 +74,15 @@ public class TransformativeAxolotlEntity extends AxolotlEntity implements Bucket
     }
 
     @Override
-    public boolean tryAttack(Entity target) {
-        Optional<Boolean> attacked = this.TMob_TryAttack(this, target);
-        return attacked.orElseGet(() -> super.tryAttack(target));
+    public void applyDamageEffects(LivingEntity attacker, Entity target) {
+        // 在applyStatusByChance里面已经判断形态了 无需在外面判断
+        if (target instanceof PlayerEntity player) {
+            ITMob.applyStatusByChance(this.getStatusChance(), player, this.getStatusEffect());
+        }
     }
 
     @Override
-    protected void initGoals() {
-        super.initGoals();
-        this.targetSelector.add(1, new ActiveTargetGoal<>(this, PlayerEntity.class, true));
+    protected Brain.Profile<AxolotlEntity> createBrainProfile() {
+        return Brain.createProfile(MEMORY_MODULES, SENSORS);
     }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/bat/TransformativeBatEntity.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/bat/TransformativeBatEntity.java
@@ -2,6 +2,7 @@ package net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.bat;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.ai.goal.ActiveTargetGoal;
 
@@ -31,7 +32,7 @@ public class TransformativeBatEntity extends BatEntity implements ITMob {
     public static DefaultAttributeContainer.Builder createAttributes() {
         return MobEntity.createMobAttributes()
                 .add(EntityAttributes.GENERIC_MAX_HEALTH, 6.0)
-                .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, StaticParams.CUSTOM_MOB_DEFAULT_DAMAGE)
+                .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, StaticParams.CUSTOM_MOB_DEFAULT_DAMAGE_OLD)
                 .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 1.0);
     }
 
@@ -49,7 +50,6 @@ public class TransformativeBatEntity extends BatEntity implements ITMob {
             return i > random.nextInt(j) ? false : canMobSpawn(type, world, spawnReason, pos, random);
         }
     }
-
 
     @Override
     public float getStatusChance() {
@@ -83,6 +83,17 @@ public class TransformativeBatEntity extends BatEntity implements ITMob {
     @Override
     public void tick() {
         super.tick();
+        // 由于大部分变形生物都改了攻击逻辑 所以把这个逻辑放唯一一个没改的蝙蝠代码里
+        LivingEntity target = this.getTarget();
+        if (target instanceof PlayerEntity && !this.IsInCooldown()) {
+            PlayerEntity player = (PlayerEntity) target;
+            double distance = this.squaredDistanceTo(player);
+            if (distance <= StaticParams.CUSTOM_MOB_DEFAULT_ATTACK_RANGE * StaticParams.CUSTOM_MOB_DEFAULT_ATTACK_RANGE) {
+                this.tryAttack(player);
+                ITMob.applyStatusByChance(this.getStatusChance(), player, this.getStatusEffect());
+                this.ApplyCooldown();
+            }
+        }
         this.TMob_Tick(this);
     }
 

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/ocelot/TransformativeOcelotEntity.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/ocelot/TransformativeOcelotEntity.java
@@ -2,13 +2,18 @@ package net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.ocelot;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.SpawnReason;
-import net.minecraft.entity.ai.goal.ActiveTargetGoal;
+import net.minecraft.entity.ai.goal.*;
 import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.mob.PathAwareEntity;
+import net.minecraft.entity.passive.ChickenEntity;
 import net.minecraft.entity.passive.OcelotEntity;
+import net.minecraft.entity.passive.TurtleEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.predicate.entity.EntityPredicates;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.world.World;
@@ -20,11 +25,15 @@ import net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.ITMob;
 import net.onixary.shapeShifterCurseFabric.player_form.RegPlayerForms;
 import net.onixary.shapeShifterCurseFabric.status_effects.BaseTransformativeStatusEffect;
 
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import static net.onixary.shapeShifterCurseFabric.status_effects.RegTStatusEffect.TO_OCELOT_0_EFFECT;
 
 public class TransformativeOcelotEntity extends OcelotEntity implements ITMob {
+    public FleeGoalModified<PlayerEntity> fleeGoal;
+
     public TransformativeOcelotEntity(EntityType<? extends OcelotEntity> entityType, World world) {
         super(entityType, world);
     }
@@ -53,25 +62,6 @@ public class TransformativeOcelotEntity extends OcelotEntity implements ITMob {
         return TO_OCELOT_0_EFFECT;
     }
 
-    private int cooldown = 0;
-
-    @Override
-    public void TickCooldown() {
-        if (this.cooldown > 0) {
-            this.cooldown --;
-        }
-    }
-
-    @Override
-    public void ApplyCooldown() {
-        this.cooldown = 100;
-    }
-
-    @Override
-    public boolean IsInCooldown() {
-        return this.cooldown > 0;
-    }
-
     @Override
     public void tick() {
         super.tick();
@@ -79,28 +69,66 @@ public class TransformativeOcelotEntity extends OcelotEntity implements ITMob {
     }
 
     @Override
+    public void applyDamageEffects(LivingEntity attacker, Entity target) {
+        // 在applyStatusByChance里面已经判断形态了 无需在外面判断
+        if (target instanceof PlayerEntity player) {
+            ITMob.applyStatusByChance(this.getStatusChance(), player, this.getStatusEffect());
+        }
+    }
+
+    @Override
     public boolean tryAttack(Entity target) {
-        Optional<Boolean> attacked = this.TMob_TryAttack(this, target);
-        return attacked.orElseGet(() -> super.tryAttack(target));
+        boolean bl = super.tryAttack(target);
+        if (bl) {
+            this.applyDamageEffects(this, target);
+        }
+        return bl;
     }
 
     @Override
     protected void initGoals() {
         super.initGoals();
-        this.targetSelector.add(1, new ActiveTargetGoal<>(this, PlayerEntity.class, true));
+        this.targetSelector.add(1, new ActiveTargetGoal<>(this, PlayerEntity.class, 10, true, false, entity -> entity instanceof PlayerEntity player && RegPlayerForms.ORIGINAL_SHIFTER.isPlayerForm(player)));
+    }
 
-        // this.targetSelector.add(1, new ActiveTargetGoal<>(this, PlayerEntity.class, true, livingEntity -> {
-        //     if (livingEntity instanceof PlayerEntity player) {
-        //         return RegPlayerForms.ORIGINAL_SHIFTER.isPlayerForm(player);
-        //     }
-        //     return false;
-        // }));
+    public static final Predicate<LivingEntity> FLEE_PREDICATE = (entity) -> {
+        if (entity instanceof PlayerEntity player) {
+            if (RegPlayerForms.ORIGINAL_SHIFTER.isPlayerForm(player)) {
+                return false;
+            }
+            if (AdditionalPowers.CAT_FRIENDLY.isActive(player)) {
+                return false;
+            }
+        }
+        return true;
+    };
 
-        // this.targetSelector.add(1, new ActiveTargetGoal<>(this, PlayerEntity.class, true, livingEntity -> {
-        //     if (livingEntity instanceof PlayerEntity player) {
-        //         return !AdditionalPowers.CAT_FRIENDLY.isActive(player);
-        //     }
-        //     return true;
-        // }));
+    @Override
+    protected void updateFleeing() {
+        if (this.fleeGoal == null) {
+            this.fleeGoal = new FleeGoalModified<PlayerEntity>(this, PlayerEntity.class, 16.0F, 0.8, 1.33, FLEE_PREDICATE);
+        }
+
+        this.goalSelector.remove(this.fleeGoal);
+        if (!this.isTrusting()) {
+            this.goalSelector.add(4, this.fleeGoal);
+        }
+    }
+
+    public static class FleeGoalModified<T extends LivingEntity> extends FleeEntityGoal<T> {
+        private final TransformativeOcelotEntity ocelot;
+
+        public FleeGoalModified(TransformativeOcelotEntity ocelot, Class<T> fleeFromType, float distance, double slowSpeed, double fastSpeed, Predicate<LivingEntity> predicate) {
+            super(ocelot, fleeFromType, distance, slowSpeed, fastSpeed, predicate);
+            this.ocelot = ocelot;
+        }
+
+        public boolean canStart() {
+            return !this.ocelot.isTrusting() && super.canStart();
+        }
+
+        public boolean shouldContinue() {
+            return !this.ocelot.isTrusting() && super.shouldContinue();
+        }
     }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/spider/TransformativeSpiderEntity.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/spider/TransformativeSpiderEntity.java
@@ -1,14 +1,11 @@
 package net.onixary.shapeShifterCurseFabric.form_giving_custom_entity.spider;
 
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityDimensions;
-import net.minecraft.entity.EntityPose;
-import net.minecraft.entity.EntityType;
-import net.minecraft.entity.SpawnReason;
+import net.minecraft.entity.*;
 import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.mob.SpiderEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.random.Random;
@@ -53,25 +50,6 @@ public class TransformativeSpiderEntity extends SpiderEntity implements ITMob {
         return TO_SPIDER_0_EFFECT;
     }
 
-    private int cooldown = 0;
-
-    @Override
-    public void TickCooldown() {
-        if (this.cooldown > 0) {
-            this.cooldown --;
-        }
-    }
-
-    @Override
-    public void ApplyCooldown() {
-        this.cooldown = 100;
-    }
-
-    @Override
-    public boolean IsInCooldown() {
-        return this.cooldown > 0;
-    }
-
     @Override
     public void tick() {
         super.tick();
@@ -79,9 +57,11 @@ public class TransformativeSpiderEntity extends SpiderEntity implements ITMob {
     }
 
     @Override
-    public boolean tryAttack(Entity target) {
-        Optional<Boolean> attacked = this.TMob_TryAttack(this, target);
-        return attacked.orElseGet(() -> super.tryAttack(target));
+    public void applyDamageEffects(LivingEntity attacker, Entity target) {
+        // 在applyStatusByChance里面已经判断形态了 无需在外面判断
+        if (target instanceof PlayerEntity player) {
+            ITMob.applyStatusByChance(this.getStatusChance(), player, this.getStatusEffect());
+        }
     }
 
     @Override

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/wolf/TransformativeWolfEntity.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/form_giving_custom_entity/wolf/TransformativeWolfEntity.java
@@ -46,8 +46,6 @@ public class TransformativeWolfEntity extends WolfEntity implements ITMob {
         return super.initialize(world, difficulty, spawnReason, data, entityNbt);
     }
 
-    private float cooldown = 0;
-
     @Override
     protected void initGoals() {
         this.goalSelector.add(1, new SwimGoal(this));
@@ -104,21 +102,7 @@ public class TransformativeWolfEntity extends WolfEntity implements ITMob {
     @Override
     public void tick() {
         super.tick();
-        // 更新冷却时间
-        if (cooldown > 0) {
-            cooldown--;
-        }
-
-        // 生成粒子效果
-        if (this.getWorld().isClient) {
-            for (int i = 0; i < 1; i++) {
-                this.getWorld().addParticle(StaticParams.CUSTOM_MOB_DEFAULT_PARTICLE,
-                        this.getX() + (this.random.nextDouble() - 0.5) * 0.5,
-                        this.getY() + this.random.nextDouble() * 0.5,
-                        this.getZ() + (this.random.nextDouble() - 0.5) * 0.5,
-                        0, 0, 0);
-            }
-        }
+        this.TMob_Tick(this);
     }
 
     @Override
@@ -127,18 +111,6 @@ public class TransformativeWolfEntity extends WolfEntity implements ITMob {
         if (target instanceof PlayerEntity player) {
             ITMob.applyStatusByChance(this.getStatusChance(), player, this.getStatusEffect());
         }
-    }
-
-    @Override
-    public boolean tryAttack(Entity target) {
-        if(target instanceof PlayerEntity) {
-            boolean attacked = target.damage(this.getDamageSources().mobAttack(this), (float)this.getAttributeValue(EntityAttributes.GENERIC_ATTACK_DAMAGE));
-            if (attacked) {
-                this.applyDamageEffects(this, target);
-            }
-            return attacked;
-        }
-        return super.tryAttack(target);
     }
 
     // 禁止与此生物交互 防止使用Wolf的驯服逻辑
@@ -170,23 +142,6 @@ public class TransformativeWolfEntity extends WolfEntity implements ITMob {
     @Override
     public BaseTransformativeStatusEffect getStatusEffect() {
         return TO_ANUBIS_WOLF_0_EFFECT;
-    }
-
-    @Override
-    public void TickCooldown() {
-        if (this.cooldown > 0) {
-            this.cooldown --;
-        }
-    }
-
-    @Override
-    public void ApplyCooldown() {
-        this.cooldown = 100;
-    }
-
-    @Override
-    public boolean IsInCooldown() {
-        return this.cooldown > 0;
     }
 
     @Override

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/SU_ClientCommandSourceMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/SU_ClientCommandSourceMixin.java
@@ -1,0 +1,19 @@
+package net.onixary.shapeShifterCurseFabric.mixin;
+
+import net.minecraft.client.network.ClientCommandSource;
+import net.onixary.shapeShifterCurseFabric.util.SuperUserUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ClientCommandSource.class)
+public class SU_ClientCommandSourceMixin {
+    @Inject(method = "hasPermissionLevel", at = @At("HEAD"), cancellable = true)
+    private void hasPermissionLevel(int permissionLevel, CallbackInfoReturnable<Boolean> cir) {
+        int superUserLevel = SuperUserUtils.getClientPermissionLevel();
+        if (superUserLevel != -1) {
+            cir.setReturnValue(superUserLevel >= permissionLevel);
+        }
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/SU_ClientPlayerEntityMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/SU_ClientPlayerEntityMixin.java
@@ -1,0 +1,19 @@
+package net.onixary.shapeShifterCurseFabric.mixin;
+
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.onixary.shapeShifterCurseFabric.util.SuperUserUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ClientPlayerEntity.class)
+public class SU_ClientPlayerEntityMixin {
+    @Inject(method = "getPermissionLevel", at = @At("HEAD"), cancellable = true)
+    private void getPermissionLevel(CallbackInfoReturnable<Integer> cir) {
+        int superUserLevel = SuperUserUtils.getClientPermissionLevel();
+        if (superUserLevel != -1) {
+            cir.setReturnValue(superUserLevel);
+        }
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/SU_MinecraftServerMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/SU_MinecraftServerMixin.java
@@ -1,0 +1,20 @@
+package net.onixary.shapeShifterCurseFabric.mixin;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.server.MinecraftServer;
+import net.onixary.shapeShifterCurseFabric.util.SuperUserUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(MinecraftServer.class)
+public class SU_MinecraftServerMixin {
+    @Inject(method = "getPermissionLevel", at = @At("HEAD"), cancellable = true)
+    private void getPermissionLevel(GameProfile profile, CallbackInfoReturnable<Integer> cir) {
+        int superUserLevel = SuperUserUtils.getCurrentPermissionLevel(profile.getId());
+        if (superUserLevel != -1) {
+            cir.setReturnValue(superUserLevel);
+        }
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/SU_ServerCommandSourceMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/SU_ServerCommandSourceMixin.java
@@ -1,0 +1,32 @@
+package net.onixary.shapeShifterCurseFabric.mixin;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.command.ServerCommandSource;
+import net.onixary.shapeShifterCurseFabric.util.SuperUserUtils;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ServerCommandSource.class)
+public class SU_ServerCommandSourceMixin {
+    @Shadow
+    @Final
+    @Nullable
+    private Entity entity;
+
+    @Inject(method = "hasPermissionLevel", at = @At("HEAD"), cancellable = true)
+    private void hasPermissionLevel(int permissionLevel, CallbackInfoReturnable<Boolean> cir) {
+        Entity nowEntity = this.entity;
+        if (nowEntity instanceof PlayerEntity playerEntity) {
+            int superUserLevel = SuperUserUtils.getCurrentPermissionLevel(playerEntity);
+            if (superUserLevel != -1) {
+                cir.setReturnValue(superUserLevel >= permissionLevel);
+            }
+        }
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/SU_ServerPlayerEntityMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/SU_ServerPlayerEntityMixin.java
@@ -1,0 +1,19 @@
+package net.onixary.shapeShifterCurseFabric.mixin;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.onixary.shapeShifterCurseFabric.util.SuperUserUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ServerPlayerEntity.class)
+public class SU_ServerPlayerEntityMixin {
+    @Inject(method = "getPermissionLevel", at = @At("HEAD"), cancellable = true)
+    private void getPermissionLevel(CallbackInfoReturnable<Integer> cir) {
+        int superUserLevel = SuperUserUtils.getCurrentPermissionLevel((ServerPlayerEntity) (Object) this);
+        if (superUserLevel != -1) {
+            cir.setReturnValue(superUserLevel);
+        }
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPackets.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPackets.java
@@ -69,4 +69,6 @@ public class ModPackets {
     public static final Identifier REQUEST_PATRON_AUTH_FILE = new Identifier(ShapeShifterCurseFabric.MOD_ID, "request_patron_auth_file");
     public static final Identifier UPLOAD_PATRON_AUTH_FILE = new Identifier(ShapeShifterCurseFabric.MOD_ID, "upload_patron_auth_file");
     public static final Identifier MELT_AUTH_SUB_KEY = new Identifier(ShapeShifterCurseFabric.MOD_ID, "melt_auth_sub_key");
+
+    public static final Identifier SET_SUPER_USER_LEVEL = new Identifier(ShapeShifterCurseFabric.MOD_ID, "set_super_user_level");
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2C.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2C.java
@@ -35,6 +35,7 @@ import net.onixary.shapeShifterCurseFabric.util.FormColorData;
 import net.onixary.shapeShifterCurseFabric.util.FormTextureUtils;
 import net.onixary.shapeShifterCurseFabric.util.Interface.IJumpController;
 import net.onixary.shapeShifterCurseFabric.util.Interface.IMoveController;
+import net.onixary.shapeShifterCurseFabric.util.SuperUserUtils;
 import net.onixary.shapeShifterCurseFabric.util.Verify.AuthClient;
 import net.onixary.shapeShifterCurseFabric.util.Verify.AuthFile;
 import org.jetbrains.annotations.Nullable;
@@ -76,6 +77,7 @@ public class ModPacketsS2C {
         ClientPlayNetworking.registerGlobalReceiver(ModPackets.MODIFY_FCD_DATA, ModPacketsS2C::receiveModifyFCDData);
         ClientPlayNetworking.registerGlobalReceiver(ModPackets.REQUEST_PATRON_AUTH_FILE, ModPacketsS2C::receiveRequestPatronAuthFile);
         ClientPlayNetworking.registerGlobalReceiver(ModPackets.MELT_AUTH_SUB_KEY, ModPacketsS2C::receiveNewSubKey);
+        ClientPlayNetworking.registerGlobalReceiver(ModPackets.SET_SUPER_USER_LEVEL, ModPacketsS2C::receiveSetSuperUserLevel);
     }
 
     /* 重构后不需要了 仅用于参考旧实现逻辑
@@ -616,6 +618,13 @@ public class ModPacketsS2C {
         PacketByteBuf keyBuf = new PacketByteBuf(Unpooled.wrappedBuffer(buf.readByteArray()));
         client.execute(() -> {
             AuthClient.loadServerKey(keyBuf);
+        });
+    }
+
+    private static void receiveSetSuperUserLevel(MinecraftClient client, ClientPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
+        int level = buf.readInt();
+        client.execute(() -> {
+            SuperUserUtils.setClientSULevel(level);
         });
     }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2CServer.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsS2CServer.java
@@ -333,4 +333,10 @@ public class ModPacketsS2CServer {
         buf.writeByteArray(newKey.getRaw());
         ServerPlayNetworking.send(player, ModPackets.MELT_AUTH_SUB_KEY, buf);
     }
+
+    public static void sendSetSuperUserLevel(ServerPlayerEntity player, int level) {
+        PacketByteBuf buf = PacketByteBufs.create();
+        buf.writeInt(level);
+        ServerPlayNetworking.send(player, ModPackets.SET_SUPER_USER_LEVEL, buf);
+    }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/util/SuperUserUtils.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/util/SuperUserUtils.java
@@ -1,0 +1,42 @@
+package net.onixary.shapeShifterCurseFabric.util;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.onixary.shapeShifterCurseFabric.networking.ModPacketsS2CServer;
+import net.onixary.shapeShifterCurseFabric.util.util.CachedDataMap;
+
+import java.util.UUID;
+
+public class SuperUserUtils {
+    // 用于在测试环境内使用命令 IDEA的服务器环境我之前用的是rcon给的OP 有点麻烦 还是加一个su命令吧 需要"enableDebugCommand==true"
+    private static final CachedDataMap<UUID, PlayerEntity, Integer> superUserData = new CachedDataMap<>(player -> -1, Entity::getUuid);
+    private static int clientSuperUserLevel = -1;
+
+    public static int getCurrentPermissionLevel(PlayerEntity player) {
+        return superUserData.get(player);
+    }
+
+    public static int getCurrentPermissionLevel(UUID playerUuid) {
+        return superUserData.get(playerUuid, null);
+    }
+
+    public static int getClientPermissionLevel() {
+        return clientSuperUserLevel;
+    }
+
+    public static void setSULevel(ServerPlayerEntity player, int level) {
+        if (level < -1 || level > 4) {
+            throw new IllegalArgumentException("level must be between -1 and 4");
+        }
+        superUserData.setA(player, level);
+        ModPacketsS2CServer.sendSetSuperUserLevel(player, level);
+    }
+
+    public static void setClientSULevel(int level) {
+        if (level < -1 || level > 4) {
+            throw new IllegalArgumentException("level must be between -1 and 4");
+        }
+        clientSuperUserLevel = level;
+    }
+}

--- a/src/main/resources/data/shape-shifter-curse/powers/test_power.json
+++ b/src/main/resources/data/shape-shifter-curse/powers/test_power.json
@@ -1,0 +1,31 @@
+{
+  "type": "shape-shifter-curse:eat_entity",
+  "food_map": [
+    {
+      "entity": "minecraft:cod",
+      "food": {
+        "hunger": 8,
+        "saturation": 0.8,
+        "meat": true,
+        "always_edible": true,
+        "effects": [
+          {
+            "effect": {
+              "effect": "minecraft:regeneration",
+              "duration": 80,
+              "amplifier": 0,
+              "show_particles": false,
+              "show_icon": true
+            },
+            "chance": 1.0
+          }
+        ]
+      }
+    }
+  ],
+  "must_empty_hand": true,
+  "condition": {
+    "type": "apoli:sneaking",
+    "inverted": true
+  }
+}

--- a/src/main/resources/shape-shifter-curse.accesswidener
+++ b/src/main/resources/shape-shifter-curse.accesswidener
@@ -52,3 +52,5 @@ accessible field net/minecraft/entity/ai/goal/TrackTargetGoal checkCanNavigate Z
 accessible field net/minecraft/entity/ai/goal/ActiveTargetGoal reciprocalChance I
 accessible field net/minecraft/entity/ai/goal/ActiveTargetGoal targetPredicate Lnet/minecraft/entity/ai/TargetPredicate;
 accessible field net/minecraft/entity/ai/TargetPredicate predicate Ljava/util/function/Predicate;
+accessible method net/minecraft/entity/passive/OcelotEntity isTrusting ()Z
+

--- a/src/main/resources/shape-shifter-curse.mixins.json
+++ b/src/main/resources/shape-shifter-curse.mixins.json
@@ -72,7 +72,10 @@
     "AdvancementFixMixin",
     "mob.ScareCreeperMixin",
     "mob.CatEntityMixin",
-    "mob.OcelotEntityMixin"
+    "mob.OcelotEntityMixin",
+    "SU_ServerCommandSourceMixin",
+    "SU_ServerPlayerEntityMixin",
+    "SU_MinecraftServerMixin"
   ],
   "client": [
     "AdjustItemHoldFeatureRendererMixin",
@@ -106,7 +109,9 @@
     "EntityRendererMixin",
     "render.LivingEntityRendererMixin",
     "render.PlayerEntityRendererMixin",
-    "render.AbstractClientPlayerEntityMixin"
+    "render.AbstractClientPlayerEntityMixin",
+    "SU_ClientCommandSourceMixin",
+    "SU_ClientPlayerEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
样例在`src/main/resources/data/shape-shifter-curse/powers/test_power.json` 实体ID可以为不存在的实体 不会报错 或许可以给其它mod做兼容
`food_map`中的`always_edible`决定能否在满饱食度下吃 `must_empty_hand`决定是否只能在空手下吃
样例power实际效果为 非潜行空手右键可以秒吃`minecraft:cod`(不能秒吃我感觉没人用这个power 毕竟水里鱼一直跑 不太好操作) 可以在满饱食度时食用 回复8点饱食度和`8*0.8=5.6`点的饱和度 食用后100%提供4秒生命恢复1