### PR TITLE
修复 #527

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/CustomEdibleItemMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/CustomEdibleItemMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Hand;
 import net.minecraft.world.World;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -102,11 +103,13 @@ public abstract class CustomEdibleItemMixin {
 
     @ModifyExpressionValue(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/Item;isFood()Z"))
     private boolean use$isFood(boolean original, World world, PlayerEntity user, Hand hand) {
+        // ShapeShifterCurseFabric.LOGGER.error("SSC_CE_SYSTEM_CEI_01");
         return getPowerFoodComponent(user, user.getStackInHand(hand)) != null || original;
     }
 
     @ModifyExpressionValue(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/Item;getFoodComponent()Lnet/minecraft/item/FoodComponent;"))
     private FoodComponent use$getFoodComponent(FoodComponent original, World world, PlayerEntity user, Hand hand) {
+        // ShapeShifterCurseFabric.LOGGER.error("SSC_CE_SYSTEM_CEI_02");
         FoodComponent fc = getPowerFoodComponent(user, user.getStackInHand(hand));
         if (fc == null) {
             return original;
@@ -116,6 +119,7 @@ public abstract class CustomEdibleItemMixin {
 
     @ModifyExpressionValue(method = "finishUsing", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/Item;isFood()Z"))
     private boolean finishUsing$isFood(boolean original, ItemStack stack, World world, LivingEntity user) {
+        // ShapeShifterCurseFabric.LOGGER.error("SSC_CE_SYSTEM_CEI_03");
         if (user instanceof PlayerEntity playerEntity) {
             return getPowerFoodComponent(playerEntity, stack) != null || original;
         }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/CustomEdiblePlayerAMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/CustomEdiblePlayerAMixin.java
@@ -7,6 +7,7 @@ import net.minecraft.item.FoodComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.UseAction;
 import net.minecraft.world.World;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -20,6 +21,7 @@ public class CustomEdiblePlayerAMixin {
 
     @ModifyExpressionValue(method = "eatFood", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isFood()Z"))
     private boolean eatFood$isFood(boolean original, World world, ItemStack stack) {
+        // ShapeShifterCurseFabric.LOGGER.error("SSC_CE_SYSTEM_CEPA_01");
         if ((Object)this instanceof PlayerEntity playerEntity) {
             return getPowerFoodComponent(playerEntity, stack) != null || original;
         }
@@ -28,6 +30,7 @@ public class CustomEdiblePlayerAMixin {
 
     @ModifyExpressionValue(method = "applyFoodEffects", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/Item;isFood()Z"))
     private boolean applyFoodEffects$isFood(boolean original, ItemStack stack, World world, LivingEntity targetEntity) {
+        // ShapeShifterCurseFabric.LOGGER.error("SSC_CE_SYSTEM_CEPA_02");
         if ((Object)this instanceof PlayerEntity playerEntity) {
             return getPowerFoodComponent(playerEntity, stack) != null || original;
         }
@@ -36,6 +39,7 @@ public class CustomEdiblePlayerAMixin {
 
     @ModifyExpressionValue(method = "applyFoodEffects", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/Item;getFoodComponent()Lnet/minecraft/item/FoodComponent;"))
     private FoodComponent applyFoodEffects$getFoodComponent(FoodComponent original, ItemStack stack, World world, LivingEntity targetEntity) {
+        // ShapeShifterCurseFabric.LOGGER.error("SSC_CE_SYSTEM_CEPA_03");
         if (targetEntity instanceof PlayerEntity playerEntity) {
             FoodComponent fc = getPowerFoodComponent(playerEntity, stack);
             if (fc == null) {
@@ -48,6 +52,7 @@ public class CustomEdiblePlayerAMixin {
 
     @ModifyExpressionValue(method = "shouldSpawnConsumptionEffects", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getMaxUseTime()I"))
     private int shouldSpawnConsumptionEffects$getMaxUseTime(int original) {
+        // ShapeShifterCurseFabric.LOGGER.error("SSC_CE_SYSTEM_CEPA_04");
         if ((Object)this instanceof PlayerEntity playerEntity) {
             FoodComponent fc = getPowerFoodComponent(playerEntity, activeItemStack);
             if (fc == null) {
@@ -60,6 +65,7 @@ public class CustomEdiblePlayerAMixin {
 
     @ModifyExpressionValue(method = "onTrackedDataSet", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getMaxUseTime()I"))
     private int onTrackedDataSet$getMaxUseTime(int original) {
+        // ShapeShifterCurseFabric.LOGGER.error("SSC_CE_SYSTEM_CEPA_05");
         if ((Object)this instanceof PlayerEntity playerEntity) {
             FoodComponent fc = getPowerFoodComponent(playerEntity, activeItemStack);
             if (fc == null) {
@@ -70,8 +76,14 @@ public class CustomEdiblePlayerAMixin {
         return original;
     }
 
+    // 和Lodestone冲突
+    // 可惜协议是LGPL3的 我没法把有问题的代码复制出来解释
+    // https://github.com/LodestarMC/Lodestone/blob/1.20.1-fabric/src/main/java/team/lodestar/lodestone/mixin/common/LivingEntityMixin.java
+    // 中的lodestone$injectUseEvent会直接ci.cancel 我ModifyExpressionValue优先度没Inject高
+
     @ModifyExpressionValue(method = "setCurrentHand", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getMaxUseTime()I"))
     private int setCurrentHand$getMaxUseTime(int original) {
+        // ShapeShifterCurseFabric.LOGGER.error("SSC_CE_SYSTEM_CEPA_06");
         if ((Object)this instanceof PlayerEntity playerEntity) {
             FoodComponent fc = getPowerFoodComponent(playerEntity, activeItemStack);
             if (fc == null) {
@@ -84,6 +96,7 @@ public class CustomEdiblePlayerAMixin {
 
     @ModifyExpressionValue(method = "shouldSpawnConsumptionEffects", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/Item;getFoodComponent()Lnet/minecraft/item/FoodComponent;"))
     private FoodComponent shouldSpawnConsumptionEffects$getFoodComponent(FoodComponent original) {
+        // ShapeShifterCurseFabric.LOGGER.error("SSC_CE_SYSTEM_CEPA_07");
         if ((Object)this instanceof PlayerEntity playerEntity) {
             FoodComponent fc = getPowerFoodComponent(playerEntity, activeItemStack);
             if (fc == null) {
@@ -96,6 +109,7 @@ public class CustomEdiblePlayerAMixin {
 
     @ModifyExpressionValue(method = "spawnConsumptionEffects", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/util/UseAction;"))
     private UseAction spawnConsumptionEffects$getUseAction(UseAction original, ItemStack stack, int particleCount) {
+        // ShapeShifterCurseFabric.LOGGER.error("SSC_CE_SYSTEM_CEPA_08");
         if ((Object)this instanceof PlayerEntity playerEntity) {
             FoodComponent fc = getPowerFoodComponent(playerEntity, activeItemStack);
             if (fc == null) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/CustomEdiblePlayerBMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/CustomEdiblePlayerBMixin.java
@@ -11,6 +11,7 @@ import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.stat.Stats;
 import net.minecraft.world.World;
+import net.onixary.shapeShifterCurseFabric.ShapeShifterCurseFabric;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -27,6 +28,7 @@ public abstract class CustomEdiblePlayerBMixin extends LivingEntity {
 
     @Inject(method = "eatFood", at = @At(value = "HEAD"), cancellable = true)
     private void eatFood(World world, ItemStack stack, CallbackInfoReturnable<ItemStack> cir) {
+        // ShapeShifterCurseFabric.LOGGER.error("SSC_CE_SYSTEM_CEPB_01");
         if ((Object)this instanceof PlayerEntity playerEntity) {
             FoodComponent foodComponent = getPowerFoodComponent(playerEntity, stack);
             if (foodComponent == null) {

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerMovementControlMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/PlayerMovementControlMixin.java
@@ -104,7 +104,6 @@ public class PlayerMovementControlMixin implements IMoveController {
         // 发送网络包到服务器
         if (player.getWorld().isClient()) {
             PacketByteBuf buf = PacketByteBufs.create();
-            buf.writeUuid(player.getUuid());
             ClientPlayNetworking.send(ModPackets.JUMP_EVENT_ID, buf);
         }
     }
@@ -162,7 +161,6 @@ public class PlayerMovementControlMixin implements IMoveController {
             // 发送网络包到服务器
             if (player.getWorld().isClient()) {
                 PacketByteBuf buf = PacketByteBufs.create();
-                buf.writeUuid(player.getUuid());
                 ClientPlayNetworking.send(ModPackets.SPRINTING_TO_SNEAKING_EVENT_ID, buf);
             }
         }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/integration/LodeStoneIntegrationMixin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/integration/LodeStoneIntegrationMixin.java
@@ -1,0 +1,47 @@
+package net.onixary.shapeShifterCurseFabric.mixin.integration;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.FoodComponent;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
+import net.minecraft.world.event.GameEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static net.onixary.shapeShifterCurseFabric.util.CustomEdibleUtils.getPowerFoodComponent;
+
+@Mixin(LivingEntity.class)
+public abstract class LodeStoneIntegrationMixin {
+    @Shadow
+    protected ItemStack activeItemStack;
+
+    @Shadow
+    protected int itemUseTimeLeft;
+
+    @Shadow
+    protected abstract void setLivingFlag(int mask, boolean value);
+
+    // 其实应该是Lodestone的ci.cancel的问题 不过我这边还是能修的(也就是今天心情好一些 按理说直接在Fabric.mod.json写一个不兼容就行 Lodestone的直接ci.cancel会和大量Mod冲突)
+    // 调了半天 现在心情不好了 感觉Lodestone就没考虑别人的Mixin 直接ci.cancel还把客户端操作给屏蔽了 还有大量位置直接覆盖原始值 还不用mixinExtra读取原始值
+
+    @Inject(method = "setCurrentHand", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getMaxUseTime()I"), order = 900)
+    private void setCurrentHand$getMaxUseTimeA(Hand hand, CallbackInfo ci) {
+        if ((Object)this instanceof PlayerEntity playerEntity) {
+            FoodComponent fc = getPowerFoodComponent(playerEntity, activeItemStack);
+            if (fc == null) {
+                return;
+            }
+            this.itemUseTimeLeft = fc.isSnack() ? 16 : 32;
+            if (!playerEntity.getWorld().isClient) {
+                this.setLivingFlag(1, true);
+                this.setLivingFlag(2, hand == Hand.OFF_HAND);
+                playerEntity.emitGameEvent(GameEvent.ITEM_INTERACT_START);
+            }
+        }
+        return;
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/plugin/MixinConfigPlugin.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/mixin/plugin/MixinConfigPlugin.java
@@ -37,6 +37,7 @@ public class MixinConfigPlugin implements IMixinConfigPlugin {
         mixinRequiredMods.put("net.onixary.shapeShifterCurseFabric.mixin.forge.CurioItemImpl", new MixinRequiredMods(new String[]{"curios"}, new String[]{}));
         mixinRequiredMods.put("net.onixary.shapeShifterCurseFabric.mixin.forge.CurioUtilsImpl", new MixinRequiredMods(new String[]{"curios"}, new String[]{}));
         mixinRequiredMods.put("net.onixary.shapeShifterCurseFabric.mixin.integration.BOP_WebbingBlockMixin", new MixinRequiredMods(new String[]{"biomesoplenty"}, new String[]{}));
+        mixinRequiredMods.put("net.onixary.shapeShifterCurseFabric.mixin.integration.LodeStoneIntegrationMixin", new MixinRequiredMods(new String[]{"lodestone"}, new String[]{}));
 
         mixinAccessoryMixin.put("net.onixary.shapeShifterCurseFabric.mixin.accessory.TrinketImpl", "trinkets");
         mixinAccessoryMixin.put("net.onixary.shapeShifterCurseFabric.mixin.forge.CurioImpl", "curios");

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsC2S.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/networking/ModPacketsC2S.java
@@ -69,29 +69,18 @@ public class ModPacketsC2S {
 
         // jump_event condition handle
         ServerPlayNetworking.registerGlobalReceiver(JUMP_EVENT_ID, (server, player, handler, buf, responseSender) -> {
-            UUID playerUuid = buf.readUuid();
-
             server.execute(() -> {
                 // 在服务器端设置跳跃状态
-                if (player.getUuid().equals(playerUuid)) {
-                    JumpEventCondition.setJumping(player, true);
-                }
-
-                PowerHolderComponent.getPowers(player, ActionOnJumpPower.class)
-                        .forEach(ActionOnJumpPower::executeAction);
+                JumpEventCondition.setJumping(player, true);
+                PowerHolderComponent.getPowers(player, ActionOnJumpPower.class).forEach(ActionOnJumpPower::executeAction);
             });
         });
 
         // SPRINTING_TO_SNEAKING_EVENT condition handle
         ServerPlayNetworking.registerGlobalReceiver(SPRINTING_TO_SNEAKING_EVENT_ID, (server, player, handler, buf, responseSender) -> {
-            UUID playerUuid = buf.readUuid();
-
             server.execute(() -> {
                 // 在服务器端处理疾跑转潜行事件
-                if (player.getUuid().equals(playerUuid)) {
-                    PowerHolderComponent.getPowers(player, ActionOnSprintingToSneakingPower.class)
-                            .forEach(ActionOnSprintingToSneakingPower::executeAction);
-                }
+                PowerHolderComponent.getPowers(player, ActionOnSprintingToSneakingPower.class).forEach(ActionOnSprintingToSneakingPower::executeAction);
             });
         });
 

--- a/src/main/resources/shape-shifter-curse.mixins.json
+++ b/src/main/resources/shape-shifter-curse.mixins.json
@@ -75,7 +75,8 @@
     "mob.OcelotEntityMixin",
     "SU_ServerCommandSourceMixin",
     "SU_ServerPlayerEntityMixin",
-    "SU_MinecraftServerMixin"
+    "SU_MinecraftServerMixin",
+    "integration.LodeStoneIntegrationMixin"
   ],
   "client": [
     "AdjustItemHoldFeatureRendererMixin",


### PR DESCRIPTION
Closes #527

问题的根源是LodeStone直接ci.cancel 这么操作大概率会与其他的Mod的功能冲突 所以理论上是可以不用修的(直接写个不兼容就行)
不过我也是查了半天 不修一下感觉之前的研究就没用了(其实就是能解决 虽然这个Bug其实算是LodeStone的 要是不好解决就不会写了(比如补丁可能会造成其他兼容影响问题 就大概率不写) 如果还有其他不兼容(LodeStone直接ci.cancel和直接替换值的操作有不少) 我可能就会把这个补丁删了 然后在Fabric.mod.json写一个不兼容)

上面的 `Closes #527` 是试试github关键字 我之前都是手动修改pr右侧数据的 看看能不能自动识别