### PR TITLE
重构可滚动字符串实现

### DIFF
--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P1.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P1.java
@@ -54,7 +54,7 @@ public class BookOfShapeShifterScreenV2_P1 extends Screen implements WidgetEXUti
         // D -> (9, 9), (19, 95)
         // Size -> (108, 48) Pos -> (17, 92)
         this.addDrawableChild(BuildDetailScreenButton(19, 95, 9, 9, CodexData.getContentText(CodexData.ContentType.TITLE, currentPlayer)));
-        ScaleScrollTextWidget TitleLabel = (ScaleScrollTextWidget) new ScaleScrollTextWidget(BookPosX + 17 * BookScale, BookPosY + 105 * BookScale, 108 * BookScale, 5 * BookScale, Scale, CodexData.getContentText(CodexData.ContentType.TITLE, currentPlayer), scaleTextRenderer).shadow(false).setTextColor(DefaultTextColor);
+        ScaleScrollTextWidget TitleLabel = (ScaleScrollTextWidget) new ScaleScrollTextWidget(BookPosX + 17 * BookScale, BookPosY + 105 * BookScale, 108 * BookScale, 48 * BookScale, Scale, CodexData.getContentText(CodexData.ContentType.TITLE, currentPlayer), scaleTextRenderer).shadow(false).setTextColor(DefaultTextColor);
         TitleLabel.setEnableScrollableIconRender(true);
         this.addWidget(TitleLabel);
         this.addDrawableChild(TitleLabel);
@@ -63,7 +63,7 @@ public class BookOfShapeShifterScreenV2_P1 extends Screen implements WidgetEXUti
         // Size -> (107, 56) Pos -> (17, 153)
         this.addDrawableChild(BuildDetailScreenButton(116, 143, 9, 9, CodexData.getContentText(CodexData.ContentType.EQUIP, currentPlayer)));
         this.addDrawableChild(new TextWidget(BookPosX + 17 * BookScale, BookPosY + 143 * BookScale, 107 * BookScale, 6 * BookScale, CodexData.headerEquip, textRenderer).setTextColor(HeaderTextColor));
-        ScaleScrollTextWidget StatusLabel = (ScaleScrollTextWidget) new ScaleScrollTextWidget(BookPosX + 17 * BookScale, BookPosY + 153 * BookScale, 107 * BookScale, 6 * BookScale, Scale, CodexData.getContentText(CodexData.ContentType.EQUIP, currentPlayer), scaleTextRenderer).shadow(false).setTextColor(DefaultTextColor);
+        ScaleScrollTextWidget StatusLabel = (ScaleScrollTextWidget) new ScaleScrollTextWidget(BookPosX + 17 * BookScale, BookPosY + 153 * BookScale, 107 * BookScale, 56 * BookScale, Scale, CodexData.getContentText(CodexData.ContentType.EQUIP, currentPlayer), scaleTextRenderer).shadow(false).setTextColor(DefaultTextColor);
         StatusLabel.setEnableScrollableIconRender(true);
         this.addWidget(StatusLabel);
         this.addDrawableChild(StatusLabel);
@@ -87,7 +87,7 @@ public class BookOfShapeShifterScreenV2_P1 extends Screen implements WidgetEXUti
         // Size -> (176, 184) Pos -> (142, 23)
         this.addDrawableChild(BuildDetailScreenButton(311, 13, 9, 9, CodexData.getContentText(CodexData.ContentType.APPEARANCE, currentPlayer)));
         this.addDrawableChild(new TextWidget(BookPosX + 142 * BookScale, BookPosY + 11 * BookScale, 176 * BookScale, 8 * BookScale, CodexData.headerAppearance, textRenderer).setTextColor(HeaderTextColor));
-        ScaleScrollTextWidget AppearanceLabel = (ScaleScrollTextWidget) new ScaleScrollTextWidget(BookPosX + 142 * BookScale, BookPosY + 26 * BookScale, 176 * BookScale, 20 * BookScale, Scale, CodexData.getContentText(CodexData.ContentType.APPEARANCE, currentPlayer), scaleTextRenderer).shadow(false).setTextColor(DefaultTextColor);
+        ScaleScrollTextWidget AppearanceLabel = (ScaleScrollTextWidget) new ScaleScrollTextWidget(BookPosX + 142 * BookScale, BookPosY + 26 * BookScale, 176 * BookScale, 184 * BookScale, Scale, CodexData.getContentText(CodexData.ContentType.APPEARANCE, currentPlayer), scaleTextRenderer).shadow(false).setTextColor(DefaultTextColor);
         AppearanceLabel.setEnableScrollableIconRender(true);
         this.addWidget(AppearanceLabel);
         this.addDrawableChild(AppearanceLabel);

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P2.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/BookOfShapeShifterScreenV2_P2.java
@@ -50,7 +50,7 @@ public class BookOfShapeShifterScreenV2_P2 extends Screen implements WidgetEXUti
         // Size -> (83, 181) Pos -> (13, 26)
         this.addDrawableChild(BuildDetailScreenButton(80, 12, 9, 9, CodexData.getContentText(CodexData.ContentType.PROS, currentPlayer)));
         this.addDrawableChild(new TextWidget(BookPosX + 26 * BookScale, BookPosY + 10 * BookScale, 53 * BookScale, 11 * BookScale, CodexData.headerPros, textRenderer).setTextColor(HeaderTextColor));
-        ScaleScrollTextWidget Pros = (ScaleScrollTextWidget) new ScaleScrollTextWidget(BookPosX + 13 * BookScale, BookPosY + 26 * BookScale, 83 * BookScale, 18 * BookScale, Scale, CodexData.getContentText(CodexData.ContentType.PROS, currentPlayer), scaleTextRenderer).shadow(false).setTextColor(DefaultTextColor);
+        ScaleScrollTextWidget Pros = (ScaleScrollTextWidget) new ScaleScrollTextWidget(BookPosX + 13 * BookScale, BookPosY + 26 * BookScale, 83 * BookScale, 181 * BookScale, Scale, CodexData.getContentText(CodexData.ContentType.PROS, currentPlayer), scaleTextRenderer).shadow(false).setTextColor(DefaultTextColor);
         // ScaleScrollTextWidget Pros = (ScaleScrollTextWidget) new ScaleScrollTextWidget(BookPosX + 13 * BookScale, BookPosY + 26 * BookScale, 83 * BookScale, 4 * BookScale, Scale, CodexData.getContentText(CodexData.ContentType.PROS, currentPlayer), scaleTextRenderer).shadow(false).setTextColor(DefaultTextColor);
         Pros.setEnableScrollableIconRender(true);
         this.addWidget(Pros);
@@ -60,7 +60,7 @@ public class BookOfShapeShifterScreenV2_P2 extends Screen implements WidgetEXUti
         // Size -> (82, 182) Pos -> (110, 26)
         this.addDrawableChild(BuildDetailScreenButton(185, 12, 9, 9, CodexData.getContentText(CodexData.ContentType.CONS, currentPlayer)));
         this.addDrawableChild(new TextWidget(BookPosX + 120 * BookScale, BookPosY + 10 * BookScale, 63 * BookScale, 11 * BookScale, CodexData.headerCons, textRenderer).setTextColor(HeaderTextColor));
-        ScaleScrollTextWidget Cons = (ScaleScrollTextWidget) new ScaleScrollTextWidget(BookPosX + 110 * BookScale, BookPosY + 26 * BookScale, 82 * BookScale, 18 * BookScale, Scale, CodexData.getContentText(CodexData.ContentType.CONS, currentPlayer), scaleTextRenderer).shadow(false).setTextColor(DefaultTextColor);
+        ScaleScrollTextWidget Cons = (ScaleScrollTextWidget) new ScaleScrollTextWidget(BookPosX + 110 * BookScale, BookPosY + 26 * BookScale, 82 * BookScale, 182 * BookScale, Scale, CodexData.getContentText(CodexData.ContentType.CONS, currentPlayer), scaleTextRenderer).shadow(false).setTextColor(DefaultTextColor);
         // ScaleScrollTextWidget Cons = (ScaleScrollTextWidget) new ScaleScrollTextWidget(BookPosX + 110 * BookScale, BookPosY + 26 * BookScale, 82 * BookScale, 4 * BookScale, Scale, CodexData.getContentText(CodexData.ContentType.CONS, currentPlayer), scaleTextRenderer).shadow(false).setTextColor(DefaultTextColor);
         Cons.setEnableScrollableIconRender(true);
         this.addWidget(Cons);
@@ -74,7 +74,7 @@ public class BookOfShapeShifterScreenV2_P2 extends Screen implements WidgetEXUti
         MultilineTextWidget InstinctsDesc = new ScaleMultilineTextWidget(BookPosX + 220 * BookScale, BookPosY + 24 * BookScale, CodexData.getDescText(CodexData.ContentType.INSTINCTS, currentPlayer), scaleTextRenderer, Scale).shadow(false).setMaxWidth(106 * BookScale);
         this.addDrawableChild(InstinctsDesc);
         int InstinctsDescHeight = InstinctsDesc.getHeight();
-        ScaleScrollTextWidget Instincts = (ScaleScrollTextWidget) new ScaleScrollTextWidget(BookPosX + 220 * BookScale, BookPosY + 24 * BookScale + InstinctsDescHeight + Math.round(9 * Scale), 106 * BookScale, ((112 - InstinctsDescHeight) / 9 + 1) * BookScale, Scale, CodexData.getContentText(CodexData.ContentType.INSTINCTS, currentPlayer), scaleTextRenderer).shadow(false).setTextColor(DefaultTextColor);
+        ScaleScrollTextWidget Instincts = (ScaleScrollTextWidget) new ScaleScrollTextWidget(BookPosX + 220 * BookScale, BookPosY + 24 * BookScale + InstinctsDescHeight + Math.round(9 * Scale), 106 * BookScale, (112 - InstinctsDescHeight) * BookScale, Scale, CodexData.getContentText(CodexData.ContentType.INSTINCTS, currentPlayer), scaleTextRenderer).shadow(false).setTextColor(DefaultTextColor);
         Instincts.setEnableScrollableIconRender(true);
         this.addWidget(Instincts);
         this.addDrawableChild(Instincts);

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/DetailScreen.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/DetailScreen.java
@@ -28,7 +28,7 @@ public class DetailScreen extends Screen implements WidgetEXUtils.IWidgetEX {
         int TextSizeX = width - TextX * 2;
         int TextSizeY = height - 60;
         int TextDefaultColor = 0xFFFFFF;
-        ScaleScrollTextWidget DetailTextWidget = (ScaleScrollTextWidget) new ScaleScrollTextWidget(TextX, TextY, TextSizeX, TextSizeY / 9, 1.0f, DetailText, textRenderer).setTextColor(TextDefaultColor);
+        ScaleScrollTextWidget DetailTextWidget = (ScaleScrollTextWidget) new ScaleScrollTextWidget(TextX, TextY, TextSizeX, TextSizeY, 1.0f, DetailText, textRenderer).setTextColor(TextDefaultColor);
         DetailTextWidget.setEnableScrollableIconRender(true);
         this.addWidget(DetailTextWidget);
         this.addDrawableChild(DetailTextWidget);

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/FormUpdateScreen.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/FormUpdateScreen.java
@@ -1,0 +1,80 @@
+package net.onixary.shapeShifterCurseFabric.custom_ui;
+
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.onixary.shapeShifterCurseFabric.custom_ui.ui_part.WidgetEXUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+// 标记 UNTESTED 代表这个函数没测试 测试完了就删(估计最后得有一堆没测试函数 还是标一下大概率炸的函数吧)
+
+public class FormUpdateScreen extends Screen implements WidgetEXUtils.IWidgetEX {
+    // Node得建立一个注册表 用来标记Power更改 Icon路径 再上几个API什么的
+    // NodeMetaData生成也得要注册表 根据FormData里的数据选对应的初始化函数
+
+    public record NodeMetaData(int tier, int y, @NotNull Identifier nodeID, @Nullable Identifier nodeDependID) {}
+
+    public final HashMap<Identifier, NodeMetaData> nodeMap = new HashMap<>();
+    public final List<NodeMetaData> nodeMetaDataList = new ArrayList<>();
+    public @Nullable NodeMetaData nowSelectNodeMetaData;
+    public final int nodeBaseX = 0;
+    public final int nodeBaseY = 0;
+    public final int Tier0X = 100;
+    public final int posXPerTier = 100;
+    public final int nodeLineRootXOffset = 9;
+    public final int nodeLineDependXOffset = -9;
+    public final int LineColor = 0xFF9F9F9F;
+
+    @Override
+    public WidgetEXUtils.WidgetRect getRect() {
+        return null;
+    }
+
+    public List<WidgetEXUtils.IWidgetEX> WidgetList = new ArrayList<>();
+
+    @Override
+    public List<WidgetEXUtils.IWidgetEX> getWidgetList() {
+        return this.WidgetList;
+    }
+
+    protected FormUpdateScreen(Text title) {
+        super(title);
+    }
+
+    @Override
+    public void init() {
+        super.init();
+    }
+
+    // Utils
+    public @Nullable FormUpdateScreen.NodeMetaData getNode(Identifier nodeID) {
+        return nodeMap.get(nodeID);
+    }
+
+    // UNTESTED
+    public void drawConnectLine(DrawContext context, NodeMetaData nodeMetaData) {
+        Identifier depend = nodeMetaData.nodeDependID;
+        if (depend == null) return;
+        NodeMetaData dependNodeMetaData = getNode(depend);
+        if (dependNodeMetaData == null) return;
+        int X1 = nodeBaseX + Tier0X + this.posXPerTier * nodeMetaData.tier + nodeLineDependXOffset;
+        int X2 = nodeBaseX + Tier0X + this.posXPerTier * dependNodeMetaData.tier + nodeLineRootXOffset;
+        int Y1 = nodeBaseY + nodeMetaData.y;
+        int Y2 = nodeBaseY + dependNodeMetaData.y;
+        int HalfX = (X1 + X2) / 2;
+        context.fill(X1, Y1, HalfX + 1, Y1, LineColor);
+        context.fill(HalfX, Y1, HalfX + 1, Y2, LineColor);
+        context.fill(HalfX, Y2, X2 + 1, Y2, LineColor);
+    }
+
+    // UNTESTED
+    public void drawNode(DrawContext context, NodeMetaData nodeMetaData) {
+        // TODO 需要完成Node数据注册表
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/StartBookScreenV2.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/StartBookScreenV2.java
@@ -48,7 +48,7 @@ public class StartBookScreenV2 extends Screen implements WidgetEXUtils.IWidgetEX
         // 渲染文字
         int TextPosX = width / 2 - TextSizeX / 2;
         int TextPosY = height / 2 - TextSizeY / 2 + TextPosYFix;
-        ScaleScrollTextWidget StartBookLabel = new ScaleScrollTextWidget(TextPosX, TextPosY, TextSizeX, TextSizeY / 9, 1.0f, Text.translatable("screen.shape-shifter-curse.book_of_shape_shifter.start_content_text"), textRenderer);
+        ScaleScrollTextWidget StartBookLabel = new ScaleScrollTextWidget(TextPosX, TextPosY, TextSizeX, TextSizeY, 1.0f, Text.translatable("screen.shape-shifter-curse.book_of_shape_shifter.start_content_text"), textRenderer);
         StartBookLabel.setEnableScrollableIconRender(true);
         this.addWidget(StartBookLabel);
         this.addDrawableChild(StartBookLabel);

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/ui_part/ScaleScrollTextWidget.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/custom_ui/ui_part/ScaleScrollTextWidget.java
@@ -1,5 +1,6 @@
 package net.onixary.shapeShifterCurseFabric.custom_ui.ui_part;
 
+import net.minecraft.client.font.MultilineText;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.widget.MultilineTextWidget;
@@ -14,38 +15,37 @@ import java.util.Objects;
 
 public class ScaleScrollTextWidget extends MultilineTextWidget implements WidgetEXUtils.IWidgetEX {
     private final float Scale;
+    private final float realScale;
     private boolean shadow;
 
 
     private int realWidth;
-    private int realHeight;
     private int MaxWidth;
     private int MaxRows;
 
-    private boolean textDone = false;
+    private int boxHeight = 0;
 
     private final List<WidgetEXUtils.IWidgetEX> widgetList = List.of();
     private WidgetEXUtils.WidgetRect rect;
-
-    private List<OrderedText> texts = new ArrayList<>();
-    private List<OrderedText> currentTexts = new ArrayList<>();
 
     public boolean enableScrollableIconRender = false;
     public int IconSize = 8;
     public Identifier IconTexID = ShapeShifterCurseFabric.identifier("textures/gui/scrollable_icon.png");
 
-    public int textsLineCount = 0;
-    public int scroll = 0;
+    public int scroll = 0;  // 单位改成像素
 
-    public ScaleScrollTextWidget(int x, int y, int width, int maxRow, float Scale, Text message, TextRenderer textRenderer) {
+
+    public ScaleScrollTextWidget(int x, int y, int width, int height, float Scale, Text message, TextRenderer textRenderer) {
         super(x, y, message, textRenderer);
         this.Scale = Scale;
-        this.rect = new WidgetEXUtils.WidgetRect(x, y, width, maxRow * 9);
+        int textHeight = Math.round(textRenderer.fontHeight * Scale);
+        this.realScale = (float) textHeight / (float) textRenderer.fontHeight;
+        this.rect = new WidgetEXUtils.WidgetRect(x, y, width, height);
         assert width > 0;
-        assert maxRow > 0;
+        assert height > 0;
         this.setMaxWidth(width);
-        this.setMaxRows(maxRow);
-        this.calculateText();
+        this.setMaxRows(1_000_000_000);
+        this.boxHeight = height;
     }
 
     @Override
@@ -66,10 +66,10 @@ public class ScaleScrollTextWidget extends MultilineTextWidget implements Widget
     public void onClickWidget(double mouseX, double mouseY, int button) {
         if (this.enableScrollableIconRender) {
             if (mouseX >= this.realWidth - IconSize && mouseX <= this.realWidth && mouseY >= 0 && mouseY < IconSize) {
-                this.scroll(-this.MaxRows);
+                this.scroll(-this.boxHeight);
             }
-            if (mouseX >= this.realWidth - IconSize && mouseX <= this.realWidth && mouseY >= this.realHeight - IconSize && mouseY < this.realHeight) {
-                this.scroll(this.MaxRows);
+            if (mouseX >= this.realWidth - IconSize && mouseX <= this.realWidth && mouseY >= this.boxHeight - IconSize && mouseY < this.boxHeight) {
+                this.scroll(this.boxHeight);
             }
         }
     }
@@ -80,9 +80,9 @@ public class ScaleScrollTextWidget extends MultilineTextWidget implements Widget
             return;
         }
         deltaYTotal += deltaY;
-        if (deltaYTotal > 9 || deltaYTotal < -9) {
-            int amount = (int) (deltaYTotal / 9);
-            deltaYTotal -= amount * 9;
+        if (deltaYTotal > 1 || deltaYTotal < -1) {
+            int amount = (int) (deltaYTotal);
+            deltaYTotal -= amount;
             this.scroll(-amount);
         }
     }
@@ -93,29 +93,10 @@ public class ScaleScrollTextWidget extends MultilineTextWidget implements Widget
             return;
         }
         scrollZTotal += mouseZ;
-        if (scrollZTotal > 0.5f || scrollZTotal < -0.5f) {
-            int amount = (int) (scrollZTotal * 2);
-            scrollZTotal -= amount * 0.5f;
+        if (scrollZTotal > 0.0625f || scrollZTotal < -0.0625f) {
+            int amount = (int) (scrollZTotal * 16);
+            scrollZTotal -= amount * 0.0625f;
             this.scroll(-amount);
-        }
-    }
-
-    private void calculateCurrentText() {
-        if (this.texts.size() < this.scroll + this.MaxRows) {
-            this.currentTexts = this.texts.subList(this.scroll, this.texts.size());
-        } else {
-            this.currentTexts = this.texts.subList(this.scroll, this.scroll + this.MaxRows);
-        }
-    }
-
-    private void calculateText() {
-        try {
-            this.texts = this.getTextRenderer().wrapLines(this.getMessage(), this.getTextWidth());
-            this.textsLineCount = this.texts.size();
-            this.calculateCurrentText();
-            this.textDone = true;
-        } catch (Exception e) {
-            ShapeShifterCurseFabric.LOGGER.error("Error while calculating text", e);
         }
     }
 
@@ -132,34 +113,24 @@ public class ScaleScrollTextWidget extends MultilineTextWidget implements Widget
                 this.modMaxWidth(0);
             }
             this.enableScrollableIconRender = enableScrollableIconRender;
-            this.reloadText();
+            this.scroll = 0;
         }
         return this;
     }
 
-    public void reloadText() {
-        this.textDone = false;
-        this.calculateText();
+    public void reloadText(Text message) {
+        this.setMessage(message);
         this.scroll = 0;
     }
 
-    public void reloadText(Text message) {
-        this.setMessage(message);
-        this.reloadText();
-    }
-
     public void scroll(int amount) {
-        if (!this.textDone) {
-            this.calculateText();
-        }
         this.scroll += amount;
-        if (this.scroll > this.texts.size() - this.MaxRows) {
-            this.scroll = this.texts.size() - this.MaxRows;
+        if (this.scroll > this.getHeight() - this.boxHeight) {
+            this.scroll = this.getHeight() - this.boxHeight;
         }
         if (this.scroll < 0) {
             this.scroll = 0;
         }
-        this.calculateCurrentText();
     }
 
     public int modMaxWidth = 0;
@@ -179,7 +150,6 @@ public class ScaleScrollTextWidget extends MultilineTextWidget implements Widget
 
     @Override
     public MultilineTextWidget setMaxRows(int maxRows) {
-        this.realHeight = maxRows * 9;
         this.MaxRows = Math.round(maxRows * (1 / this.Scale));
         super.setMaxRows(this.MaxRows);
         return this;
@@ -196,68 +166,37 @@ public class ScaleScrollTextWidget extends MultilineTextWidget implements Widget
 
     @Override
     public int getHeight() {
-        return (int) (super.getHeight() * this.Scale);
-    }
-
-    private int drawCenterWithShadow(DrawContext context, List<OrderedText> lines, int x, int y, int lineHeight, int color) {
-        int i = y;
-        TextRenderer textRenderer = this.getTextRenderer();
-        for(OrderedText line : lines) {
-            context.drawTextWithShadow(textRenderer, line, x - textRenderer.getWidth(line) / 2, i, color);
-            i += lineHeight;
-        }
-        return i;
-    }
-
-    public int drawWithShadow(DrawContext context, List<OrderedText> lines, int x, int y, int lineHeight, int color) {
-        int i = y;
-        TextRenderer textRenderer = this.getTextRenderer();
-        for(OrderedText line : lines) {
-            context.drawTextWithShadow(textRenderer, line, x, i, color);
-            i += lineHeight;
-        }
-
-        return i;
-    }
-
-    public int drawWithOutShadow(DrawContext context, List<OrderedText> lines, int x, int y, int lineHeight, int color) {
-        int i = y;
-        TextRenderer textRenderer = this.getTextRenderer();
-        for(OrderedText line : lines) {
-            context.drawText(textRenderer, line, x, i, color, false);
-            i += lineHeight;
-        }
-
-        return i;
+        return (int) (super.getHeight() * this.realScale);
     }
 
     @Override
     public void renderButton(DrawContext context, int mouseX, int mouseY, float delta) {
-        if (!this.textDone) {
-            this.calculateText();
-        }
         int i = this.getX();
         int j = this.getY();
         if (this.enableScrollableIconRender) {
             if (this.scroll > 0) {
                 context.drawTexture(IconTexID, i + realWidth - IconSize, j, 0, 0, IconSize, IconSize, IconSize, IconSize * 2);
             }
-            if (this.scroll < this.texts.size() - this.MaxRows) {
-                context.drawTexture(IconTexID, i + realWidth - IconSize, j + realHeight - IconSize, 0, IconSize, IconSize, IconSize, IconSize, IconSize * 2);
+            if (this.scroll < this.getHeight() - this.boxHeight) {
+                context.drawTexture(IconTexID, i + realWidth - IconSize, j + boxHeight - IconSize, 0, IconSize, IconSize, IconSize, IconSize, IconSize * 2);
             }
         }
+        MultilineText multilineText = (MultilineText)this.cacheKeyToText.map(this.getCacheKey());
         Objects.requireNonNull(this.getTextRenderer());
         int k = Math.round(9 * this.Scale);
         int l = this.getTextColor();
+        // 这API真好用 比我硬算剔除好写不止一点
+        context.enableScissor(i, j, i + this.getWidth(), j + this.boxHeight);
         if (this.centered) {
-            this.drawCenterWithShadow(context, this.currentTexts, i + this.getWidth() / 2, j, k, l);
+            multilineText.drawCenterWithShadow(context, i + this.getWidth() / 2, j - scroll, k, l);
         } else {
             if(this.shadow){
-                this.drawWithShadow(context, this.currentTexts, i, j, k, l);
+                multilineText.drawWithShadow(context, i, j - scroll, k, l);
             }
             else{
-                this.drawWithOutShadow(context, this.currentTexts, i, j, k, l);
+                multilineText.draw(context, i, j - scroll, k, l);
             }
         }
+        context.disableScissor();
     }
 }

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/perk/IPerk.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/perk/IPerk.java
@@ -1,0 +1,20 @@
+package net.onixary.shapeShifterCurseFabric.perk;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Identifier;
+import net.onixary.shapeShifterCurseFabric.player_form.IForm;
+
+// Server Side
+public interface IPerk {
+    Identifier getID();
+
+    default void onGain(PlayerEntity player, IForm form) {
+        this.onLoad(player, form);
+    }
+
+    default boolean canGain(PlayerEntity player, IForm form) {
+        return true;  // Tier 和 DependentPerkID 的判定由 PerkTree 处理
+    }
+
+    default void onLoad(PlayerEntity player, IForm form) { }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/perk/NormalPerk.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/perk/NormalPerk.java
@@ -1,0 +1,53 @@
+package net.onixary.shapeShifterCurseFabric.perk;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Identifier;
+import net.onixary.shapeShifterCurseFabric.player_form.IForm;
+import net.onixary.shapeShifterCurseFabric.player_form.utils.FormUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NormalPerk implements IPerk {
+    public final Identifier perkID;
+    public final List<Identifier> powerAdd = new ArrayList<>();
+    public final List<Identifier> powerRemove = new ArrayList<>();
+
+    public NormalPerk(Identifier perkID) {
+        this.perkID = perkID;
+    }
+
+    public NormalPerk addPower(Identifier... powerIDs) {
+        for (Identifier powerID : powerIDs) {
+            if (!powerAdd.contains(powerID)) {
+                powerAdd.add(powerID);
+            }
+        }
+        return this;
+    }
+
+    public NormalPerk removePower(Identifier... powerIDs) {
+        for (Identifier powerID : powerIDs) {
+            if (!powerRemove.contains(powerID)) {
+                powerRemove.add(powerID);
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public Identifier getID() {
+        return this.perkID;
+    }
+
+    @Override
+    public void onLoad(PlayerEntity player, IForm form) {
+        Identifier powerSource = form.getFormLayer().getRight();
+        for (Identifier powerID : powerAdd) {
+            FormUtils.applyPower(player, powerID, powerSource);
+        }
+        for (Identifier powerID : powerRemove) {
+            FormUtils.removePower(player, powerID, powerSource);
+        }
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/perk/PerkTree.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/perk/PerkTree.java
@@ -1,0 +1,60 @@
+package net.onixary.shapeShifterCurseFabric.perk;
+
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+// Common Side
+public class PerkTree {
+    public static class PerkNode {
+        public final Identifier perkID;
+        public final int tier;
+        public final int y;
+        public final @Nullable Identifier dependentPerkID;
+
+        public PerkNode(Identifier perkID, int tier, int y, @Nullable Identifier dependentPerkID) {
+            this.perkID = perkID;
+            this.tier = tier;
+            this.y = y;
+            this.dependentPerkID = dependentPerkID;
+        }
+    }
+
+    public final Identifier treeID;
+    public final List<PerkNode> perkNodes = new ArrayList<>();
+    public final Map<Identifier, PerkNode> perkNodeMap = new HashMap<>();
+
+    public PerkTree(Identifier treeID) {
+        this.treeID = treeID;
+    }
+
+    public Identifier getID() {
+        return treeID;
+    }
+
+    public PerkTree addNode(Identifier perkID, int tier, int y, @Nullable Identifier dependentPerkID) {
+        return this.addNode(new PerkNode(perkID, tier, y, dependentPerkID));
+    }
+
+    public PerkTree addNode(PerkNode perkNode) {
+        perkNodes.add(perkNode);
+        perkNodeMap.put(perkNode.perkID, perkNode);
+        return this;
+    }
+
+    public @Nullable PerkNode getNode(Identifier perkID) {
+        return perkNodeMap.get(perkID);
+    }
+
+    public @Nullable PerkNode getDependentNode(Identifier perkID) {
+        PerkNode perkNode = getNode(perkID);
+        if (perkNode != null && perkNode.dependentPerkID != null) {
+            return getNode(perkNode.dependentPerkID);
+        }
+        return null;
+    }
+}

--- a/src/main/java/net/onixary/shapeShifterCurseFabric/perk/RegPerks.java
+++ b/src/main/java/net/onixary/shapeShifterCurseFabric/perk/RegPerks.java
@@ -1,0 +1,29 @@
+package net.onixary.shapeShifterCurseFabric.perk;
+
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+
+public class RegPerks {
+    public static final HashMap<Identifier, IPerk> PerkRegistry = new HashMap<>();
+    public static final HashMap<Identifier, PerkTree> PerkTreeRegistry = new HashMap<>();
+
+    public static Identifier registerPerk(IPerk perk) {
+        PerkRegistry.put(perk.getID(), perk);
+        return perk.getID();
+    }
+
+    public static @Nullable IPerk getPerk(Identifier perkID) {
+        return PerkRegistry.get(perkID);
+    }
+
+    public static Identifier registerPerkTree(PerkTree perkTree) {
+        PerkTreeRegistry.put(perkTree.getID(), perkTree);
+        return perkTree.getID();
+    }
+
+    public static @Nullable PerkTree getPerkTree(Identifier perkTreeID) {
+        return PerkTreeRegistry.get(perkTreeID);
+    }
+}


### PR DESCRIPTION
现在用剔除了 是真方便 原始实现是手动计算剔除(可麻烦了) 顺便修复了之前文本高度计算异常的Bug 现在能填充满整个页面了
这回那个升级UI的一个难点解决了 剩下的就是技术方案的选择了(在init下直接生成完 然后同步修改x,y 或者直接在render动态画) 我先思考一下(看看有没有其他可用的API) 选择一下方案